### PR TITLE
fix: fix ID names in deparments

### DIFF
--- a/scripts/officials.json
+++ b/scripts/officials.json
@@ -5726,7 +5726,7 @@
     "NameKN": "ಟಿ ಚಂದ್ರಶೇಖರ ಪ್ರಸಾದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "A.Narayanapura",
     "Designation": "",
     "Name": "",
@@ -5740,7 +5740,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "AECS Layout-1",
     "Designation": "Assistant Engineer",
     "Name": " Manjunath / Sahanab begam",
@@ -5754,7 +5754,7 @@
     "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "AECS Layout-2",
     "Designation": "Assistant Engineer",
     "Name": " Latheef Saheb",
@@ -5768,7 +5768,7 @@
     "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Agrahara Dasarahalli",
     "Designation": "Assistant Engineer",
     "Name": " Rajendra kumar",
@@ -5782,7 +5782,7 @@
     "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ananda Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Kumar",
@@ -5796,7 +5796,7 @@
     "NameKN": " ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Annapoorneshwari Nagar",
     "Designation": "",
     "Name": "",
@@ -5810,7 +5810,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Annapoorneswari Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Vishwanath",
@@ -5824,7 +5824,7 @@
     "NameKN": " ವಿಶ್ವನಾಥ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bahubali Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Karthik Manju",
@@ -5838,7 +5838,7 @@
     "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Baiyappanahalli",
     "Designation": "Assistant Engineer",
     "Name": " Poornima",
@@ -5852,7 +5852,7 @@
     "NameKN": " ಪೂರ್ಣಿಮಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Baiyappanahalli",
     "Designation": "",
     "Name": "",
@@ -5866,7 +5866,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Banaswadi",
     "Designation": "",
     "Name": "",
@@ -5880,7 +5880,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bannapa Park",
     "Designation": "",
     "Name": "",
@@ -5894,7 +5894,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Basavanapura",
     "Designation": "",
     "Name": "",
@@ -5908,7 +5908,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bellandur",
     "Designation": "Assistant Engineer",
     "Name": "",
@@ -5922,7 +5922,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BEML Layout",
     "Designation": "",
     "Name": "",
@@ -5936,7 +5936,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bhashyam Park",
     "Designation": "Assistant Engineer",
     "Name": " Kishore",
@@ -5950,7 +5950,7 @@
     "NameKN": " ಕಿಶೋರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BSK-I",
     "Designation": "",
     "Name": "",
@@ -5964,7 +5964,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BSK-II",
     "Designation": "",
     "Name": "",
@@ -5978,7 +5978,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BTM I & II",
     "Designation": "Assistant Engineer",
     "Name": " Hanumantharaju C P",
@@ -5992,7 +5992,7 @@
     "NameKN": " ಹನುಮಂತರಾಜು ಸಿ ಪಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Byrasandra",
     "Designation": "Assistant Engineer",
     "Name": " Shreeja",
@@ -6006,7 +6006,7 @@
     "NameKN": " ಶ್ರೀಜಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "C.V.Raman Nagar",
     "Designation": "",
     "Name": "",
@@ -6020,7 +6020,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Challakere / Horamavu / Kalkere / Kothanur-Byrathi",
     "Designation": "Assistant Engineer",
     "Name": " Anand",
@@ -6034,7 +6034,7 @@
     "NameKN": " ಆನಂದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Chamarajpet",
     "Designation": "Assistant Engineer",
     "Name": " Praveen .G",
@@ -6048,7 +6048,7 @@
     "NameKN": " ಪ್ರವೀಣ್ .ಜಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Chandra Layout",
     "Designation": "Assistant Engineer",
     "Name": " Ramegowda",
@@ -6062,7 +6062,7 @@
     "NameKN": " ರಾಮೇಗೌಡ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Chikkalalbhag",
     "Designation": "Assistant Engineer",
     "Name": " Seema",
@@ -6076,7 +6076,7 @@
     "NameKN": " ಸೀಮಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "CLR",
     "Designation": "Assistant Engineer",
     "Name": " D S Rangaiah",
@@ -6090,7 +6090,7 @@
     "NameKN": " ಡಿ ಎಸ್ ರಂಗಯ್ಯ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Coles Park",
     "Designation": "Assistant Engineer",
     "Name": " Rajesh S D",
@@ -6104,7 +6104,7 @@
     "NameKN": " ರಾಜೇಶ್ ಎಸ್ ಡಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Devagiri I&II",
     "Designation": "",
     "Name": "",
@@ -6118,7 +6118,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Devasandra",
     "Designation": "Assistant Engineer",
     "Name": " Dinesh Ballu",
@@ -6132,7 +6132,7 @@
     "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Doddanekundi",
     "Designation": "",
     "Name": "",
@@ -6146,7 +6146,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Domlur",
     "Designation": "Assistant Engineer",
     "Name": " Mamatha M H",
@@ -6160,7 +6160,7 @@
     "NameKN": " ಮಮತಾ ಎಂ ಎಚ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Frazer Town",
     "Designation": "Assistant Engineer",
     "Name": " Rahul",
@@ -6174,7 +6174,7 @@
     "NameKN": " ರಾಹುಲ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Gangena Halli",
     "Designation": "",
     "Name": "",
@@ -6188,7 +6188,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Gangenahalli",
     "Designation": "Assistant Engineer",
     "Name": " Kumar",
@@ -6202,7 +6202,7 @@
     "NameKN": " ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Girinagara",
     "Designation": "Assistant Engineer",
     "Name": " Usha C R",
@@ -6216,7 +6216,7 @@
     "NameKN": " ಉಷಾ ಸಿ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HAL 2nd Stage",
     "Designation": "Assistant Engineer",
     "Name": "",
@@ -6230,7 +6230,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HAL Airport",
     "Designation": "Assistant Engineer",
     "Name": " Ranjan",
@@ -6244,7 +6244,7 @@
     "NameKN": " ರಂಜನ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HBR",
     "Designation": "Assistant Engineer",
     "Name": " Daval sab Karnachi",
@@ -6258,7 +6258,7 @@
     "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Heggana Halli",
     "Designation": "Assistant Engineer",
     "Name": " Nadish",
@@ -6272,7 +6272,7 @@
     "NameKN": " ನಾಡಿಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HGR",
     "Designation": "Assistant Engineer",
     "Name": " Mahesh Kumar K.S",
@@ -6286,7 +6286,7 @@
     "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hombe Gowda nagar",
     "Designation": "Assistant Engineer",
     "Name": " Shreeja",
@@ -6300,7 +6300,7 @@
     "NameKN": " ಶ್ರೀಜಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hoodi",
     "Designation": "Assistant Engineer",
     "Name": " Ravi Kumar",
@@ -6314,7 +6314,7 @@
     "NameKN": " ರವಿ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hosahalli",
     "Designation": "Assistant Engineer",
     "Name": " Swathi",
@@ -6328,7 +6328,7 @@
     "NameKN": " ಸ್ವಾತಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hosakerehalli",
     "Designation": "Assistant Engineer",
     "Name": " Sridhar.S",
@@ -6342,7 +6342,7 @@
     "NameKN": " ಶ್ರೀಧರ್.ಎಸ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HRBR",
     "Designation": "Assistant Engineer",
     "Name": " Daval sab Karnachi",
@@ -6356,7 +6356,7 @@
     "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HSR Layout",
     "Designation": "",
     "Name": "",
@@ -6370,7 +6370,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ideal Homes Layout",
     "Designation": "Assistant Engineer",
     "Name": " Rahul Rathod",
@@ -6384,7 +6384,7 @@
     "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Indiranagar",
     "Designation": "Assistant Engineer",
     "Name": " Shashi Kumar",
@@ -6398,7 +6398,7 @@
     "NameKN": " ಶಶಿ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "ISRO Layout",
     "Designation": "",
     "Name": "",
@@ -6412,7 +6412,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ittamadu",
     "Designation": "Assistant Engineer",
     "Name": " Lingaraju",
@@ -6426,7 +6426,7 @@
     "NameKN": " ಲಿಂಗರಾಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "J J Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Lakshmi Narayana Gowda",
@@ -6440,7 +6440,7 @@
     "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jakkur",
     "Designation": "Assistant Engineer",
     "Name": " Pradeep",
@@ -6454,7 +6454,7 @@
     "NameKN": " ಪ್ರದೀಪ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jayamahal",
     "Designation": "Assistant Engineer",
     "Name": " Jayashree",
@@ -6468,7 +6468,7 @@
     "NameKN": " ಜಯಶ್ರೀ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jayanagar 4th 'T'  block",
     "Designation": "Assistant Engineer",
     "Name": " Lakshmi",
@@ -6482,7 +6482,7 @@
     "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jayanagar 4th block",
     "Designation": "Assistant Engineer",
     "Name": " Shreeja",
@@ -6496,7 +6496,7 @@
     "NameKN": " ಶ್ರೀಜಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JB Nagar",
     "Designation": "Assistant Engineer",
     "Name": "",
@@ -6510,7 +6510,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Johnson Market",
     "Designation": "Assistant Engineer",
     "Name": " Murali C P",
@@ -6524,7 +6524,7 @@
     "NameKN": " ಮುರಳಿ ಸಿ ಪಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JP Nagar 1st Phase",
     "Designation": "Assistant Engineer",
     "Name": " Lakshmi",
@@ -6538,7 +6538,7 @@
     "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JP Nagar 2nd Phase",
     "Designation": "Assistant Engineer",
     "Name": " Akram",
@@ -6552,7 +6552,7 @@
     "NameKN": " ಅಕ್ರಮ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JP Nagar 3rd Phase",
     "Designation": "",
     "Name": "",
@@ -6566,7 +6566,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "K G Nagara",
     "Designation": "",
     "Name": "",
@@ -6580,7 +6580,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "K.R.Puram",
     "Designation": "",
     "Name": "",
@@ -6594,7 +6594,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kamakshipalya/ Kamalanagar",
     "Designation": "Assistant Engineer",
     "Name": " Shivakumar",
@@ -6608,7 +6608,7 @@
     "NameKN": " ಶಿವಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kathriguppe",
     "Designation": "Assistant Engineer",
     "Name": " Kumuda",
@@ -6622,7 +6622,7 @@
     "NameKN": " ಕುಮುದಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kengeri",
     "Designation": "Assistant Engineer",
     "Name": " Rahul Rathod",
@@ -6636,7 +6636,7 @@
     "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kethamarana Halli",
     "Designation": "Assistant Engineer",
     "Name": " Pushpa",
@@ -6650,7 +6650,7 @@
     "NameKN": " ಪುಷ್ಪಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "KG Tower",
     "Designation": "Assistant Engineer",
     "Name": " Jayashree",
@@ -6664,7 +6664,7 @@
     "NameKN": " ಜಯಶ್ರೀ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kodichikkanahalli",
     "Designation": "Assistant Engineer",
     "Name": " Vikas D S / Nagaraj S R",
@@ -6678,7 +6678,7 @@
     "NameKN": " ವಿಕಾಸ್ ಡಿ ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kodichikkanahalli",
     "Designation": "",
     "Name": "",
@@ -6692,7 +6692,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kodichikkanahalli",
     "Designation": "",
     "Name": "",
@@ -6706,7 +6706,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Koramanagala",
     "Designation": "",
     "Name": "",
@@ -6720,7 +6720,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Koramangala",
     "Designation": "Assistant Engineer",
     "Name": " Gajanana",
@@ -6734,7 +6734,7 @@
     "NameKN": " ಗಜಾನನ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kothanurdinne",
     "Designation": "Assistant Engineer",
     "Name": " Akshay C",
@@ -6748,7 +6748,7 @@
     "NameKN": " ಅಕ್ಷಯ್ ಸಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kumara Park",
     "Designation": "Assistant Engineer",
     "Name": " Dastagiri Basha",
@@ -6762,7 +6762,7 @@
     "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kumaraswamy Layout",
     "Designation": "Assistant Engineer",
     "Name": " Preethi J",
@@ -6776,7 +6776,7 @@
     "NameKN": " ಪ್ರೀತಿ ಜೆ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Lingarajpura",
     "Designation": "Assistant Engineer",
     "Name": " Rajini A",
@@ -6790,7 +6790,7 @@
     "NameKN": " ರಜಿನಿ ಎ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "LLR",
     "Designation": "Assistant Engineer",
     "Name": " Seema",
@@ -6804,7 +6804,7 @@
     "NameKN": " ಸೀಮಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Machalibetta",
     "Designation": "Assistant Engineer",
     "Name": " Mallappa Mali",
@@ -6818,7 +6818,7 @@
     "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Magadi Road",
     "Designation": "Assistant Engineer",
     "Name": " Dinesh",
@@ -6832,7 +6832,7 @@
     "NameKN": " ದಿನೇಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Mahalakshmi Layuot",
     "Designation": "Assistant Engineer",
     "Name": " Pushpa",
@@ -6846,7 +6846,7 @@
     "NameKN": " ಪುಷ್ಪಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Malleshwarm",
     "Designation": "Assistant Engineer",
     "Name": " Suhana",
@@ -6860,7 +6860,7 @@
     "NameKN": " ಸುಹಾನಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "MEI Layout (Dasarahalli)",
     "Designation": "Assistant Engineer",
     "Name": " Karthik Manju",
@@ -6874,7 +6874,7 @@
     "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "MNK Park",
     "Designation": "Assistant Engineer",
     "Name": " Karthik M",
@@ -6888,7 +6888,7 @@
     "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Moodala Palya",
     "Designation": "Assistant Engineer",
     "Name": " Sathish T",
@@ -6902,7 +6902,7 @@
     "NameKN": " ಸತೀಶ್ ಟಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Mount Joy",
     "Designation": "Assistant Engineer",
     "Name": " Sudarshan D N",
@@ -6916,7 +6916,7 @@
     "NameKN": " ಸುದರ್ಶನ್ ಡಿ ಎನ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Mysore Road",
     "Designation": "Assistant Engineer",
     "Name": " Dinesh",
@@ -6930,7 +6930,7 @@
     "NameKN": " ದಿನೇಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Nagarabhavi",
     "Designation": "Assistant Engineer",
     "Name": " Harsha V",
@@ -6944,7 +6944,7 @@
     "NameKN": " ಹರ್ಷ ವಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Nagendra Block",
     "Designation": "Assistant Engineer",
     "Name": " Usha C R",
@@ -6958,7 +6958,7 @@
     "NameKN": " ಉಷಾ ಸಿ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Nandini Layout",
     "Designation": "Assistant Engineer",
     "Name": " Dushyanth",
@@ -6972,7 +6972,7 @@
     "NameKN": " ದುಷ್ಯಂತ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "New BEL Road",
     "Designation": "Assistant Engineer",
     "Name": " Dastagir Basha",
@@ -6986,7 +6986,7 @@
     "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "OMBR",
     "Designation": "Assistant Engineer",
     "Name": " Manjunatha",
@@ -7000,7 +7000,7 @@
     "NameKN": " ಮಂಜುನಾಥ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Peenya",
     "Designation": "Assistant Engineer",
     "Name": " Ganesh",
@@ -7014,7 +7014,7 @@
     "NameKN": " ಗಣೇಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Peenya Dasarahalli",
     "Designation": "Assistant Engineer",
     "Name": " Sandeep",
@@ -7028,7 +7028,7 @@
     "NameKN": " ಸಂದೀಪ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Pillana Garden-1",
     "Designation": "Assistant Engineer",
     "Name": " Rahul",
@@ -7042,7 +7042,7 @@
     "NameKN": " ರಾಹುಲ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Pillana Garden-2",
     "Designation": "Assistant Engineer",
     "Name": " Mallappa Mali",
@@ -7056,7 +7056,7 @@
     "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "PP Layout",
     "Designation": "Assistant Engineer",
     "Name": " Shekar",
@@ -7070,7 +7070,7 @@
     "NameKN": " ಶೇಖರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Rajaji Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Pushpa",
@@ -7084,7 +7084,7 @@
     "NameKN": " ಪುಷ್ಪಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ramamurthy Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Anand",
@@ -7098,7 +7098,7 @@
     "NameKN": " ಆನಂದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "RT Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Kumar",
@@ -7112,7 +7112,7 @@
     "NameKN": " ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Sahakar Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Chinthana K",
@@ -7126,7 +7126,7 @@
     "NameKN": " ಚಿಂತನ ಕೆ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Sanjay Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Dastagiri Basha",
@@ -7140,7 +7140,7 @@
     "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Srirampura",
     "Designation": "Assistant Engineer",
     "Name": " Siddaraju",
@@ -7154,7 +7154,7 @@
     "NameKN": " ಸಿದ್ದರಾಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Sudhama Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Suhas",
@@ -7168,7 +7168,7 @@
     "NameKN": " ಸುಹಾಸ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ulsoor",
     "Designation": "Assistant Engineer",
     "Name": " Ravi Kiran(i/c)",
@@ -7182,7 +7182,7 @@
     "NameKN": " ರವಿ ಕಿರಣ್ (i/c)"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vidyaranyapura",
     "Designation": "Assistant Engineer",
     "Name": " Dhanalakshmi M",
@@ -7196,7 +7196,7 @@
     "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vignana Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Mohammed Mudassir",
@@ -7210,7 +7210,7 @@
     "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vijay Nagar OHT",
     "Designation": "",
     "Name": "",
@@ -7224,7 +7224,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "VIjaya Bank Layout",
     "Designation": "Assistant Engineer",
     "Name": " Nagaraj S R",
@@ -7238,7 +7238,7 @@
     "NameKN": " ನಾಗರಾಜ್ ಎಸ್ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vijnanapura",
     "Designation": "Assistant Engineer",
     "Name": " Anand",
@@ -7252,7 +7252,7 @@
     "NameKN": " ಆನಂದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vishveshwaraiah Layout",
     "Designation": "",
     "Name": "",
@@ -7266,7 +7266,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vjayanagar OHT",
     "Designation": "Assistant Engineer",
     "Name": " Ramegowda B",
@@ -7280,7 +7280,7 @@
     "NameKN": " ರಾಮೇಗೌಡ ಬಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "VV Puram",
     "Designation": "Assistant Engineer",
     "Name": " Prahalad",
@@ -7294,7 +7294,7 @@
     "NameKN": " ಪ್ರಹ್ಲಾದ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "WCR-I",
     "Designation": "Assistant Engineer",
     "Name": " Rajendra kumar",
@@ -7308,7 +7308,7 @@
     "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Yelahanka New Town",
     "Designation": "Assistant Engineer",
     "Name": " Manjunatha Hallur",
@@ -7322,7 +7322,7 @@
     "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Yelahanka Old Town",
     "Designation": "Assistant Engineer",
     "Name": " Vinay kumar P B",
@@ -7336,7 +7336,7 @@
     "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ ಬಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Yeshwanthpura",
     "Designation": "Assistant Engineer",
     "Name": " Kishore",

--- a/scripts/xls2json.py
+++ b/scripts/xls2json.py
@@ -27,6 +27,7 @@ df = df.replace({
     'BESCOM (Division)': 'bescom_division',
     'BESCOM (Subdivision)': 'bescom_subdivision',
     'BWSSB (Division)': 'bwssb_division',
+    'BWSSB (Service Station)': 'bwssb_service_station',
     'Elections (Assembly Constituency)': 'election_ac',
     'Elections (Parliamentary Constituency)': 'election_pc',
     'Pincode': 'pincode',

--- a/src/officials.json
+++ b/src/officials.json
@@ -5726,7 +5726,7 @@
     "NameKN": "ಟಿ ಚಂದ್ರಶೇಖರ ಪ್ರಸಾದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "A.Narayanapura",
     "Designation": "",
     "Name": "",
@@ -5740,7 +5740,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "AECS Layout-1",
     "Designation": "Assistant Engineer",
     "Name": " Manjunath / Sahanab begam",
@@ -5754,7 +5754,7 @@
     "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "AECS Layout-2",
     "Designation": "Assistant Engineer",
     "Name": " Latheef Saheb",
@@ -5768,7 +5768,7 @@
     "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Agrahara Dasarahalli",
     "Designation": "Assistant Engineer",
     "Name": " Rajendra kumar",
@@ -5782,7 +5782,7 @@
     "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ananda Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Kumar",
@@ -5796,7 +5796,7 @@
     "NameKN": " ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Annapoorneshwari Nagar",
     "Designation": "",
     "Name": "",
@@ -5810,7 +5810,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Annapoorneswari Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Vishwanath",
@@ -5824,7 +5824,7 @@
     "NameKN": " ವಿಶ್ವನಾಥ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bahubali Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Karthik Manju",
@@ -5838,7 +5838,7 @@
     "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Baiyappanahalli",
     "Designation": "Assistant Engineer",
     "Name": " Poornima",
@@ -5852,7 +5852,7 @@
     "NameKN": " ಪೂರ್ಣಿಮಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Baiyappanahalli",
     "Designation": "",
     "Name": "",
@@ -5866,7 +5866,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Banaswadi",
     "Designation": "",
     "Name": "",
@@ -5880,7 +5880,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bannapa Park",
     "Designation": "",
     "Name": "",
@@ -5894,7 +5894,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Basavanapura",
     "Designation": "",
     "Name": "",
@@ -5908,7 +5908,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bellandur",
     "Designation": "Assistant Engineer",
     "Name": "",
@@ -5922,7 +5922,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BEML Layout",
     "Designation": "",
     "Name": "",
@@ -5936,7 +5936,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Bhashyam Park",
     "Designation": "Assistant Engineer",
     "Name": " Kishore",
@@ -5950,7 +5950,7 @@
     "NameKN": " ಕಿಶೋರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BSK-I",
     "Designation": "",
     "Name": "",
@@ -5964,7 +5964,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BSK-II",
     "Designation": "",
     "Name": "",
@@ -5978,7 +5978,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "BTM I & II",
     "Designation": "Assistant Engineer",
     "Name": " Hanumantharaju C P",
@@ -5992,7 +5992,7 @@
     "NameKN": " ಹನುಮಂತರಾಜು ಸಿ ಪಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Byrasandra",
     "Designation": "Assistant Engineer",
     "Name": " Shreeja",
@@ -6006,7 +6006,7 @@
     "NameKN": " ಶ್ರೀಜಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "C.V.Raman Nagar",
     "Designation": "",
     "Name": "",
@@ -6020,7 +6020,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Challakere / Horamavu / Kalkere / Kothanur-Byrathi",
     "Designation": "Assistant Engineer",
     "Name": " Anand",
@@ -6034,7 +6034,7 @@
     "NameKN": " ಆನಂದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Chamarajpet",
     "Designation": "Assistant Engineer",
     "Name": " Praveen .G",
@@ -6048,7 +6048,7 @@
     "NameKN": " ಪ್ರವೀಣ್ .ಜಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Chandra Layout",
     "Designation": "Assistant Engineer",
     "Name": " Ramegowda",
@@ -6062,7 +6062,7 @@
     "NameKN": " ರಾಮೇಗೌಡ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Chikkalalbhag",
     "Designation": "Assistant Engineer",
     "Name": " Seema",
@@ -6076,7 +6076,7 @@
     "NameKN": " ಸೀಮಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "CLR",
     "Designation": "Assistant Engineer",
     "Name": " D S Rangaiah",
@@ -6090,7 +6090,7 @@
     "NameKN": " ಡಿ ಎಸ್ ರಂಗಯ್ಯ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Coles Park",
     "Designation": "Assistant Engineer",
     "Name": " Rajesh S D",
@@ -6104,7 +6104,7 @@
     "NameKN": " ರಾಜೇಶ್ ಎಸ್ ಡಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Devagiri I&II",
     "Designation": "",
     "Name": "",
@@ -6118,7 +6118,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Devasandra",
     "Designation": "Assistant Engineer",
     "Name": " Dinesh Ballu",
@@ -6132,7 +6132,7 @@
     "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Doddanekundi",
     "Designation": "",
     "Name": "",
@@ -6146,7 +6146,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Domlur",
     "Designation": "Assistant Engineer",
     "Name": " Mamatha M H",
@@ -6160,7 +6160,7 @@
     "NameKN": " ಮಮತಾ ಎಂ ಎಚ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Frazer Town",
     "Designation": "Assistant Engineer",
     "Name": " Rahul",
@@ -6174,7 +6174,7 @@
     "NameKN": " ರಾಹುಲ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Gangena Halli",
     "Designation": "",
     "Name": "",
@@ -6188,7 +6188,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Gangenahalli",
     "Designation": "Assistant Engineer",
     "Name": " Kumar",
@@ -6202,7 +6202,7 @@
     "NameKN": " ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Girinagara",
     "Designation": "Assistant Engineer",
     "Name": " Usha C R",
@@ -6216,7 +6216,7 @@
     "NameKN": " ಉಷಾ ಸಿ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HAL 2nd Stage",
     "Designation": "Assistant Engineer",
     "Name": "",
@@ -6230,7 +6230,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HAL Airport",
     "Designation": "Assistant Engineer",
     "Name": " Ranjan",
@@ -6244,7 +6244,7 @@
     "NameKN": " ರಂಜನ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HBR",
     "Designation": "Assistant Engineer",
     "Name": " Daval sab Karnachi",
@@ -6258,7 +6258,7 @@
     "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Heggana Halli",
     "Designation": "Assistant Engineer",
     "Name": " Nadish",
@@ -6272,7 +6272,7 @@
     "NameKN": " ನಾಡಿಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HGR",
     "Designation": "Assistant Engineer",
     "Name": " Mahesh Kumar K.S",
@@ -6286,7 +6286,7 @@
     "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hombe Gowda nagar",
     "Designation": "Assistant Engineer",
     "Name": " Shreeja",
@@ -6300,7 +6300,7 @@
     "NameKN": " ಶ್ರೀಜಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hoodi",
     "Designation": "Assistant Engineer",
     "Name": " Ravi Kumar",
@@ -6314,7 +6314,7 @@
     "NameKN": " ರವಿ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hosahalli",
     "Designation": "Assistant Engineer",
     "Name": " Swathi",
@@ -6328,7 +6328,7 @@
     "NameKN": " ಸ್ವಾತಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Hosakerehalli",
     "Designation": "Assistant Engineer",
     "Name": " Sridhar.S",
@@ -6342,7 +6342,7 @@
     "NameKN": " ಶ್ರೀಧರ್.ಎಸ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HRBR",
     "Designation": "Assistant Engineer",
     "Name": " Daval sab Karnachi",
@@ -6356,7 +6356,7 @@
     "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "HSR Layout",
     "Designation": "",
     "Name": "",
@@ -6370,7 +6370,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ideal Homes Layout",
     "Designation": "Assistant Engineer",
     "Name": " Rahul Rathod",
@@ -6384,7 +6384,7 @@
     "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Indiranagar",
     "Designation": "Assistant Engineer",
     "Name": " Shashi Kumar",
@@ -6398,7 +6398,7 @@
     "NameKN": " ಶಶಿ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "ISRO Layout",
     "Designation": "",
     "Name": "",
@@ -6412,7 +6412,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ittamadu",
     "Designation": "Assistant Engineer",
     "Name": " Lingaraju",
@@ -6426,7 +6426,7 @@
     "NameKN": " ಲಿಂಗರಾಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "J J Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Lakshmi Narayana Gowda",
@@ -6440,7 +6440,7 @@
     "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jakkur",
     "Designation": "Assistant Engineer",
     "Name": " Pradeep",
@@ -6454,7 +6454,7 @@
     "NameKN": " ಪ್ರದೀಪ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jayamahal",
     "Designation": "Assistant Engineer",
     "Name": " Jayashree",
@@ -6468,7 +6468,7 @@
     "NameKN": " ಜಯಶ್ರೀ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jayanagar 4th 'T'  block",
     "Designation": "Assistant Engineer",
     "Name": " Lakshmi",
@@ -6482,7 +6482,7 @@
     "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Jayanagar 4th block",
     "Designation": "Assistant Engineer",
     "Name": " Shreeja",
@@ -6496,7 +6496,7 @@
     "NameKN": " ಶ್ರೀಜಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JB Nagar",
     "Designation": "Assistant Engineer",
     "Name": "",
@@ -6510,7 +6510,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Johnson Market",
     "Designation": "Assistant Engineer",
     "Name": " Murali C P",
@@ -6524,7 +6524,7 @@
     "NameKN": " ಮುರಳಿ ಸಿ ಪಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JP Nagar 1st Phase",
     "Designation": "Assistant Engineer",
     "Name": " Lakshmi",
@@ -6538,7 +6538,7 @@
     "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JP Nagar 2nd Phase",
     "Designation": "Assistant Engineer",
     "Name": " Akram",
@@ -6552,7 +6552,7 @@
     "NameKN": " ಅಕ್ರಮ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "JP Nagar 3rd Phase",
     "Designation": "",
     "Name": "",
@@ -6566,7 +6566,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "K G Nagara",
     "Designation": "",
     "Name": "",
@@ -6580,7 +6580,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "K.R.Puram",
     "Designation": "",
     "Name": "",
@@ -6594,7 +6594,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kamakshipalya/ Kamalanagar",
     "Designation": "Assistant Engineer",
     "Name": " Shivakumar",
@@ -6608,7 +6608,7 @@
     "NameKN": " ಶಿವಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kathriguppe",
     "Designation": "Assistant Engineer",
     "Name": " Kumuda",
@@ -6622,7 +6622,7 @@
     "NameKN": " ಕುಮುದಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kengeri",
     "Designation": "Assistant Engineer",
     "Name": " Rahul Rathod",
@@ -6636,7 +6636,7 @@
     "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kethamarana Halli",
     "Designation": "Assistant Engineer",
     "Name": " Pushpa",
@@ -6650,7 +6650,7 @@
     "NameKN": " ಪುಷ್ಪಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "KG Tower",
     "Designation": "Assistant Engineer",
     "Name": " Jayashree",
@@ -6664,7 +6664,7 @@
     "NameKN": " ಜಯಶ್ರೀ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kodichikkanahalli",
     "Designation": "Assistant Engineer",
     "Name": " Vikas D S / Nagaraj S R",
@@ -6678,7 +6678,7 @@
     "NameKN": " ವಿಕಾಸ್ ಡಿ ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kodichikkanahalli",
     "Designation": "",
     "Name": "",
@@ -6692,7 +6692,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kodichikkanahalli",
     "Designation": "",
     "Name": "",
@@ -6706,7 +6706,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Koramanagala",
     "Designation": "",
     "Name": "",
@@ -6720,7 +6720,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Koramangala",
     "Designation": "Assistant Engineer",
     "Name": " Gajanana",
@@ -6734,7 +6734,7 @@
     "NameKN": " ಗಜಾನನ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kothanurdinne",
     "Designation": "Assistant Engineer",
     "Name": " Akshay C",
@@ -6748,7 +6748,7 @@
     "NameKN": " ಅಕ್ಷಯ್ ಸಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kumara Park",
     "Designation": "Assistant Engineer",
     "Name": " Dastagiri Basha",
@@ -6762,7 +6762,7 @@
     "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Kumaraswamy Layout",
     "Designation": "Assistant Engineer",
     "Name": " Preethi J",
@@ -6776,7 +6776,7 @@
     "NameKN": " ಪ್ರೀತಿ ಜೆ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Lingarajpura",
     "Designation": "Assistant Engineer",
     "Name": " Rajini A",
@@ -6790,7 +6790,7 @@
     "NameKN": " ರಜಿನಿ ಎ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "LLR",
     "Designation": "Assistant Engineer",
     "Name": " Seema",
@@ -6804,7 +6804,7 @@
     "NameKN": " ಸೀಮಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Machalibetta",
     "Designation": "Assistant Engineer",
     "Name": " Mallappa Mali",
@@ -6818,7 +6818,7 @@
     "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Magadi Road",
     "Designation": "Assistant Engineer",
     "Name": " Dinesh",
@@ -6832,7 +6832,7 @@
     "NameKN": " ದಿನೇಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Mahalakshmi Layuot",
     "Designation": "Assistant Engineer",
     "Name": " Pushpa",
@@ -6846,7 +6846,7 @@
     "NameKN": " ಪುಷ್ಪಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Malleshwarm",
     "Designation": "Assistant Engineer",
     "Name": " Suhana",
@@ -6860,7 +6860,7 @@
     "NameKN": " ಸುಹಾನಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "MEI Layout (Dasarahalli)",
     "Designation": "Assistant Engineer",
     "Name": " Karthik Manju",
@@ -6874,7 +6874,7 @@
     "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "MNK Park",
     "Designation": "Assistant Engineer",
     "Name": " Karthik M",
@@ -6888,7 +6888,7 @@
     "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Moodala Palya",
     "Designation": "Assistant Engineer",
     "Name": " Sathish T",
@@ -6902,7 +6902,7 @@
     "NameKN": " ಸತೀಶ್ ಟಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Mount Joy",
     "Designation": "Assistant Engineer",
     "Name": " Sudarshan D N",
@@ -6916,7 +6916,7 @@
     "NameKN": " ಸುದರ್ಶನ್ ಡಿ ಎನ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Mysore Road",
     "Designation": "Assistant Engineer",
     "Name": " Dinesh",
@@ -6930,7 +6930,7 @@
     "NameKN": " ದಿನೇಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Nagarabhavi",
     "Designation": "Assistant Engineer",
     "Name": " Harsha V",
@@ -6944,7 +6944,7 @@
     "NameKN": " ಹರ್ಷ ವಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Nagendra Block",
     "Designation": "Assistant Engineer",
     "Name": " Usha C R",
@@ -6958,7 +6958,7 @@
     "NameKN": " ಉಷಾ ಸಿ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Nandini Layout",
     "Designation": "Assistant Engineer",
     "Name": " Dushyanth",
@@ -6972,7 +6972,7 @@
     "NameKN": " ದುಷ್ಯಂತ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "New BEL Road",
     "Designation": "Assistant Engineer",
     "Name": " Dastagir Basha",
@@ -6986,7 +6986,7 @@
     "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "OMBR",
     "Designation": "Assistant Engineer",
     "Name": " Manjunatha",
@@ -7000,7 +7000,7 @@
     "NameKN": " ಮಂಜುನಾಥ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Peenya",
     "Designation": "Assistant Engineer",
     "Name": " Ganesh",
@@ -7014,7 +7014,7 @@
     "NameKN": " ಗಣೇಶ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Peenya Dasarahalli",
     "Designation": "Assistant Engineer",
     "Name": " Sandeep",
@@ -7028,7 +7028,7 @@
     "NameKN": " ಸಂದೀಪ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Pillana Garden-1",
     "Designation": "Assistant Engineer",
     "Name": " Rahul",
@@ -7042,7 +7042,7 @@
     "NameKN": " ರಾಹುಲ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Pillana Garden-2",
     "Designation": "Assistant Engineer",
     "Name": " Mallappa Mali",
@@ -7056,7 +7056,7 @@
     "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "PP Layout",
     "Designation": "Assistant Engineer",
     "Name": " Shekar",
@@ -7070,7 +7070,7 @@
     "NameKN": " ಶೇಖರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Rajaji Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Pushpa",
@@ -7084,7 +7084,7 @@
     "NameKN": " ಪುಷ್ಪಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ramamurthy Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Anand",
@@ -7098,7 +7098,7 @@
     "NameKN": " ಆನಂದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "RT Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Kumar",
@@ -7112,7 +7112,7 @@
     "NameKN": " ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Sahakar Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Chinthana K",
@@ -7126,7 +7126,7 @@
     "NameKN": " ಚಿಂತನ ಕೆ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Sanjay Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Dastagiri Basha",
@@ -7140,7 +7140,7 @@
     "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Srirampura",
     "Designation": "Assistant Engineer",
     "Name": " Siddaraju",
@@ -7154,7 +7154,7 @@
     "NameKN": " ಸಿದ್ದರಾಜು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Sudhama Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Suhas",
@@ -7168,7 +7168,7 @@
     "NameKN": " ಸುಹಾಸ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Ulsoor",
     "Designation": "Assistant Engineer",
     "Name": " Ravi Kiran(i/c)",
@@ -7182,7 +7182,7 @@
     "NameKN": " ರವಿ ಕಿರಣ್ (i/c)"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vidyaranyapura",
     "Designation": "Assistant Engineer",
     "Name": " Dhanalakshmi M",
@@ -7196,7 +7196,7 @@
     "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vignana Nagar",
     "Designation": "Assistant Engineer",
     "Name": " Mohammed Mudassir",
@@ -7210,7 +7210,7 @@
     "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vijay Nagar OHT",
     "Designation": "",
     "Name": "",
@@ -7224,7 +7224,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "VIjaya Bank Layout",
     "Designation": "Assistant Engineer",
     "Name": " Nagaraj S R",
@@ -7238,7 +7238,7 @@
     "NameKN": " ನಾಗರಾಜ್ ಎಸ್ ಆರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vijnanapura",
     "Designation": "Assistant Engineer",
     "Name": " Anand",
@@ -7252,7 +7252,7 @@
     "NameKN": " ಆನಂದ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vishveshwaraiah Layout",
     "Designation": "",
     "Name": "",
@@ -7266,7 +7266,7 @@
     "NameKN": ""
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Vjayanagar OHT",
     "Designation": "Assistant Engineer",
     "Name": " Ramegowda B",
@@ -7280,7 +7280,7 @@
     "NameKN": " ರಾಮೇಗೌಡ ಬಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "VV Puram",
     "Designation": "Assistant Engineer",
     "Name": " Prahalad",
@@ -7294,7 +7294,7 @@
     "NameKN": " ಪ್ರಹ್ಲಾದ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "WCR-I",
     "Designation": "Assistant Engineer",
     "Name": " Rajendra kumar",
@@ -7308,7 +7308,7 @@
     "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Yelahanka New Town",
     "Designation": "Assistant Engineer",
     "Name": " Manjunatha Hallur",
@@ -7322,7 +7322,7 @@
     "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Yelahanka Old Town",
     "Designation": "Assistant Engineer",
     "Name": " Vinay kumar P B",
@@ -7336,7 +7336,7 @@
     "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ ಬಿ"
   },
   {
-    "Department": "BWSSB (Service Station)",
+    "Department": "bwssb_service_station",
     "Area": "Yeshwanthpura",
     "Designation": "Assistant Engineer",
     "Name": " Kishore",


### PR DESCRIPTION
Small fix. 

Department value was previously 'BWSSB (Service Station)' instead of the correct `bwssb_service_station`. 

Closes #53 