### PR TITLE
Link directly to officials

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "svelte-i18n": "^4.0.1",
     "svelte-use-click-outside": "^1.0.0",
     "vite-plugin-radar": "^0.9.6"
-    "svelte-use-click-outside": "^1.0.0"
   },
   "config": {
     "googleSheet": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,12 @@
     "maplibre-gl": "^4.7.1",
     "polygon-lookup": "^2.6.0",
     "svelte-i18n": "^4.0.1",
-    "svelte-use-click-outside": "^1.0.0",
-    "vite-plugin-radar": "^0.9.6"
+    "svelte-use-click-outside": "^1.0.0"
+  },
+  "config": {
+    "googleSheet": {
+      "id": "1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY",
+      "gid": "1265603145"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "maplibre-gl": "^4.7.1",
     "polygon-lookup": "^2.6.0",
     "svelte-i18n": "^4.0.1",
+    "svelte-use-click-outside": "^1.0.0",
+    "vite-plugin-radar": "^0.9.6"
     "svelte-use-click-outside": "^1.0.0"
   },
   "config": {

--- a/scripts/officials.json
+++ b/scripts/officials.json
@@ -11,7 +11,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ ಎನ್"
+    "NameKN": "ಶಿವಶಂಕರ ಎನ್",
+    "cellRef": "A2"
   },
   {
     "Department": "admin_district",
@@ -25,7 +26,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ನಗರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಜಗದೀಶ ಜಿ"
+    "NameKN": "ಜಗದೀಶ ಜಿ",
+    "cellRef": "A3"
   },
   {
     "Department": "admin_district",
@@ -39,7 +41,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A4"
   },
   {
     "Department": "admin_district",
@@ -53,7 +56,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A5"
   },
   {
     "Department": "admin_district",
@@ -67,7 +71,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A6"
   },
   {
     "Department": "admin_district",
@@ -81,7 +86,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A7"
   },
   {
     "Department": "admin_district",
@@ -95,7 +101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A8"
   },
   {
     "Department": "admin_district",
@@ -109,7 +116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A9"
   },
   {
     "Department": "admin_district",
@@ -123,7 +131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A10"
   },
   {
     "Department": "admin_taluk",
@@ -137,7 +146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಪಿ ದಿನೇಶ್"
+    "NameKN": "ಪಿ ದಿನೇಶ್",
+    "cellRef": "A11"
   },
   {
     "Department": "admin_taluk",
@@ -151,7 +161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A12"
   },
   {
     "Department": "admin_taluk",
@@ -165,7 +176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಪೂರ್ವ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ರಾಜೀವ್"
+    "NameKN": "ಅಜಿತ್ ರೈ ಸಾರೋಕೆ",
+    "cellRef": "A13"
   },
   {
     "Department": "admin_taluk",
@@ -179,7 +191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಬಾಲಕೃಷ್ಣ"
+    "NameKN": "ಬಾಲಕೃಷ್ಣ",
+    "cellRef": "A14"
   },
   {
     "Department": "admin_taluk",
@@ -193,7 +206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ"
+    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ",
+    "cellRef": "A15"
   },
   {
     "Department": "admin_taluk",
@@ -207,7 +221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A16"
   },
   {
     "Department": "admin_taluk",
@@ -221,7 +236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A17"
   },
   {
     "Department": "admin_taluk",
@@ -235,7 +251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A18"
   },
   {
     "Department": "admin_taluk",
@@ -249,7 +266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A19"
   },
   {
     "Department": "admin_taluk",
@@ -263,7 +281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A20"
   },
   {
     "Department": "admin_taluk",
@@ -277,7 +296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A21"
   },
   {
     "Department": "admin_taluk",
@@ -291,7 +311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A22"
   },
   {
     "Department": "admin_taluk",
@@ -305,7 +326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A23"
   },
   {
     "Department": "admin_taluk",
@@ -319,7 +341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A24"
   },
   {
     "Department": "admin_taluk",
@@ -333,7 +356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A25"
   },
   {
     "Department": "admin_taluk",
@@ -347,7 +371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A26"
   },
   {
     "Department": "admin_taluk",
@@ -361,7 +386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A27"
   },
   {
     "Department": "admin_taluk",
@@ -375,7 +401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A28"
   },
   {
     "Department": "admin_taluk",
@@ -389,7 +416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A29"
   },
   {
     "Department": "admin_taluk",
@@ -403,7 +431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A30"
   },
   {
     "Department": "admin_taluk",
@@ -417,7 +446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ಎಫ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A31"
   },
   {
     "Department": "admin_taluk",
@@ -431,7 +461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A32"
   },
   {
     "Department": "admin_taluk",
@@ -445,7 +476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A33"
   },
   {
     "Department": "admin_taluk",
@@ -459,7 +491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A34"
   },
   {
     "Department": "admin_taluk",
@@ -473,7 +506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A35"
   },
   {
     "Department": "admin_taluk",
@@ -487,7 +521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A36"
   },
   {
     "Department": "admin_taluk",
@@ -501,7 +536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A37"
   },
   {
     "Department": "admin_taluk",
@@ -515,7 +551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A38"
   },
   {
     "Department": "admin_taluk",
@@ -529,7 +566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A39"
   },
   {
     "Department": "admin_taluk",
@@ -543,7 +581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A40"
   },
   {
     "Department": "admin_taluk",
@@ -557,7 +596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A41"
   },
   {
     "Department": "admin_taluk",
@@ -571,7 +611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A42"
   },
   {
     "Department": "admin_taluk",
@@ -585,7 +626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A43"
   },
   {
     "Department": "admin_taluk",
@@ -599,7 +641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A44"
   },
   {
     "Department": "admin_taluk",
@@ -613,7 +656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A45"
   },
   {
     "Department": "admin_taluk",
@@ -627,7 +671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A46"
   },
   {
     "Department": "admin_taluk",
@@ -641,7 +686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A47"
   },
   {
     "Department": "admin_taluk",
@@ -655,7 +701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A48"
   },
   {
     "Department": "admin_taluk",
@@ -669,7 +716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A49"
   },
   {
     "Department": "admin_taluk",
@@ -683,7 +731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A50"
   },
   {
     "Department": "admin_taluk",
@@ -697,7 +746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A51"
   },
   {
     "Department": "admin_taluk",
@@ -711,7 +761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A52"
   },
   {
     "Department": "admin_taluk",
@@ -725,7 +776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
+    "NameKN": "ನರಶಿಮಾಮೂರ್ತಿ",
+    "cellRef": "A53"
   },
   {
     "Department": "bbmp_wards",
@@ -739,7 +791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ"
+    "NameKN": "ಅಕ್ಷತಾ",
+    "cellRef": "A54"
   },
   {
     "Department": "bbmp_wards",
@@ -753,7 +806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್"
+    "NameKN": "ರವಿಕುಮಾರ್",
+    "cellRef": "A55"
   },
   {
     "Department": "bbmp_wards",
@@ -767,7 +821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್. ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಿ. ಶ್ರೀನಿವಾಸ ಮೂರ್ತಿ"
+    "NameKN": "ಜಿ ಶ್ರೀನಿವಾಸಮೂರ್ತಿ",
+    "cellRef": "A56"
   },
   {
     "Department": "bbmp_wards",
@@ -781,7 +836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಗರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ"
+    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ",
+    "cellRef": "A57"
   },
   {
     "Department": "bbmp_wards",
@@ -795,7 +851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್"
+    "NameKN": "ಸೋಮಶೇಖರ್",
+    "cellRef": "A58"
   },
   {
     "Department": "bbmp_wards",
@@ -809,7 +866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಂಜನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು"
+    "NameKN": "ರಘು",
+    "cellRef": "A59"
   },
   {
     "Department": "bbmp_wards",
@@ -823,7 +881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಮನೆ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜ್ ಕುಮಾರ್"
+    "NameKN": "ರಾಜ್ ಕುಮಾರ್",
+    "cellRef": "A60"
   },
   {
     "Department": "bbmp_wards",
@@ -837,7 +896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೇಖ್ ಅಹಮದ್"
+    "NameKN": "ಶೇಖ್ ಅಹಮದ್",
+    "cellRef": "A61"
   },
   {
     "Department": "bbmp_wards",
@@ -851,7 +911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜ್ಯೋತಿ"
+    "NameKN": "ಜ್ಯೋತಿ",
+    "cellRef": "A62"
   },
   {
     "Department": "bbmp_wards",
@@ -865,7 +926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಟ್ಟೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ"
+    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ",
+    "cellRef": "A63"
   },
   {
     "Department": "bbmp_wards",
@@ -879,7 +941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್"
+    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್",
+    "cellRef": "A64"
   },
   {
     "Department": "bbmp_wards",
@@ -893,7 +956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಜಾದ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್"
+    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್",
+    "cellRef": "A65"
   },
   {
     "Department": "bbmp_wards",
@@ -907,7 +971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿ ವೆಂಕಟ ರೆಡ್ಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ"
+    "NameKN": "ಮಮತಾ",
+    "cellRef": "A66"
   },
   {
     "Department": "bbmp_wards",
@@ -921,7 +986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
+    "cellRef": "A67"
   },
   {
     "Department": "bbmp_wards",
@@ -935,7 +1001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ"
+    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ",
+    "cellRef": "A68"
   },
   {
     "Department": "bbmp_wards",
@@ -949,7 +1016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಮಾ"
+    "NameKN": "ಸುಮಾ",
+    "cellRef": "A69"
   },
   {
     "Department": "bbmp_wards",
@@ -963,7 +1031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಡೆ ಮಠ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪೂರ್ಣಿಮಾ"
+    "NameKN": "ಪೂರ್ಣಿಮಾ",
+    "cellRef": "A70"
   },
   {
     "Department": "bbmp_wards",
@@ -977,7 +1046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ."
+    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ",
+    "cellRef": "A71"
   },
   {
     "Department": "bbmp_wards",
@@ -991,7 +1061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೆಂಕಟೇಶ್",
+    "cellRef": "A72"
   },
   {
     "Department": "bbmp_wards",
@@ -1005,7 +1076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನೀಲಕಂಠಯ್ಯ"
+    "NameKN": "ನೀಲಕಂಠಯ್ಯ",
+    "cellRef": "A73"
   },
   {
     "Department": "bbmp_wards",
@@ -1019,7 +1091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A74"
   },
   {
     "Department": "bbmp_wards",
@@ -1033,7 +1106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ"
+    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ",
+    "cellRef": "A75"
   },
   {
     "Department": "bbmp_wards",
@@ -1047,7 +1121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಾವಿತ್ರಿ"
+    "NameKN": "ಸಾವಿತ್ರಿ",
+    "cellRef": "A76"
   },
   {
     "Department": "bbmp_wards",
@@ -1061,7 +1136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಳೇಕಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A77"
   },
   {
     "Department": "bbmp_wards",
@@ -1075,7 +1151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿನ್ನಿಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್"
+    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್",
+    "cellRef": "A78"
   },
   {
     "Department": "bbmp_wards",
@@ -1089,7 +1166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್ ದೇವಾ"
+    "NameKN": "ರಮೇಶ್ ದೇವಾ",
+    "cellRef": "A79"
   },
   {
     "Department": "bbmp_wards",
@@ -1103,7 +1181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿ ಟಿ ಎಂ ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕಲಾ"
+    "NameKN": "ಶಶಿಕಲಾ",
+    "cellRef": "A80"
   },
   {
     "Department": "bbmp_wards",
@@ -1117,7 +1196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಕುಮಾರ್"
+    "NameKN": "ಶಿವಕುಮಾರ್",
+    "cellRef": "A81"
   },
   {
     "Department": "bbmp_wards",
@@ -1131,7 +1211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅನುಷಾ"
+    "NameKN": "ಅನುಷಾ",
+    "cellRef": "A82"
   },
   {
     "Department": "bbmp_wards",
@@ -1145,7 +1226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಿ.ಎನ್. ರಾಘವೇಂದ್ರ"
+    "NameKN": "ಬಿಎನ್ ರಾಘವೇಂದ್ರ",
+    "cellRef": "A83"
   },
   {
     "Department": "bbmp_wards",
@@ -1159,7 +1241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ ವಿ ರಾಮನ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ"
+    "NameKN": "ರವಿ",
+    "cellRef": "A84"
   },
   {
     "Department": "bbmp_wards",
@@ -1173,7 +1256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಲವಾದಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಸಂತ್"
+    "NameKN": "ವಸಂತ್",
+    "cellRef": "A85"
   },
   {
     "Department": "bbmp_wards",
@@ -1187,7 +1271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ"
+    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ",
+    "cellRef": "A86"
   },
   {
     "Department": "bbmp_wards",
@@ -1201,7 +1286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೌಮ್ಯಾ"
+    "NameKN": "ಸೌಮ್ಯಾ",
+    "cellRef": "A87"
   },
   {
     "Department": "bbmp_wards",
@@ -1215,7 +1301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮುಂಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಯನತಾರಾ ಡಾ."
+    "NameKN": "ನಯನತಾರಾ ಡಾ",
+    "cellRef": "A88"
   },
   {
     "Department": "bbmp_wards",
@@ -1229,7 +1316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರಾಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾರತಿ"
+    "NameKN": "ಭಾರತಿ",
+    "cellRef": "A89"
   },
   {
     "Department": "bbmp_wards",
@@ -1243,7 +1331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ"
+    "NameKN": "ಶಂಕರಪ್ಪ",
+    "cellRef": "A90"
   },
   {
     "Department": "bbmp_wards",
@@ -1257,7 +1346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್"
+    "NameKN": "ಶರತ್",
+    "cellRef": "A91"
   },
   {
     "Department": "bbmp_wards",
@@ -1271,7 +1361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯದುಕೃಷ್ಣ"
+    "NameKN": "ಯದುಕೃಷ್ಣ",
+    "cellRef": "A92"
   },
   {
     "Department": "bbmp_wards",
@@ -1285,7 +1376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೊಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ"
+    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ",
+    "cellRef": "A93"
   },
   {
     "Department": "bbmp_wards",
@@ -1299,7 +1391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೌಡೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪಾಪರೆಡ್ಡಿ"
+    "NameKN": "ಪಾಪರೆಡ್ಡಿ",
+    "cellRef": "A94"
   },
   {
     "Department": "bbmp_wards",
@@ -1313,7 +1406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೌಡೇಶ್ವರಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೆ.ಜಿ. ಸುಂದರೇಶ್"
+    "NameKN": "ಕೆ ಜಿ ಸುಂದರೇಶ್",
+    "cellRef": "A95"
   },
   {
     "Department": "bbmp_wards",
@@ -1327,7 +1421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಟನ್ ಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು"
+    "NameKN": "ರಾಜು",
+    "cellRef": "A96"
   },
   {
     "Department": "bbmp_wards",
@@ -1341,7 +1436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಕ್ಸ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ"
+    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ",
+    "cellRef": "A97"
   },
   {
     "Department": "bbmp_wards",
@@ -1355,7 +1451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದತ್ತಾತ್ರೇಯ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್"
+    "NameKN": "ವಿಶ್ವನಾಥ್",
+    "cellRef": "A98"
   },
   {
     "Department": "bbmp_wards",
@@ -1369,7 +1466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಯಾನಂದ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮು"
+    "NameKN": "ರಾಮು",
+    "cellRef": "A99"
   },
   {
     "Department": "bbmp_wards",
@@ -1383,7 +1481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೀಪಾಂಜಲಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು"
+    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು",
+    "cellRef": "A100"
   },
   {
     "Department": "bbmp_wards",
@@ -1397,7 +1496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಗಿರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್"
+    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್",
+    "cellRef": "A101"
   },
   {
     "Department": "bbmp_wards",
@@ -1411,7 +1511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವರ ಜೀವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್"
+    "NameKN": "ಉಮೇಶ್",
+    "cellRef": "A102"
   },
   {
     "Department": "bbmp_wards",
@@ -1425,7 +1526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವರಾಜ್ ಅರಸ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ"
+    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ",
+    "cellRef": "A103"
   },
   {
     "Department": "bbmp_wards",
@@ -1439,7 +1541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿತ್ಯ ಕೆ.ಎ."
+    "NameKN": "ನಿತ್ಯ ಕೆಎ",
+    "cellRef": "A104"
   },
   {
     "Department": "bbmp_wards",
@@ -1453,7 +1556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧರ್ಮರಾಯ ಸ್ವಾಮಿ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಲು ರಾಥೋರ್"
+    "NameKN": "ವಲು ರಾಥೋರ್",
+    "cellRef": "A105"
   },
   {
     "Department": "bbmp_wards",
@@ -1467,7 +1571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ಬಿದರಕಲ್ಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಿದ್ಧರಾಜ್"
+    "NameKN": "ಸಿದ್ದರಾಜು",
+    "cellRef": "A106"
   },
   {
     "Department": "bbmp_wards",
@@ -1481,7 +1586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ಬೊಮ್ಮಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬೀರೇಶ್"
+    "NameKN": "ಬೀರೇಶ್",
+    "cellRef": "A107"
   },
   {
     "Department": "bbmp_wards",
@@ -1495,7 +1601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ಗಣಪತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗಸ್ವಾಮಿ"
+    "NameKN": "ರಂಗಸ್ವಾಮಿ",
+    "cellRef": "A108"
   },
   {
     "Department": "bbmp_wards",
@@ -1509,7 +1616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ನೆಕ್ಕುಂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್"
+    "NameKN": "ರವಿಕುಮಾರ್",
+    "cellRef": "A109"
   },
   {
     "Department": "bbmp_wards",
@@ -1523,7 +1631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪ್ಪುರಾಜ್"
+    "NameKN": "ಅಪ್ಪುರಾಜ್",
+    "cellRef": "A110"
   },
   {
     "Department": "bbmp_wards",
@@ -1537,7 +1646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಡಾ. ಪುನೀತ್ ರಾಜ್ ಕುಮಾರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ"
+    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ",
+    "cellRef": "A111"
   },
   {
     "Department": "bbmp_wards",
@@ -1551,7 +1661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಡಾ. ರಾಜ್ ಕುಮಾರ್ ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್"
+    "NameKN": "ಪ್ರಕಾಶ್",
+    "cellRef": "A112"
   },
   {
     "Department": "bbmp_wards",
@@ -1565,7 +1676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಈಜಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನುಪಮಾ"
+    "NameKN": "ಡಾ.ಅನುಪಮಾ",
+    "cellRef": "A113"
   },
   {
     "Department": "bbmp_wards",
@@ -1579,7 +1691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಲಿ ಆಂಜನೇಯ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶಿಲ್ಪಾ"
+    "NameKN": "ಡಾ.ಶಿಲ್ಪಾ",
+    "cellRef": "A114"
   },
   {
     "Department": "bbmp_wards",
@@ -1593,7 +1706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿಯಪ್ಪ"
+    "NameKN": "ಮುನಿಯಪ್ಪ",
+    "cellRef": "A115"
   },
   {
     "Department": "bbmp_wards",
@@ -1607,7 +1721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಣೇಶ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್"
+    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್",
+    "cellRef": "A116"
   },
   {
     "Department": "bbmp_wards",
@@ -1621,7 +1736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಭಿಲಾಷ್"
+    "NameKN": "ಅಭಿಲಾಷ್",
+    "cellRef": "A117"
   },
   {
     "Department": "bbmp_wards",
@@ -1635,7 +1751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗರುಡಾಚಾರ್ ಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೂಪ್ರಧಾ"
+    "NameKN": "ಭೂಪ್ರದ",
+    "cellRef": "A118"
   },
   {
     "Department": "bbmp_wards",
@@ -1649,7 +1766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗವಿ ಗಂಗಾಧರೇಶ್ವರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು"
+    "NameKN": "ರಘು",
+    "cellRef": "A119"
   },
   {
     "Department": "bbmp_wards",
@@ -1663,7 +1781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಯಿತ್ರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಕುಮಾರ್"
+    "NameKN": "ರಾಜಕುಮಾರ್",
+    "cellRef": "A120"
   },
   {
     "Department": "bbmp_wards",
@@ -1677,7 +1796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಘರೇಭಾವಿಪಾಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A121"
   },
   {
     "Department": "bbmp_wards",
@@ -1691,7 +1811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೊಟ್ಟಿಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ"
+    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ",
+    "cellRef": "A122"
   },
   {
     "Department": "bbmp_wards",
@@ -1705,7 +1826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್"
+    "NameKN": "ಉಮೇಶ್",
+    "cellRef": "A123"
   },
   {
     "Department": "bbmp_wards",
@@ -1719,7 +1841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುರಪ್ಪನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್"
+    "NameKN": "ಸಂತೋಷ್",
+    "cellRef": "A124"
   },
   {
     "Department": "bbmp_wards",
@@ -1733,7 +1856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A125"
   },
   {
     "Department": "bbmp_wards",
@@ -1747,7 +1871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಂಪಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗರಾಜು"
+    "NameKN": "ರಂಗರಾಜು",
+    "cellRef": "A126"
   },
   {
     "Department": "bbmp_wards",
@@ -1761,7 +1886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HBR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರವಿಕುಮಾರ್"
+    "NameKN": "ಡಾ.ರವಿಕುಮಾರ್",
+    "cellRef": "A127"
   },
   {
     "Department": "bbmp_wards",
@@ -1775,7 +1901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಕೆಂಪಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ"
+    "NameKN": "ಅಕ್ಷತಾ",
+    "cellRef": "A128"
   },
   {
     "Department": "bbmp_wards",
@@ -1789,7 +1916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಇಮ್ರಾನ್"
+    "NameKN": "ಇಮ್ರಾನ್",
+    "cellRef": "A129"
   },
   {
     "Department": "bbmp_wards",
@@ -1803,7 +1931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹನುಮಂತ ನಾಯಕ್"
+    "NameKN": "ಹನುಮಂತ ನಾಯಕ್",
+    "cellRef": "A130"
   },
   {
     "Department": "bbmp_wards",
@@ -1817,7 +1946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಮ್ಮಿಗೆಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ"
+    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ",
+    "cellRef": "A131"
   },
   {
     "Department": "bbmp_wards",
@@ -1831,7 +1961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಈರಣ್ಣ"
+    "NameKN": "ಈರಣ್ಣ",
+    "cellRef": "A132"
   },
   {
     "Department": "bbmp_wards",
@@ -1845,7 +1976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೇರೋಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A133"
   },
   {
     "Department": "bbmp_wards",
@@ -1859,7 +1991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎನ್. ಎಸ್. ನಾಗೇಂದ್ರ"
+    "NameKN": "ಎನ್ ಎಸ್ ನಾಗೇಂದ್ರ",
+    "cellRef": "A134"
   },
   {
     "Department": "bbmp_wards",
@@ -1873,7 +2006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಗಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಧರ್"
+    "NameKN": "ಶಶಿಧರ್",
+    "cellRef": "A135"
   },
   {
     "Department": "bbmp_wards",
@@ -1887,7 +2021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊರಮಾವು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A136"
   },
   {
     "Department": "bbmp_wards",
@@ -1901,7 +2036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ರಸ್ತೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A137"
   },
   {
     "Department": "bbmp_wards",
@@ -1915,7 +2051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
+    "cellRef": "A138"
   },
   {
     "Department": "bbmp_wards",
@@ -1929,7 +2066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲೋಹಿತ್"
+    "NameKN": "ಲೋಹಿತ್",
+    "cellRef": "A139"
   },
   {
     "Department": "bbmp_wards",
@@ -1943,7 +2081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಯ್ಸಳ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
+    "cellRef": "A140"
   },
   {
     "Department": "bbmp_wards",
@@ -1957,7 +2096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು"
+    "NameKN": "ರಾಜು",
+    "cellRef": "A141"
   },
   {
     "Department": "bbmp_wards",
@@ -1971,7 +2111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್"
+    "NameKN": "ಪ್ರಕಾಶ್",
+    "cellRef": "A142"
   },
   {
     "Department": "bbmp_wards",
@@ -1985,7 +2126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A143"
   },
   {
     "Department": "bbmp_wards",
@@ -1999,7 +2141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಳಿಮಾವು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A144"
   },
   {
     "Department": "bbmp_wards",
@@ -2013,7 +2156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಬ್ಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A145"
   },
   {
     "Department": "bbmp_wards",
@@ -2027,7 +2171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ ಪಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫಜಲ್ ಅಹಮದ್"
+    "NameKN": "ಫಜಲ್ ಅಹಮದ್",
+    "cellRef": "A146"
   },
   {
     "Department": "bbmp_wards",
@@ -2041,7 +2186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರು"
+    "NameKN": "ಚಂದ್ರು",
+    "cellRef": "A147"
   },
   {
     "Department": "bbmp_wards",
@@ -2055,7 +2201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರುಣ್"
+    "NameKN": "ವರುಣ್",
+    "cellRef": "A148"
   },
   {
     "Department": "bbmp_wards",
@@ -2069,7 +2216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರ್"
+    "NameKN": "ವಿಶ್ವೇಶ್ವರ್",
+    "cellRef": "A149"
   },
   {
     "Department": "bbmp_wards",
@@ -2083,7 +2231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜರಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್"
+    "NameKN": "ನಾಗೇಶ್",
+    "cellRef": "A150"
   },
   {
     "Department": "bbmp_wards",
@@ -2097,7 +2246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಚಾಮರಾಜೇಂದ್ರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಷ್ಣುಕಾಂತ್"
+    "NameKN": "ವಿಷ್ಣುಕಾಂತ್",
+    "cellRef": "A151"
   },
   {
     "Department": "bbmp_wards",
@@ -2111,7 +2261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪೂರ್ವ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಚಿಕೇತ್"
+    "NameKN": "ನಚಿಕೇತ್",
+    "cellRef": "A152"
   },
   {
     "Department": "bbmp_wards",
@@ -2125,7 +2276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನಭೀಮ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ"
+    "NameKN": "ಶಿವಶಂಕರ",
+    "cellRef": "A153"
   },
   {
     "Department": "bbmp_wards",
@@ -2139,7 +2291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜ್ಞಾನ ಭಾರತಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರನಾರಾಯಣ್"
+    "NameKN": "ವರನಾರಾಯಣ",
+    "cellRef": "A154"
   },
   {
     "Department": "bbmp_wards",
@@ -2153,7 +2306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೋಗುಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಧನ್ಯ ಕುಮಾರ್"
+    "NameKN": "ಡಾ.ಧನ್ಯ ಕುಮಾರ್",
+    "cellRef": "A155"
   },
   {
     "Department": "bbmp_wards",
@@ -2167,7 +2321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿಲ್ಪಾ"
+    "NameKN": "ಶಿಲ್ಪಾ",
+    "cellRef": "A156"
   },
   {
     "Department": "bbmp_wards",
@@ -2181,7 +2336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್"
+    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್",
+    "cellRef": "A157"
   },
   {
     "Department": "bbmp_wards",
@@ -2195,7 +2351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ",
+    "cellRef": "A158"
   },
   {
     "Department": "bbmp_wards",
@@ -2209,7 +2366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ"
+    "NameKN": "ಮಮತಾ",
+    "cellRef": "A159"
   },
   {
     "Department": "bbmp_wards",
@@ -2223,7 +2381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡು ಮಲ್ಲೇಶ್ವರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹರ್ಷ ನಾಯಕ್"
+    "NameKN": "ಹರ್ಷ ನಾಯಕ್",
+    "cellRef": "A160"
   },
   {
     "Department": "bbmp_wards",
@@ -2237,7 +2396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉದಯ್ ಚೌಗಲೆ"
+    "NameKN": "ಉದಯ್ ಚೌಗಲೆ",
+    "cellRef": "A161"
   },
   {
     "Department": "bbmp_wards",
@@ -2251,7 +2411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ",
+    "cellRef": "A162"
   },
   {
     "Department": "bbmp_wards",
@@ -2265,7 +2426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಗ್ಗದಾಸನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ"
+    "NameKN": "ಮಂಜುಳಾ",
+    "cellRef": "A163"
   },
   {
     "Department": "bbmp_wards",
@@ -2279,7 +2441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಳೇನ ಅಗ್ರಹಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A164"
   },
   {
     "Department": "bbmp_wards",
@@ -2293,7 +2456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ"
+    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ",
+    "cellRef": "A165"
   },
   {
     "Department": "bbmp_wards",
@@ -2307,7 +2471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಸವರಾಜ"
+    "NameKN": "ಬಸವರಾಜ",
+    "cellRef": "A166"
   },
   {
     "Department": "bbmp_wards",
@@ -2321,7 +2486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮ್ಮಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ್"
+    "NameKN": "ಡಾ.ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ",
+    "cellRef": "A167"
   },
   {
     "Department": "bbmp_wards",
@@ -2335,7 +2501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಕುಮಾರ್"
+    "NameKN": "ವಿಜಯಕುಮಾರ್",
+    "cellRef": "A168"
   },
   {
     "Department": "bbmp_wards",
@@ -2349,7 +2516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ದೇವಿಕಾ ರಾಣಿ "
+    "NameKN": "ದೇವಿಕಾ ರಾಣಿ ಡಾ",
+    "cellRef": "A169"
   },
   {
     "Department": "bbmp_wards",
@@ -2363,7 +2531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ"
+    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ",
+    "cellRef": "A170"
   },
   {
     "Department": "bbmp_wards",
@@ -2377,7 +2546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾವೇರಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೆಂಕಟೇಶ್",
+    "cellRef": "A171"
   },
   {
     "Department": "bbmp_wards",
@@ -2391,7 +2561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫರ್ಜಾನಾ"
+    "NameKN": "ಫರ್ಜಾನಾ",
+    "cellRef": "A172"
   },
   {
     "Department": "bbmp_wards",
@@ -2405,7 +2576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪೇಗೌಡ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ"
+    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ",
+    "cellRef": "A173"
   },
   {
     "Department": "bbmp_wards",
@@ -2419,7 +2591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ"
+    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ",
+    "cellRef": "A174"
   },
   {
     "Department": "bbmp_wards",
@@ -2433,7 +2606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A175"
   },
   {
     "Department": "bbmp_wards",
@@ -2447,7 +2621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್"
+    "NameKN": "ಪ್ರದೀಪ್",
+    "cellRef": "A176"
   },
   {
     "Department": "bbmp_wards",
@@ -2461,7 +2636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಗಿಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್"
+    "NameKN": "ರಂಗನಾಥ್",
+    "cellRef": "A177"
   },
   {
     "Department": "bbmp_wards",
@@ -2475,7 +2651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಣನಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಮ್"
+    "NameKN": "ಜಯರಾಮ್",
+    "cellRef": "A178"
   },
   {
     "Department": "bbmp_wards",
@@ -2489,7 +2666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊನೆನ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ"
+    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ",
+    "cellRef": "A179"
   },
   {
     "Department": "bbmp_wards",
@@ -2503,7 +2681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A180"
   },
   {
     "Department": "bbmp_wards",
@@ -2517,7 +2696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಟ್ಟಿಗೆಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ"
+    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ",
+    "cellRef": "A181"
   },
   {
     "Department": "bbmp_wards",
@@ -2531,7 +2711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೂಡ್ಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A182"
   },
   {
     "Department": "bbmp_wards",
@@ -2545,7 +2726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
+    "cellRef": "A183"
   },
   {
     "Department": "bbmp_wards",
@@ -2559,7 +2741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಶಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ"
+    "NameKN": "ಡಾ.ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ",
+    "cellRef": "A184"
   },
   {
     "Department": "bbmp_wards",
@@ -2573,7 +2756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುವೆಂಪು ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ. ಧಾರೇಶ್ವರ್"
+    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ ಧಾರೇಶ್ವರ",
+    "cellRef": "A185"
   },
   {
     "Department": "bbmp_wards",
@@ -2587,7 +2771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ"
+    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ",
+    "cellRef": "A186"
   },
   {
     "Department": "bbmp_wards",
@@ -2601,7 +2786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್"
+    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್",
+    "cellRef": "A187"
   },
   {
     "Department": "bbmp_wards",
@@ -2615,7 +2801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಷ್ಮೀದೇವಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್"
+    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್",
+    "cellRef": "A188"
   },
   {
     "Department": "bbmp_wards",
@@ -2629,7 +2816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗಧೀರನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A189"
   },
   {
     "Department": "bbmp_wards",
@@ -2643,7 +2831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A190"
   },
   {
     "Department": "bbmp_wards",
@@ -2657,7 +2846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾಂತೇಶ್"
+    "NameKN": "ಮಹಾಂತೇಶ",
+    "cellRef": "A191"
   },
   {
     "Department": "bbmp_wards",
@@ -2671,7 +2861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮೀಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್"
+    "NameKN": "ನಾಗೇಶ್",
+    "cellRef": "A192"
   },
   {
     "Department": "bbmp_wards",
@@ -2685,7 +2876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳತಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕುಮಾರ್"
+    "NameKN": "ಶಶಿಕುಮಾರ್",
+    "cellRef": "A193"
   },
   {
     "Department": "bbmp_wards",
@@ -2699,7 +2891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೀಮಾ ನಾಯಕ್"
+    "NameKN": "ಭೀಮಾ ನಾಯಕ್",
+    "cellRef": "A194"
   },
   {
     "Department": "bbmp_wards",
@@ -2713,7 +2906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ"
+    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ",
+    "cellRef": "A195"
   },
   {
     "Department": "bbmp_wards",
@@ -2727,7 +2921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಮ್ಮನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಗೋಪಾಲ್"
+    "NameKN": "ರಾಜಗೋಪಾಲ್",
+    "cellRef": "A196"
   },
   {
     "Department": "bbmp_wards",
@@ -2741,7 +2936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮನೋರಾಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A197"
   },
   {
     "Department": "bbmp_wards",
@@ -2755,7 +2951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರತ್ತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರಾಕೇಶ್"
+    "NameKN": "ಡಾ.ರಾಕೇಶ್",
+    "cellRef": "A198"
   },
   {
     "Department": "bbmp_wards",
@@ -2769,7 +2966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ"
+    "NameKN": "ಡಾ.ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ",
+    "cellRef": "A199"
   },
   {
     "Department": "bbmp_wards",
@@ -2783,7 +2981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ"
+    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ",
+    "cellRef": "A200"
   },
   {
     "Department": "bbmp_wards",
@@ -2797,7 +2996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಸೇವಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣ ಗೌಡ"
+    "NameKN": "ಕೃಷ್ಣ ಗೌಡ",
+    "cellRef": "A201"
   },
   {
     "Department": "bbmp_wards",
@@ -2811,7 +3011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿರ್ಮಲಾ"
+    "NameKN": "ನಿರ್ಮಲಾ",
+    "cellRef": "A202"
   },
   {
     "Department": "bbmp_wards",
@@ -2825,7 +3026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್"
+    "NameKN": "ಸೋಮಶೇಖರ್",
+    "cellRef": "A203"
   },
   {
     "Department": "bbmp_wards",
@@ -2839,7 +3041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುನೆಕೊಳ್ಳಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ"
+    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ",
+    "cellRef": "A204"
   },
   {
     "Department": "bbmp_wards",
@@ -2853,7 +3056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುನೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೇವರಾಜ್ಯ"
+    "NameKN": "ದೇವರಾಜ್ಯ",
+    "cellRef": "A205"
   },
   {
     "Department": "bbmp_wards",
@@ -2867,7 +3071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಮಂದಯ್ಯ"
+    "NameKN": "ಸಮಂದಯ್ಯ",
+    "cellRef": "A206"
   },
   {
     "Department": "bbmp_wards",
@@ -2881,7 +3086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇವನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A207"
   },
   {
     "Department": "bbmp_wards",
@@ -2895,7 +3101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗನಾಥಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A208"
   },
   {
     "Department": "bbmp_wards",
@@ -2909,7 +3116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ"
+    "NameKN": "ಮಂಜುಳಾ",
+    "cellRef": "A209"
   },
   {
     "Department": "bbmp_wards",
@@ -2923,7 +3131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚರಣ್ ರಾಜ್"
+    "NameKN": "ಚರಣ್ ರಾಜ್",
+    "cellRef": "A210"
   },
   {
     "Department": "bbmp_wards",
@@ -2937,7 +3146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗವಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅತೀಫ್ ಅಹಮದ್"
+    "NameKN": "ಅತೀಫ್ ಅಹಮದ್",
+    "cellRef": "A211"
   },
   {
     "Department": "bbmp_wards",
@@ -2951,7 +3161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಲಗದರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗಭೂಷಣ"
+    "NameKN": "ನಾಗಭೂಷಣ",
+    "cellRef": "A212"
   },
   {
     "Department": "bbmp_wards",
@@ -2965,7 +3176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಲ್ವಡಿ ಕೃಷ್ಣರಾಜ ಒಡೆಯರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್"
+    "NameKN": "ಸುರೇಶ್",
+    "cellRef": "A213"
   },
   {
     "Department": "bbmp_wards",
@@ -2979,7 +3191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಯಂಡಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ"
+    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ",
+    "cellRef": "A214"
   },
   {
     "Department": "bbmp_wards",
@@ -2993,7 +3206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ಗುಡ್ಡದಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್"
+    "NameKN": "ಸಂತೋಷ್",
+    "cellRef": "A215"
   },
   {
     "Department": "bbmp_wards",
@@ -3007,7 +3221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ತಿಪ್ಪಸಂದರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ"
+    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ",
+    "cellRef": "A216"
   },
   {
     "Department": "bbmp_wards",
@@ -3021,7 +3236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೀಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿರೆಡ್ಡಿ"
+    "NameKN": "ಮುನಿರೆಡ್ಡಿ",
+    "cellRef": "A217"
   },
   {
     "Department": "bbmp_wards",
@@ -3035,7 +3251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಓಕಳಿಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A218"
   },
   {
     "Department": "bbmp_wards",
@@ -3049,7 +3266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾದರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆಯಿಷಾ"
+    "NameKN": "ಆಯಿಷಾ",
+    "cellRef": "A219"
   },
   {
     "Department": "bbmp_wards",
@@ -3063,7 +3281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪದ್ಮನಾಭ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೀಪಶ್ರೀ"
+    "NameKN": "ದೀಪಶ್ರೀ",
+    "cellRef": "A220"
   },
   {
     "Department": "bbmp_wards",
@@ -3077,7 +3296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್"
+    "NameKN": "ಸುರೇಶ್",
+    "cellRef": "A221"
   },
   {
     "Department": "bbmp_wards",
@@ -3091,7 +3311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಕೈಗಾರಿಕಾ ಪ್ರದೇಶ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್"
+    "NameKN": "ಜಯಶಂಕರ್",
+    "cellRef": "A222"
   },
   {
     "Department": "bbmp_wards",
@@ -3105,7 +3326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಿಕೇಶಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೆಂಕಟೇಶ್",
+    "cellRef": "A223"
   },
   {
     "Department": "bbmp_wards",
@@ -3119,7 +3341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಟ್ಟೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ"
+    "NameKN": "ರವಿ",
+    "cellRef": "A224"
   },
   {
     "Department": "bbmp_wards",
@@ -3133,7 +3356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಧಾಕೃಷ್ಣ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪದ್ಮರಾಜ್"
+    "NameKN": "ಪದ್ಮರಾಜ್",
+    "cellRef": "A225"
   },
   {
     "Department": "bbmp_wards",
@@ -3147,7 +3371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಗೋಪಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ"
+    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ",
+    "cellRef": "A226"
   },
   {
     "Department": "bbmp_wards",
@@ -3161,7 +3386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗಂಗಾಧರ್"
+    "NameKN": "ಗಂಗಾಧರ್",
+    "cellRef": "A227"
   },
   {
     "Department": "bbmp_wards",
@@ -3175,7 +3401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಮಹಲ್ ಗುಟ್ಟಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುಹಮ್ಮದ್ ಹಾಲಿ ಪಿಂಚಾರ್"
+    "NameKN": "ಮುಹಮ್ಮದ್ ಹಳ್ಳಿ ಪಿಂಚಾರ್",
+    "cellRef": "A228"
   },
   {
     "Department": "bbmp_wards",
@@ -3189,7 +3416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ"
+    "NameKN": "ಶಂಕರಪ್ಪ",
+    "cellRef": "A229"
   },
   {
     "Department": "bbmp_wards",
@@ -3203,7 +3431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜೀವ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್"
+    "NameKN": "ರಂಗನಾಥ್",
+    "cellRef": "A230"
   },
   {
     "Department": "bbmp_wards",
@@ -3217,7 +3446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ"
+    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ",
+    "cellRef": "A231"
   },
   {
     "Department": "bbmp_wards",
@@ -3231,7 +3461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಸ್ವಾಮಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್",
+    "cellRef": "A232"
   },
   {
     "Department": "bbmp_wards",
@@ -3245,7 +3476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್"
+    "NameKN": "ಉಮೇಶ್",
+    "cellRef": "A233"
   },
   {
     "Department": "bbmp_wards",
@@ -3259,7 +3491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "RBI ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A234"
   },
   {
     "Department": "bbmp_wards",
@@ -3273,7 +3506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ ಕೆ ಗಾರ್ಡನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿವಡ್ಡರ್"
+    "NameKN": "ರವಿವಡ್ಡರ್",
+    "cellRef": "A235"
   },
   {
     "Department": "bbmp_wards",
@@ -3287,7 +3521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಗಾಯರಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ"
+    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ",
+    "cellRef": "A236"
   },
   {
     "Department": "bbmp_wards",
@@ -3301,7 +3536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಂಗಿರಾಮ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A237"
   },
   {
     "Department": "bbmp_wards",
@@ -3315,7 +3551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಾಧವ್ ರಾವ್"
+    "NameKN": "ಮಾಧವ್ ರಾವ್",
+    "cellRef": "A238"
   },
   {
     "Department": "bbmp_wards",
@@ -3329,7 +3566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾರಕ್ಕಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್"
+    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್",
+    "cellRef": "A239"
   },
   {
     "Department": "bbmp_wards",
@@ -3343,7 +3581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಕಾಂಬರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಖಾ"
+    "NameKN": "ರೇಖಾ",
+    "cellRef": "A240"
   },
   {
     "Department": "bbmp_wards",
@@ -3357,7 +3596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಕ್ತಿ ಗಣಪತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಧು"
+    "NameKN": "ಮಧು",
+    "cellRef": "A241"
   },
   {
     "Department": "bbmp_wards",
@@ -3371,7 +3611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರ್ ಮಟ್ಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A242"
   },
   {
     "Department": "bbmp_wards",
@@ -3385,7 +3626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್"
+    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್",
+    "cellRef": "A243"
   },
   {
     "Department": "bbmp_wards",
@@ -3399,7 +3641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಯಶೋವರ್ದನ್"
+    "NameKN": "ಯಶೋವರ್ದನ್ ಡಾ",
+    "cellRef": "A244"
   },
   {
     "Department": "bbmp_wards",
@@ -3413,7 +3656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮದಾಸ್"
+    "NameKN": "ರಾಮದಾಸ್",
+    "cellRef": "A245"
   },
   {
     "Department": "bbmp_wards",
@@ -3427,7 +3671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಲ್ವರ್ ಜೂಬ್ಲಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
+    "cellRef": "A246"
   },
   {
     "Department": "bbmp_wards",
@@ -3441,7 +3686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಮೇಶ್ವರ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ"
+    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ",
+    "cellRef": "A247"
   },
   {
     "Department": "bbmp_wards",
@@ -3455,7 +3701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀಗಂಧದಕಾವಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಘವೇಂದ್ರ"
+    "NameKN": "ರಾಘವೇಂದ್ರ",
+    "cellRef": "A248"
   },
   {
     "Department": "bbmp_wards",
@@ -3469,7 +3716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಣ್ಣ"
+    "NameKN": "ಶಿವಣ್ಣ",
+    "cellRef": "A249"
   },
   {
     "Department": "bbmp_wards",
@@ -3483,7 +3731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಮಮಂದಿರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಲಾ"
+    "NameKN": "ಶಾಂತಲಾ",
+    "cellRef": "A250"
   },
   {
     "Department": "bbmp_wards",
@@ -3497,7 +3746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ಬಯ್ಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ"
+    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ",
+    "cellRef": "A251"
   },
   {
     "Department": "bbmp_wards",
@@ -3511,7 +3761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಭಾಷ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್"
+    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್",
+    "cellRef": "A252"
   },
   {
     "Department": "bbmp_wards",
@@ -3525,7 +3776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A253"
   },
   {
     "Department": "bbmp_wards",
@@ -3539,7 +3791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮನೋಹರ್"
+    "NameKN": "ಮನೋಹರ್",
+    "cellRef": "A254"
   },
   {
     "Department": "bbmp_wards",
@@ -3553,7 +3806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುದ್ದಗುಂಟೆ ಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್"
+    "NameKN": "ವಿಶ್ವನಾಥ್",
+    "cellRef": "A255"
   },
   {
     "Department": "bbmp_wards",
@@ -3567,7 +3821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
+    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ",
+    "cellRef": "A256"
   },
   {
     "Department": "bbmp_wards",
@@ -3581,7 +3836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಂಕೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಕೋಮಲ್ ಕೆ.ಆರ್"
+    "NameKN": "ಡಾ.ಕೋಮಲ್ ಕೆ.ಆರ್",
+    "cellRef": "A257"
   },
   {
     "Department": "bbmp_wards",
@@ -3595,7 +3851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸ್ವಾಮಿ ವಿವೇಕಾನಂದ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಗೌಡ"
+    "NameKN": "ಚನ್ನಗೌಡ",
+    "cellRef": "A258"
   },
   {
     "Department": "bbmp_wards",
@@ -3609,7 +3866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್"
+    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್",
+    "cellRef": "A259"
   },
   {
     "Department": "bbmp_wards",
@@ -3623,7 +3881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಥಣಿಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾದೇವ"
+    "NameKN": "ಮಹಾದೇವ",
+    "cellRef": "A260"
   },
   {
     "Department": "bbmp_wards",
@@ -3637,7 +3896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಲ್ಲಾಳು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಾಮರಾಜು"
+    "NameKN": "ಚಾಮರಾಜು",
+    "cellRef": "A261"
   },
   {
     "Department": "bbmp_wards",
@@ -3651,7 +3911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪರ್ಣಾ"
+    "NameKN": "ಅಪರ್ಣಾ",
+    "cellRef": "A262"
   },
   {
     "Department": "bbmp_wards",
@@ -3665,7 +3926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೋಹಿತ್"
+    "NameKN": "ರೋಹಿತ್",
+    "cellRef": "A263"
   },
   {
     "Department": "bbmp_wards",
@@ -3679,7 +3941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವನ್ನಾರಪೇಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A264"
   },
   {
     "Department": "bbmp_wards",
@@ -3693,7 +3956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಜ್"
+    "NameKN": "ಜಯರಾಜ್",
+    "cellRef": "A265"
   },
   {
     "Department": "bbmp_wards",
@@ -3707,7 +3971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಪ್ಪ"
+    "NameKN": "ಕೃಷ್ಣಪ್ಪ",
+    "cellRef": "A266"
   },
   {
     "Department": "bbmp_wards",
@@ -3721,7 +3986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಣ್ಣ"
+    "NameKN": "ರಾಜಣ್ಣ",
+    "cellRef": "A267"
   },
   {
     "Department": "bbmp_wards",
@@ -3735,7 +4001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾಪೀಠ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಟರಾಜ್"
+    "NameKN": "ನಟರಾಜ್",
+    "cellRef": "A268"
   },
   {
     "Department": "bbmp_wards",
@@ -3749,7 +4016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A269"
   },
   {
     "Department": "bbmp_wards",
@@ -3763,7 +4031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್"
+    "NameKN": "ಜಯಶಂಕರ್",
+    "cellRef": "A270"
   },
   {
     "Department": "bbmp_wards",
@@ -3777,7 +4046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಿನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಶೀಲಾ ಎನ್."
+    "NameKN": "ಸುಶೀಲಾ ಎನ್",
+    "cellRef": "A271"
   },
   {
     "Department": "bbmp_wards",
@@ -3791,7 +4061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್ ಕುಮಾರ್"
+    "NameKN": "ಶರತ್ ಕುಮಾರ್",
+    "cellRef": "A272"
   },
   {
     "Department": "bbmp_wards",
@@ -3805,7 +4076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವೇಶ್ವರ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್"
+    "NameKN": "ಡಾ.ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್",
+    "cellRef": "A273"
   },
   {
     "Department": "bbmp_wards",
@@ -3819,7 +4091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವನಾಥ ನಾಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರುದ್ರಮುನಿ"
+    "NameKN": "ರುದ್ರಮುನಿ",
+    "cellRef": "A274"
   },
   {
     "Department": "bbmp_wards",
@@ -3833,7 +4106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೃಷಭಾವತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A275"
   },
   {
     "Department": "bbmp_wards",
@@ -3847,7 +4121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್ ಫೀಲ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರುರಾಜ್"
+    "NameKN": "ಗುರುರಾಜ್",
+    "cellRef": "A276"
   },
   {
     "Department": "bbmp_wards",
@@ -3861,7 +4136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಡಿಯೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸನ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸನ್",
+    "cellRef": "A277"
   },
   {
     "Department": "bbmp_wards",
@@ -3875,7 +4151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ"
+    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ",
+    "cellRef": "A278"
   },
   {
     "Department": "bbmp_wards",
@@ -3889,7 +4166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯೆಲ್ಚೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಪ್ರಕಾಶ್"
+    "NameKN": "ಜಯಪ್ರಕಾಶ್",
+    "cellRef": "A279"
   },
   {
     "Department": "bbmp_wards",
@@ -3903,7 +4181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗೀತಾ"
+    "NameKN": "ಗೀತಾ",
+    "cellRef": "A280"
   },
   {
     "Department": "bbmp_zone",
@@ -3917,7 +4196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ರಮ್ಯಾ ಎಸ್."
+    "NameKN": "ರಮ್ಯಾ ಎಸ್",
+    "cellRef": "A281"
   },
   {
     "Department": "bbmp_zone",
@@ -3931,7 +4211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಹೆಚ್ .ಸಿ. ಗಿರೀಶ್"
+    "NameKN": "ಹೆಚ್ ಸಿ ಗಿರೀಶ್",
+    "cellRef": "A282"
   },
   {
     "Department": "bbmp_zone",
@@ -3945,7 +4226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್."
+    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್",
+    "cellRef": "A283"
   },
   {
     "Department": "bbmp_zone",
@@ -3959,7 +4241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕೆ.ಎನ್. ರಮೇಶ್"
+    "NameKN": "ಕೆ ಎನ್ ರಮೇಶ್",
+    "cellRef": "A284"
   },
   {
     "Department": "bbmp_zone",
@@ -3973,7 +4256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸತೀಶ ಬಿ.ಸಿ"
+    "NameKN": "ಸತೀಶ ಬಿ ಸಿ",
+    "cellRef": "A285"
   },
   {
     "Department": "bbmp_zone",
@@ -3987,7 +4271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್"
+    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್",
+    "cellRef": "A286"
   },
   {
     "Department": "bbmp_zone",
@@ -4001,7 +4286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಅರ್ಚನಾ ಎಂ.ಎಸ್"
+    "NameKN": "ಅರ್ಚನಾ ಎಂ ಎಸ್",
+    "cellRef": "A287"
   },
   {
     "Department": "bbmp_zone",
@@ -4015,7 +4301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕರೀಗೌಡ"
+    "NameKN": "ಕರೀಗೌಡ",
+    "cellRef": "A288"
   },
   {
     "Department": "bescom_division",
@@ -4029,7 +4316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A289"
   },
   {
     "Department": "bescom_division",
@@ -4043,7 +4331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A290"
   },
   {
     "Department": "bescom_division",
@@ -4057,7 +4346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A291"
   },
   {
     "Department": "bescom_division",
@@ -4071,7 +4361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A292"
   },
   {
     "Department": "bescom_division",
@@ -4085,7 +4376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A293"
   },
   {
     "Department": "bescom_division",
@@ -4099,7 +4391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A294"
   },
   {
     "Department": "bescom_division",
@@ -4113,7 +4406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A295"
   },
   {
     "Department": "bescom_division",
@@ -4127,7 +4421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A296"
   },
   {
     "Department": "bescom_division",
@@ -4141,7 +4436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A297"
   },
   {
     "Department": "bescom_division",
@@ -4155,7 +4451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A298"
   },
   {
     "Department": "bescom_division",
@@ -4169,7 +4466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A299"
   },
   {
     "Department": "bescom_division",
@@ -4183,7 +4481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A300"
   },
   {
     "Department": "bescom_division",
@@ -4197,7 +4496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A301"
   },
   {
     "Department": "bescom_division",
@@ -4211,7 +4511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A302"
   },
   {
     "Department": "bescom_division",
@@ -4225,7 +4526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A303"
   },
   {
     "Department": "bescom_division",
@@ -4239,7 +4541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A304"
   },
   {
     "Department": "bescom_division",
@@ -4253,7 +4556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A305"
   },
   {
     "Department": "bescom_division",
@@ -4267,7 +4571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A306"
   },
   {
     "Department": "bescom_division",
@@ -4281,7 +4586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A307"
   },
   {
     "Department": "bescom_division",
@@ -4295,7 +4601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A308"
   },
   {
     "Department": "bescom_division",
@@ -4309,7 +4616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A309"
   },
   {
     "Department": "bescom_division",
@@ -4323,7 +4631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A310"
   },
   {
     "Department": "bescom_division",
@@ -4337,7 +4646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A311"
   },
   {
     "Department": "bescom_division",
@@ -4351,7 +4661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನ ಸೌಧ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A312"
   },
   {
     "Department": "bescom_division",
@@ -4365,7 +4676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A313"
   },
   {
     "Department": "bescom_division",
@@ -4379,7 +4691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A314"
   },
   {
     "Department": "bescom_subdivision",
@@ -4393,7 +4706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A315"
   },
   {
     "Department": "bescom_subdivision",
@@ -4407,7 +4721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A316"
   },
   {
     "Department": "bescom_subdivision",
@@ -4421,7 +4736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ1 ರಾಜಾಜಿನಗರ 2ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A317"
   },
   {
     "Department": "bescom_subdivision",
@@ -4435,7 +4751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C2 ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A318"
   },
   {
     "Department": "bescom_subdivision",
@@ -4449,7 +4766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C3 ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A319"
   },
   {
     "Department": "bescom_subdivision",
@@ -4463,7 +4781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C4 ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A320"
   },
   {
     "Department": "bescom_subdivision",
@@ -4477,7 +4796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C5 ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A321"
   },
   {
     "Department": "bescom_subdivision",
@@ -4491,7 +4811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ6 ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A322"
   },
   {
     "Department": "bescom_subdivision",
@@ -4505,7 +4826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ7 ಯಲಹಂಕ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A323"
   },
   {
     "Department": "bescom_subdivision",
@@ -4519,7 +4841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C8 ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A324"
   },
   {
     "Department": "bescom_subdivision",
@@ -4533,7 +4856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ9 ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A325"
   },
   {
     "Department": "bescom_subdivision",
@@ -4547,7 +4871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A326"
   },
   {
     "Department": "bescom_subdivision",
@@ -4561,7 +4886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A327"
   },
   {
     "Department": "bescom_subdivision",
@@ -4575,7 +4901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A328"
   },
   {
     "Department": "bescom_subdivision",
@@ -4589,7 +4916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A329"
   },
   {
     "Department": "bescom_subdivision",
@@ -4603,7 +4931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ1 ಪಿಳ್ಳಣ್ಣ ಗಾರ್ಡನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A330"
   },
   {
     "Department": "bescom_subdivision",
@@ -4617,7 +4946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ10 ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A331"
   },
   {
     "Department": "bescom_subdivision",
@@ -4631,7 +4961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 11 ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A332"
   },
   {
     "Department": "bescom_subdivision",
@@ -4645,7 +4976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 12 ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A333"
   },
   {
     "Department": "bescom_subdivision",
@@ -4659,7 +4991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ2 ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A334"
   },
   {
     "Department": "bescom_subdivision",
@@ -4673,7 +5006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E3 MG ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A335"
   },
   {
     "Department": "bescom_subdivision",
@@ -4687,7 +5021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E4 ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A336"
   },
   {
     "Department": "bescom_subdivision",
@@ -4701,7 +5036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E5 ಕುಕ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A337"
   },
   {
     "Department": "bescom_subdivision",
@@ -4715,7 +5051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ6 ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A338"
   },
   {
     "Department": "bescom_subdivision",
@@ -4729,7 +5066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E7 ದೂರವಾಣಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A339"
   },
   {
     "Department": "bescom_subdivision",
@@ -4743,7 +5081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E8 ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A340"
   },
   {
     "Department": "bescom_subdivision",
@@ -4757,7 +5096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E9 ನಾಗವಾರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A341"
   },
   {
     "Department": "bescom_subdivision",
@@ -4771,7 +5111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A342"
   },
   {
     "Department": "bescom_subdivision",
@@ -4785,7 +5126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A343"
   },
   {
     "Department": "bescom_subdivision",
@@ -4799,7 +5141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 1 ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A344"
   },
   {
     "Department": "bescom_subdivision",
@@ -4813,7 +5156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 2 ಅಂಜನನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A345"
   },
   {
     "Department": "bescom_subdivision",
@@ -4827,7 +5171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 3 ಕಗ್ಗಲಿಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A346"
   },
   {
     "Department": "bescom_subdivision",
@@ -4841,7 +5186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "K4 RR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A347"
   },
   {
     "Department": "bescom_subdivision",
@@ -4855,7 +5201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A348"
   },
   {
     "Department": "bescom_subdivision",
@@ -4869,7 +5216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A349"
   },
   {
     "Department": "bescom_subdivision",
@@ -4883,7 +5231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A350"
   },
   {
     "Department": "bescom_subdivision",
@@ -4897,7 +5246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A351"
   },
   {
     "Department": "bescom_subdivision",
@@ -4911,7 +5261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A352"
   },
   {
     "Department": "bescom_subdivision",
@@ -4925,7 +5276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N1 ವೆಸ್ಟ್ ಕಾರ್ಡ್ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A353"
   },
   {
     "Department": "bescom_subdivision",
@@ -4939,7 +5291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N10 ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A354"
   },
   {
     "Department": "bescom_subdivision",
@@ -4953,7 +5306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N2 KHB ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A355"
   },
   {
     "Department": "bescom_subdivision",
@@ -4967,7 +5321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 3 ಬಸವೇಶ್ವರನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A356"
   },
   {
     "Department": "bescom_subdivision",
@@ -4981,7 +5336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N4 ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A357"
   },
   {
     "Department": "bescom_subdivision",
@@ -4995,7 +5351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N5 SRS ಗೇಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A358"
   },
   {
     "Department": "bescom_subdivision",
@@ -5009,7 +5366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N6 ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A359"
   },
   {
     "Department": "bescom_subdivision",
@@ -5023,7 +5381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N7 ಕುರುಬರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A360"
   },
   {
     "Department": "bescom_subdivision",
@@ -5037,7 +5396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 8 ಉಳ್ಳಾಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A361"
   },
   {
     "Department": "bescom_subdivision",
@@ -5051,7 +5411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N9 ಸೋಲದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A362"
   },
   {
     "Department": "bescom_subdivision",
@@ -5065,7 +5426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A363"
   },
   {
     "Department": "bescom_subdivision",
@@ -5079,7 +5441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 1 ಜಯನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A364"
   },
   {
     "Department": "bescom_subdivision",
@@ -5093,7 +5456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 10 ಬನ್ನೇರುಘಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A365"
   },
   {
     "Department": "bescom_subdivision",
@@ -5107,7 +5471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S11 HSR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A366"
   },
   {
     "Department": "bescom_subdivision",
@@ -5121,7 +5486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 12 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A367"
   },
   {
     "Department": "bescom_subdivision",
@@ -5135,7 +5501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 13 ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A368"
   },
   {
     "Department": "bescom_subdivision",
@@ -5149,7 +5516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 14 ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A369"
   },
   {
     "Department": "bescom_subdivision",
@@ -5163,7 +5531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 15 ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A370"
   },
   {
     "Department": "bescom_subdivision",
@@ -5177,7 +5546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S16 ಮಡಿವಾಳ SDO",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A371"
   },
   {
     "Department": "bescom_subdivision",
@@ -5191,7 +5561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S17 HAL",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A372"
   },
   {
     "Department": "bescom_subdivision",
@@ -5205,7 +5576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S18 ಚಿಕ್ಕ ಕಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A373"
   },
   {
     "Department": "bescom_subdivision",
@@ -5219,7 +5591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 19 ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A374"
   },
   {
     "Department": "bescom_subdivision",
@@ -5233,7 +5606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 2 ವಿಲ್ಸ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A375"
   },
   {
     "Department": "bescom_subdivision",
@@ -5247,7 +5621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷ್೨೦ ಆಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A376"
   },
   {
     "Department": "bescom_subdivision",
@@ -5261,7 +5636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S3 ಆಸ್ಟಿನ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A377"
   },
   {
     "Department": "bescom_subdivision",
@@ -5275,7 +5651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S4 ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A378"
   },
   {
     "Department": "bescom_subdivision",
@@ -5289,7 +5666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S5 ISRO ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A379"
   },
   {
     "Department": "bescom_subdivision",
@@ -5303,7 +5681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 6 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A380"
   },
   {
     "Department": "bescom_subdivision",
@@ -5317,7 +5696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್7 ಮುರುಗೇಶಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A381"
   },
   {
     "Department": "bescom_subdivision",
@@ -5331,7 +5711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 8 ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A382"
   },
   {
     "Department": "bescom_subdivision",
@@ -5345,7 +5726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S9 ಬನಶಂಕರಿ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A383"
   },
   {
     "Department": "bescom_subdivision",
@@ -5359,7 +5741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A384"
   },
   {
     "Department": "bescom_subdivision",
@@ -5373,7 +5756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ1",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A385"
   },
   {
     "Department": "bescom_subdivision",
@@ -5387,7 +5771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ2",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A386"
   },
   {
     "Department": "bescom_subdivision",
@@ -5401,7 +5786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ3 (ಕ್ಯಾತ್ಸಂದ್ರ)",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A387"
   },
   {
     "Department": "bescom_subdivision",
@@ -5415,7 +5801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W1 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A388"
   },
   {
     "Department": "bescom_subdivision",
@@ -5429,7 +5816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W2 ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A389"
   },
   {
     "Department": "bescom_subdivision",
@@ -5443,7 +5831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W3 ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A390"
   },
   {
     "Department": "bescom_subdivision",
@@ -5457,7 +5846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W4 AR ವೃತ್ತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A391"
   },
   {
     "Department": "bescom_subdivision",
@@ -5471,7 +5861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W5 ಕಬ್ಬನ್‌ಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A392"
   },
   {
     "Department": "bescom_subdivision",
@@ -5485,7 +5876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W6 ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A393"
   },
   {
     "Department": "bescom_subdivision",
@@ -5499,7 +5891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W7 ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A394"
   },
   {
     "Department": "bescom_subdivision",
@@ -5513,7 +5906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W8 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A395"
   },
   {
     "Department": "bwssb_division",
@@ -5527,7 +5921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇಂದ್ರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ"
+    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ",
+    "cellRef": "A396"
   },
   {
     "Department": "bwssb_division",
@@ -5541,7 +5936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್"
+    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್",
+    "cellRef": "A397"
   },
   {
     "Department": "bwssb_division",
@@ -5555,7 +5951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಜಯಪ್ರಕಾಶ್"
+    "NameKN": "ಜಯಪ್ರಕಾಶ್",
+    "cellRef": "A398"
   },
   {
     "Department": "bwssb_division",
@@ -5569,7 +5966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಈಶಾನ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ"
+    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ",
+    "cellRef": "A399"
   },
   {
     "Department": "bwssb_division",
@@ -5583,7 +5981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A400"
   },
   {
     "Department": "bwssb_division",
@@ -5597,7 +5996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A401"
   },
   {
     "Department": "bwssb_division",
@@ -5611,7 +6011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A402"
   },
   {
     "Department": "bwssb_division",
@@ -5625,7 +6026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಹರಿನಾಥ್ ಆರ್"
+    "NameKN": "ಹರಿನಾಥ್ ಆರ್",
+    "cellRef": "A403"
   },
   {
     "Department": "bwssb_division",
@@ -5639,7 +6041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್"
+    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್",
+    "cellRef": "A404"
   },
   {
     "Department": "bwssb_division",
@@ -5653,7 +6056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್."
+    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್",
+    "cellRef": "A405"
   },
   {
     "Department": "bwssb_division",
@@ -5667,7 +6071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A406"
   },
   {
     "Department": "bwssb_division",
@@ -5681,7 +6086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗರಾಜ್ ಕೆ."
+    "NameKN": "ನಾಗರಾಜ್ ಕೆ",
+    "cellRef": "A407"
   },
   {
     "Department": "bwssb_division",
@@ -5695,7 +6101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಬಸವರಾಜ ಎನ್."
+    "NameKN": "ಬಸವರಾಜ ಎನ್",
+    "cellRef": "A408"
   },
   {
     "Department": "bwssb_division",
@@ -5709,7 +6116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೈಋತ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಸ್ನೇಹಾ ವಿ."
+    "NameKN": "ಸ್ನೇಹಾ ವಿ",
+    "cellRef": "A409"
   },
   {
     "Department": "bwssb_division",
@@ -5723,7 +6131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಟಿ. ಚಂದ್ರಶೇಖರ್ ಪ್ರಸಾದ್"
+    "NameKN": "ಟಿ ಚಂದ್ರಶೇಖರ ಪ್ರಸಾದ್",
+    "cellRef": "A410"
   },
   {
     "Department": "bwssb_service_station",
@@ -5737,7 +6146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A411"
   },
   {
     "Department": "bwssb_service_station",
@@ -5751,7 +6161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ"
+    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ",
+    "cellRef": "A412"
   },
   {
     "Department": "bwssb_service_station",
@@ -5765,7 +6176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್"
+    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್",
+    "cellRef": "A413"
   },
   {
     "Department": "bwssb_service_station",
@@ -5779,7 +6191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
+    "cellRef": "A414"
   },
   {
     "Department": "bwssb_service_station",
@@ -5793,7 +6206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನಂದ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್"
+    "NameKN": " ಕುಮಾರ್",
+    "cellRef": "A415"
   },
   {
     "Department": "bwssb_service_station",
@@ -5807,7 +6221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A416"
   },
   {
     "Department": "bwssb_service_station",
@@ -5821,7 +6236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಶ್ವನಾಥ್"
+    "NameKN": " ವಿಶ್ವನಾಥ್",
+    "cellRef": "A417"
   },
   {
     "Department": "bwssb_service_station",
@@ -5835,7 +6251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಹುಬಲಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
+    "cellRef": "A418"
   },
   {
     "Department": "bwssb_service_station",
@@ -5849,7 +6266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪೂರ್ಣಿಮಾ"
+    "NameKN": " ಪೂರ್ಣಿಮಾ",
+    "cellRef": "A419"
   },
   {
     "Department": "bwssb_service_station",
@@ -5863,7 +6281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A420"
   },
   {
     "Department": "bwssb_service_station",
@@ -5877,7 +6296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A421"
   },
   {
     "Department": "bwssb_service_station",
@@ -5891,7 +6311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನಪ ಪಾರ್ಕ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A422"
   },
   {
     "Department": "bwssb_service_station",
@@ -5905,7 +6326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A423"
   },
   {
     "Department": "bwssb_service_station",
@@ -5919,7 +6341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A424"
   },
   {
     "Department": "bwssb_service_station",
@@ -5933,7 +6356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BEML ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A425"
   },
   {
     "Department": "bwssb_service_station",
@@ -5947,7 +6371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಷ್ಯಂ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್"
+    "NameKN": " ಕಿಶೋರ್",
+    "cellRef": "A426"
   },
   {
     "Department": "bwssb_service_station",
@@ -5961,7 +6386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-I",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A427"
   },
   {
     "Department": "bwssb_service_station",
@@ -5975,7 +6401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-II",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A428"
   },
   {
     "Department": "bwssb_service_station",
@@ -5989,7 +6416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM I & II",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ.ಪಿ."
+    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ ಪಿ",
+    "cellRef": "A429"
   },
   {
     "Department": "bwssb_service_station",
@@ -6003,7 +6431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ"
+    "NameKN": " ಶ್ರೀಜಾ",
+    "cellRef": "A430"
   },
   {
     "Department": "bwssb_service_station",
@@ -6017,7 +6446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ.ರಾಮನ್ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A431"
   },
   {
     "Department": "bwssb_service_station",
@@ -6031,7 +6461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ / ಹೊರಮಾವು / ಕಲ್ಕೆರೆ / ಕೊತ್ತನೂರು-ಬೈರತಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್"
+    "NameKN": " ಆನಂದ್",
+    "cellRef": "A432"
   },
   {
     "Department": "bwssb_service_station",
@@ -6045,7 +6476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ"
+    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ",
+    "cellRef": "A433"
   },
   {
     "Department": "bwssb_service_station",
@@ -6059,7 +6491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ"
+    "NameKN": " ರಾಮೇಗೌಡ",
+    "cellRef": "A434"
   },
   {
     "Department": "bwssb_service_station",
@@ -6073,7 +6506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಾಲಭಾಗ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ"
+    "NameKN": " ಸೀಮಾ",
+    "cellRef": "A435"
   },
   {
     "Department": "bwssb_service_station",
@@ -6087,7 +6521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "CLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಡಿ.ಎಸ್. ರಂಗಯ್ಯ"
+    "NameKN": " ಡಿ ಎಸ್ ರಂಗಯ್ಯ",
+    "cellRef": "A436"
   },
   {
     "Department": "bwssb_service_station",
@@ -6101,7 +6536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲ್ಸ್ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಶ್ ಎಸ್.ಡಿ"
+    "NameKN": " ರಾಜೇಶ್ ಎಸ್ ಡಿ",
+    "cellRef": "A437"
   },
   {
     "Department": "bwssb_service_station",
@@ -6115,7 +6551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಗಿರಿ I&II",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A438"
   },
   {
     "Department": "bwssb_service_station",
@@ -6129,7 +6566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು"
+    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು",
+    "cellRef": "A439"
   },
   {
     "Department": "bwssb_service_station",
@@ -6143,7 +6581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡನೆಕುಂದಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A440"
   },
   {
     "Department": "bwssb_service_station",
@@ -6157,7 +6596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಮತಾ ಎಂ.ಎಚ್"
+    "NameKN": " ಮಮತಾ ಎಂ ಎಚ್",
+    "cellRef": "A441"
   },
   {
     "Department": "bwssb_service_station",
@@ -6171,7 +6611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಜರ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್"
+    "NameKN": " ರಾಹುಲ್",
+    "cellRef": "A442"
   },
   {
     "Department": "bwssb_service_station",
@@ -6185,7 +6626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನ ಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A443"
   },
   {
     "Department": "bwssb_service_station",
@@ -6199,7 +6641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್"
+    "NameKN": " ಕುಮಾರ್",
+    "cellRef": "A444"
   },
   {
     "Department": "bwssb_service_station",
@@ -6213,7 +6656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
+    "NameKN": " ಉಷಾ ಸಿ ಆರ್",
+    "cellRef": "A445"
   },
   {
     "Department": "bwssb_service_station",
@@ -6227,7 +6671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A446"
   },
   {
     "Department": "bwssb_service_station",
@@ -6241,7 +6686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಂಜನ್"
+    "NameKN": " ರಂಜನ್",
+    "cellRef": "A447"
   },
   {
     "Department": "bwssb_service_station",
@@ -6255,7 +6701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
+    "cellRef": "A448"
   },
   {
     "Department": "bwssb_service_station",
@@ -6269,7 +6716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಡಿಶ್"
+    "NameKN": " ನಾಡಿಶ್",
+    "cellRef": "A449"
   },
   {
     "Department": "bwssb_service_station",
@@ -6283,7 +6731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HGR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್"
+    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್",
+    "cellRef": "A450"
   },
   {
     "Department": "bwssb_service_station",
@@ -6297,7 +6746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ"
+    "NameKN": " ಶ್ರೀಜಾ",
+    "cellRef": "A451"
   },
   {
     "Department": "bwssb_service_station",
@@ -6311,7 +6761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕುಮಾರ್"
+    "NameKN": " ರವಿ ಕುಮಾರ್",
+    "cellRef": "A452"
   },
   {
     "Department": "bwssb_service_station",
@@ -6325,7 +6776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸ್ವಾತಿ"
+    "NameKN": " ಸ್ವಾತಿ",
+    "cellRef": "A453"
   },
   {
     "Department": "bwssb_service_station",
@@ -6339,7 +6791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಧರ್ ಎಸ್"
+    "NameKN": " ಶ್ರೀಧರ್.ಎಸ್",
+    "cellRef": "A454"
   },
   {
     "Department": "bwssb_service_station",
@@ -6353,7 +6806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HRBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
+    "cellRef": "A455"
   },
   {
     "Department": "bwssb_service_station",
@@ -6367,7 +6821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A456"
   },
   {
     "Department": "bwssb_service_station",
@@ -6381,7 +6836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಐಡಿಯಲ್ ಹೋಮ್ಸ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
+    "cellRef": "A457"
   },
   {
     "Department": "bwssb_service_station",
@@ -6395,7 +6851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಶಿ ಕುಮಾರ್"
+    "NameKN": " ಶಶಿ ಕುಮಾರ್",
+    "cellRef": "A458"
   },
   {
     "Department": "bwssb_service_station",
@@ -6409,7 +6866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಸ್ರೋ ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A459"
   },
   {
     "Department": "bwssb_service_station",
@@ -6423,7 +6881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಟ್ಟಮಡು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಿಂಗರಾಜು"
+    "NameKN": " ಲಿಂಗರಾಜು",
+    "cellRef": "A460"
   },
   {
     "Department": "bwssb_service_station",
@@ -6437,7 +6896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ ಜೆ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ"
+    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ",
+    "cellRef": "A461"
   },
   {
     "Department": "bwssb_service_station",
@@ -6451,7 +6911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರದೀಪ್"
+    "NameKN": " ಪ್ರದೀಪ್",
+    "cellRef": "A462"
   },
   {
     "Department": "bwssb_service_station",
@@ -6465,7 +6926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಮಹಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ"
+    "NameKN": " ಜಯಶ್ರೀ",
+    "cellRef": "A463"
   },
   {
     "Department": "bwssb_service_station",
@@ -6479,7 +6941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ 'ಟಿ' ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ"
+    "NameKN": " ಲಕ್ಷ್ಮಿ",
+    "cellRef": "A464"
   },
   {
     "Department": "bwssb_service_station",
@@ -6493,7 +6956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ"
+    "NameKN": " ಶ್ರೀಜಾ",
+    "cellRef": "A465"
   },
   {
     "Department": "bwssb_service_station",
@@ -6507,7 +6971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಬಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A466"
   },
   {
     "Department": "bwssb_service_station",
@@ -6521,7 +6986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾನ್ಸನ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ"
+    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ",
+    "cellRef": "A467"
   },
   {
     "Department": "bwssb_service_station",
@@ -6535,7 +7001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 1ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ"
+    "NameKN": " ಲಕ್ಷ್ಮಿ",
+    "cellRef": "A468"
   },
   {
     "Department": "bwssb_service_station",
@@ -6549,7 +7016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ರಮ್"
+    "NameKN": " ಅಕ್ರಮ್",
+    "cellRef": "A469"
   },
   {
     "Department": "bwssb_service_station",
@@ -6563,7 +7031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 3ನೇ ಹಂತ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A470"
   },
   {
     "Department": "bwssb_service_station",
@@ -6577,7 +7046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A471"
   },
   {
     "Department": "bwssb_service_station",
@@ -6591,7 +7061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪುರಂ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A472"
   },
   {
     "Department": "bwssb_service_station",
@@ -6605,7 +7076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ/ ಕಮಲಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಿವಕುಮಾರ್"
+    "NameKN": " ಶಿವಕುಮಾರ್",
+    "cellRef": "A473"
   },
   {
     "Department": "bwssb_service_station",
@@ -6619,7 +7091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮುದಾ"
+    "NameKN": " ಕುಮುದಾ",
+    "cellRef": "A474"
   },
   {
     "Department": "bwssb_service_station",
@@ -6633,7 +7106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
+    "cellRef": "A475"
   },
   {
     "Department": "bwssb_service_station",
@@ -6647,7 +7121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇತಮಾರನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ"
+    "NameKN": " ಪುಷ್ಪಾ",
+    "cellRef": "A476"
   },
   {
     "Department": "bwssb_service_station",
@@ -6661,7 +7136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ಟವರ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ"
+    "NameKN": " ಜಯಶ್ರೀ",
+    "cellRef": "A477"
   },
   {
     "Department": "bwssb_service_station",
@@ -6675,7 +7151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಕಾಸ್ ಡಿ.ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್.ಆರ್"
+    "NameKN": " ವಿಕಾಸ್ ಡಿ ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್ ಆರ್",
+    "cellRef": "A478"
   },
   {
     "Department": "bwssb_service_station",
@@ -6689,7 +7166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A479"
   },
   {
     "Department": "bwssb_service_station",
@@ -6703,7 +7181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A480"
   },
   {
     "Department": "bwssb_service_station",
@@ -6717,7 +7196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A481"
   },
   {
     "Department": "bwssb_service_station",
@@ -6731,7 +7211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಜಾನನ"
+    "NameKN": " ಗಜಾನನ",
+    "cellRef": "A482"
   },
   {
     "Department": "bwssb_service_station",
@@ -6745,7 +7226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರುದಿನ್ನೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ಷಯ್ ಸಿ"
+    "NameKN": " ಅಕ್ಷಯ್ ಸಿ",
+    "cellRef": "A483"
   },
   {
     "Department": "bwssb_service_station",
@@ -6759,7 +7241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
+    "cellRef": "A484"
   },
   {
     "Department": "bwssb_service_station",
@@ -6773,7 +7256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರೀತಿ ಜೆ"
+    "NameKN": " ಪ್ರೀತಿ ಜೆ",
+    "cellRef": "A485"
   },
   {
     "Department": "bwssb_service_station",
@@ -6787,7 +7271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಜಿನಿ ಎ"
+    "NameKN": " ರಜಿನಿ ಎ",
+    "cellRef": "A486"
   },
   {
     "Department": "bwssb_service_station",
@@ -6801,7 +7286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "LLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ"
+    "NameKN": " ಸೀಮಾ",
+    "cellRef": "A487"
   },
   {
     "Department": "bwssb_service_station",
@@ -6815,7 +7301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಚಲಿಬೆಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
+    "cellRef": "A488"
   },
   {
     "Department": "bwssb_service_station",
@@ -6829,7 +7316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್"
+    "NameKN": " ದಿನೇಶ್",
+    "cellRef": "A489"
   },
   {
     "Department": "bwssb_service_station",
@@ -6843,7 +7331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಯೂಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ"
+    "NameKN": " ಪುಷ್ಪಾ",
+    "cellRef": "A490"
   },
   {
     "Department": "bwssb_service_station",
@@ -6857,7 +7346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾನಾ"
+    "NameKN": " ಸುಹಾನಾ",
+    "cellRef": "A491"
   },
   {
     "Department": "bwssb_service_station",
@@ -6871,7 +7361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MEI ಲೇಔಟ್ (ದಾಸರಹಳ್ಳಿ)",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
+    "cellRef": "A492"
   },
   {
     "Department": "bwssb_service_station",
@@ -6885,7 +7376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MNK ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ",
+    "cellRef": "A493"
   },
   {
     "Department": "bwssb_service_station",
@@ -6899,7 +7391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಲ ಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸತೀಶ್ ಟಿ"
+    "NameKN": " ಸತೀಶ್ ಟಿ",
+    "cellRef": "A494"
   },
   {
     "Department": "bwssb_service_station",
@@ -6913,7 +7406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೌಂಟ್ ಜಾಯ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುದರ್ಶನ್ ಡಿ.ಎನ್"
+    "NameKN": " ಸುದರ್ಶನ್ ಡಿ ಎನ್",
+    "cellRef": "A495"
   },
   {
     "Department": "bwssb_service_station",
@@ -6927,7 +7421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್"
+    "NameKN": " ದಿನೇಶ್",
+    "cellRef": "A496"
   },
   {
     "Department": "bwssb_service_station",
@@ -6941,7 +7436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹರ್ಷ ವಿ"
+    "NameKN": " ಹರ್ಷ ವಿ",
+    "cellRef": "A497"
   },
   {
     "Department": "bwssb_service_station",
@@ -6955,7 +7451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗೇಂದ್ರ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
+    "NameKN": " ಉಷಾ ಸಿ ಆರ್",
+    "cellRef": "A498"
   },
   {
     "Department": "bwssb_service_station",
@@ -6969,7 +7466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದುಷ್ಯಂತ್"
+    "NameKN": " ದುಷ್ಯಂತ್",
+    "cellRef": "A499"
   },
   {
     "Department": "bwssb_service_station",
@@ -6983,7 +7481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ BEL ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ"
+    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ",
+    "cellRef": "A500"
   },
   {
     "Department": "bwssb_service_station",
@@ -6997,7 +7496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "OMBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ"
+    "NameKN": " ಮಂಜುನಾಥ",
+    "cellRef": "A501"
   },
   {
     "Department": "bwssb_service_station",
@@ -7011,7 +7511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಣೇಶ್"
+    "NameKN": " ಗಣೇಶ್",
+    "cellRef": "A502"
   },
   {
     "Department": "bwssb_service_station",
@@ -7025,7 +7526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಂದೀಪ್"
+    "NameKN": " ಸಂದೀಪ್",
+    "cellRef": "A503"
   },
   {
     "Department": "bwssb_service_station",
@@ -7039,7 +7541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್"
+    "NameKN": " ರಾಹುಲ್",
+    "cellRef": "A504"
   },
   {
     "Department": "bwssb_service_station",
@@ -7053,7 +7556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
+    "cellRef": "A505"
   },
   {
     "Department": "bwssb_service_station",
@@ -7067,7 +7571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಪಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶೇಖರ್"
+    "NameKN": " ಶೇಖರ್",
+    "cellRef": "A506"
   },
   {
     "Department": "bwssb_service_station",
@@ -7081,7 +7586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ"
+    "NameKN": " ಪುಷ್ಪಾ",
+    "cellRef": "A507"
   },
   {
     "Department": "bwssb_service_station",
@@ -7095,7 +7601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್"
+    "NameKN": " ಆನಂದ್",
+    "cellRef": "A508"
   },
   {
     "Department": "bwssb_service_station",
@@ -7109,7 +7616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್"
+    "NameKN": " ಕುಮಾರ್",
+    "cellRef": "A509"
   },
   {
     "Department": "bwssb_service_station",
@@ -7123,7 +7631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಚಿಂತನ ಕೆ"
+    "NameKN": " ಚಿಂತನ ಕೆ",
+    "cellRef": "A510"
   },
   {
     "Department": "bwssb_service_station",
@@ -7137,7 +7646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ್ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
+    "cellRef": "A511"
   },
   {
     "Department": "bwssb_service_station",
@@ -7151,7 +7661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಿದ್ದರಾಜು"
+    "NameKN": " ಸಿದ್ದರಾಜು",
+    "cellRef": "A512"
   },
   {
     "Department": "bwssb_service_station",
@@ -7165,7 +7676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಧಾಮ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾಸ್"
+    "NameKN": " ಸುಹಾಸ್",
+    "cellRef": "A513"
   },
   {
     "Department": "bwssb_service_station",
@@ -7179,7 +7691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕಿರಣ್ (ಐ/ಸಿ)"
+    "NameKN": " ರವಿ ಕಿರಣ್ (i/c)",
+    "cellRef": "A514"
   },
   {
     "Department": "bwssb_service_station",
@@ -7193,7 +7706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ"
+    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ",
+    "cellRef": "A515"
   },
   {
     "Department": "bwssb_service_station",
@@ -7207,7 +7721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್"
+    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್",
+    "cellRef": "A516"
   },
   {
     "Department": "bwssb_service_station",
@@ -7221,7 +7736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯ್ ನಗರ OHT",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A517"
   },
   {
     "Department": "bwssb_service_station",
@@ -7235,7 +7751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ಆ.ರ್"
+    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ ಆರ್",
+    "cellRef": "A518"
   },
   {
     "Department": "bwssb_service_station",
@@ -7249,7 +7766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್"
+    "NameKN": " ಆನಂದ್",
+    "cellRef": "A519"
   },
   {
     "Department": "bwssb_service_station",
@@ -7263,7 +7781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಬಡಾವಣೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A520"
   },
   {
     "Department": "bwssb_service_station",
@@ -7277,7 +7796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ OHT",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ ಬಿ"
+    "NameKN": " ರಾಮೇಗೌಡ ಬಿ",
+    "cellRef": "A521"
   },
   {
     "Department": "bwssb_service_station",
@@ -7291,7 +7811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವಿ ಪುರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಪ್ರಹ್ಲಾದ್"
+    "NameKN": " ಪ್ರಹ್ಲಾದ",
+    "cellRef": "A522"
   },
   {
     "Department": "bwssb_service_station",
@@ -7305,7 +7826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "WCR-I",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
+    "cellRef": "A523"
   },
   {
     "Department": "bwssb_service_station",
@@ -7319,7 +7841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು"
+    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು",
+    "cellRef": "A524"
   },
   {
     "Department": "bwssb_service_station",
@@ -7333,7 +7856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಓಲ್ಡ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ.ಬಿ"
+    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ ಬಿ",
+    "cellRef": "A525"
   },
   {
     "Department": "bwssb_service_station",
@@ -7347,7 +7871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್"
+    "NameKN": " ಕಿಶೋರ್",
+    "cellRef": "A526"
   },
   {
     "Department": "police_city",
@@ -7361,7 +7886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A527"
   },
   {
     "Department": "police_city",
@@ -7375,7 +7901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A528"
   },
   {
     "Department": "police_city",
@@ -7389,7 +7916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A529"
   },
   {
     "Department": "police_city",
@@ -7403,7 +7931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A530"
   },
   {
     "Department": "police_city",
@@ -7417,7 +7946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಂಡರ್ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A531"
   },
   {
     "Department": "police_city",
@@ -7431,7 +7961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A532"
   },
   {
     "Department": "police_city",
@@ -7445,7 +7976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A533"
   },
   {
     "Department": "police_city",
@@ -7459,7 +7991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನುಗೊಂಡನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A534"
   },
   {
     "Department": "police_city",
@@ -7473,7 +8006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A535"
   },
   {
     "Department": "police_city",
@@ -7487,7 +8021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A536"
   },
   {
     "Department": "police_city",
@@ -7501,7 +8036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A537"
   },
   {
     "Department": "police_city",
@@ -7515,7 +8051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಡವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A538"
   },
   {
     "Department": "police_city",
@@ -7529,7 +8066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಗುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A539"
   },
   {
     "Department": "police_city",
@@ -7543,7 +8081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A540"
   },
   {
     "Department": "police_city",
@@ -7557,7 +8096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A541"
   },
   {
     "Department": "police_city",
@@ -7571,7 +8111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A542"
   },
   {
     "Department": "police_city",
@@ -7585,7 +8126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A543"
   },
   {
     "Department": "police_city",
@@ -7599,7 +8141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಡೆಪಾಳ್ಯ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A544"
   },
   {
     "Department": "police_city",
@@ -7613,7 +8156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A545"
   },
   {
     "Department": "police_city",
@@ -7627,7 +8171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A546"
   },
   {
     "Department": "police_city",
@@ -7641,7 +8186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವೇಶ್ವರ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A547"
   },
   {
     "Department": "police_city",
@@ -7655,7 +8201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A548"
   },
   {
     "Department": "police_city",
@@ -7669,7 +8216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A549"
   },
   {
     "Department": "police_city",
@@ -7683,7 +8231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಕವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A550"
   },
   {
     "Department": "police_city",
@@ -7697,7 +8246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A551"
   },
   {
     "Department": "police_city",
@@ -7711,7 +8261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಾವಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A552"
   },
   {
     "Department": "police_city",
@@ -7725,7 +8276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಇಎಂಎಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A553"
   },
   {
     "Department": "police_city",
@@ -7739,7 +8291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಸಗರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A554"
   },
   {
     "Department": "police_city",
@@ -7753,7 +8306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇತಮಂಗಲ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A555"
   },
   {
     "Department": "police_city",
@@ -7767,7 +8321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A556"
   },
   {
     "Department": "police_city",
@@ -7781,7 +8336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A557"
   },
   {
     "Department": "police_city",
@@ -7795,7 +8351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A558"
   },
   {
     "Department": "police_city",
@@ -7809,7 +8366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A559"
   },
   {
     "Department": "police_city",
@@ -7823,7 +8381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A560"
   },
   {
     "Department": "police_city",
@@ -7837,7 +8396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A561"
   },
   {
     "Department": "police_city",
@@ -7851,7 +8411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ಕೆ.ಅಚ್ಚುಕಟ್ಟು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A562"
   },
   {
     "Department": "police_city",
@@ -7865,7 +8426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A563"
   },
   {
     "Department": "police_city",
@@ -7879,7 +8441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A564"
   },
   {
     "Department": "police_city",
@@ -7893,7 +8456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ ರೀಫ್ಸ್ PS",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A565"
   },
   {
     "Department": "police_city",
@@ -7907,7 +8471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರಾ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A566"
   },
   {
     "Department": "police_city",
@@ -7921,7 +8486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A567"
   },
   {
     "Department": "police_city",
@@ -7935,7 +8501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A568"
   },
   {
     "Department": "police_city",
@@ -7949,7 +8516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A569"
   },
   {
     "Department": "police_city",
@@ -7963,7 +8531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A570"
   },
   {
     "Department": "police_city",
@@ -7977,7 +8546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A571"
   },
   {
     "Department": "police_city",
@@ -7991,7 +8561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A572"
   },
   {
     "Department": "police_city",
@@ -8005,7 +8576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A573"
   },
   {
     "Department": "police_city",
@@ -8019,7 +8591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A574"
   },
   {
     "Department": "police_city",
@@ -8033,7 +8606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A575"
   },
   {
     "Department": "police_city",
@@ -8047,7 +8621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A576"
   },
   {
     "Department": "police_city",
@@ -8061,7 +8636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A577"
   },
   {
     "Department": "police_city",
@@ -8075,7 +8651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮರ್ಷಿಯಲ್ ಸ್ಟ್ರೀಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A578"
   },
   {
     "Department": "police_city",
@@ -8089,7 +8666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಟನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A579"
   },
   {
     "Department": "police_city",
@@ -8103,7 +8681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A580"
   },
   {
     "Department": "police_city",
@@ -8117,7 +8696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A581"
   },
   {
     "Department": "police_city",
@@ -8131,7 +8711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಜೀವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A582"
   },
   {
     "Department": "police_city",
@@ -8145,7 +8726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಿಬ್ಬೂರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A583"
   },
   {
     "Department": "police_city",
@@ -8159,7 +8741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A584"
   },
   {
     "Department": "police_city",
@@ -8173,7 +8756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A585"
   },
   {
     "Department": "police_city",
@@ -8187,7 +8771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A586"
   },
   {
     "Department": "police_city",
@@ -8201,7 +8786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A587"
   },
   {
     "Department": "police_city",
@@ -8215,7 +8801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A588"
   },
   {
     "Department": "police_city",
@@ -8229,7 +8816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಮ್ಮಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A589"
   },
   {
     "Department": "police_city",
@@ -8243,7 +8831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A590"
   },
   {
     "Department": "police_city",
@@ -8257,7 +8846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A591"
   },
   {
     "Department": "police_city",
@@ -8271,7 +8861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A592"
   },
   {
     "Department": "police_city",
@@ -8285,7 +8876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A593"
   },
   {
     "Department": "police_city",
@@ -8299,7 +8891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A594"
   },
   {
     "Department": "police_city",
@@ -8313,7 +8906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A595"
   },
   {
     "Department": "police_city",
@@ -8327,7 +8921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A596"
   },
   {
     "Department": "police_city",
@@ -8341,7 +8936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A597"
   },
   {
     "Department": "police_city",
@@ -8355,7 +8951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಪೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A598"
   },
   {
     "Department": "police_city",
@@ -8369,7 +8966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A599"
   },
   {
     "Department": "police_city",
@@ -8383,7 +8981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A600"
   },
   {
     "Department": "police_city",
@@ -8397,7 +8996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಗೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A601"
   },
   {
     "Department": "police_city",
@@ -8411,7 +9011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A602"
   },
   {
     "Department": "police_city",
@@ -8425,7 +9026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A603"
   },
   {
     "Department": "police_city",
@@ -8439,7 +9041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನುಮತಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A604"
   },
   {
     "Department": "police_city",
@@ -8453,7 +9056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A605"
   },
   {
     "Department": "police_city",
@@ -8467,7 +9071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A606"
   },
   {
     "Department": "police_city",
@@ -8481,7 +9086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A607"
   },
   {
     "Department": "police_city",
@@ -8495,7 +9101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A608"
   },
   {
     "Department": "police_city",
@@ -8509,7 +9116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A609"
   },
   {
     "Department": "police_city",
@@ -8523,7 +9131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A610"
   },
   {
     "Department": "police_city",
@@ -8537,7 +9146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A611"
   },
   {
     "Department": "police_city",
@@ -8551,7 +9161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A612"
   },
   {
     "Department": "police_city",
@@ -8565,7 +9176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಳಿಮಾವು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A613"
   },
   {
     "Department": "police_city",
@@ -8579,7 +9191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A614"
   },
   {
     "Department": "police_city",
@@ -8593,7 +9206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಜೂರ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A615"
   },
   {
     "Department": "police_city",
@@ -8607,7 +9221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A616"
   },
   {
     "Department": "police_city",
@@ -8621,7 +9236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ.ಸಿ.ನಗರಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A617"
   },
   {
     "Department": "police_city",
@@ -8635,7 +9251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಜೀವನರಾಮ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A618"
   },
   {
     "Department": "police_city",
@@ -8649,7 +9266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A619"
   },
   {
     "Department": "police_city",
@@ -8663,7 +9281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A620"
   },
   {
     "Department": "police_city",
@@ -8677,7 +9296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಪ್ರಕಾಶ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A621"
   },
   {
     "Department": "police_city",
@@ -8691,7 +9311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A622"
   },
   {
     "Department": "police_city",
@@ -8705,7 +9326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A623"
   },
   {
     "Department": "police_city",
@@ -8719,7 +9341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜ್ಞಾನಭಾರತಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A624"
   },
   {
     "Department": "police_city",
@@ -8733,7 +9356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಜಿ.ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A625"
   },
   {
     "Department": "police_city",
@@ -8747,7 +9371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಎಂ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A626"
   },
   {
     "Department": "police_city",
@@ -8761,7 +9386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A627"
   },
   {
     "Department": "police_city",
@@ -8775,7 +9401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A628"
   },
   {
     "Department": "police_city",
@@ -8789,7 +9416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A629"
   },
   {
     "Department": "police_city",
@@ -8803,7 +9431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಗ್ಗಲೀಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A630"
   },
   {
     "Department": "police_city",
@@ -8817,7 +9446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಲಂಬೆಳ್ಳ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A631"
   },
   {
     "Department": "police_city",
@@ -8831,7 +9461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A632"
   },
   {
     "Department": "police_city",
@@ -8845,7 +9476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A633"
   },
   {
     "Department": "police_city",
@@ -8859,7 +9491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A634"
   },
   {
     "Department": "police_city",
@@ -8873,7 +9506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A635"
   },
   {
     "Department": "police_city",
@@ -8887,7 +9521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪೇಗೌಡ ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A636"
   },
   {
     "Department": "police_city",
@@ -8901,7 +9536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಚಾರ್ಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A637"
   },
   {
     "Department": "police_city",
@@ -8915,7 +9551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A638"
   },
   {
     "Department": "police_city",
@@ -8929,7 +9566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಸ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A639"
   },
   {
     "Department": "police_city",
@@ -8943,7 +9581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿರುಗಾವಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A640"
   },
   {
     "Department": "police_city",
@@ -8957,7 +9596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A641"
   },
   {
     "Department": "police_city",
@@ -8971,7 +9611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A642"
   },
   {
     "Department": "police_city",
@@ -8985,7 +9626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A643"
   },
   {
     "Department": "police_city",
@@ -8999,7 +9641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A644"
   },
   {
     "Department": "police_city",
@@ -9013,7 +9656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A645"
   },
   {
     "Department": "police_city",
@@ -9027,7 +9671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A646"
   },
   {
     "Department": "police_city",
@@ -9041,7 +9686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A647"
   },
   {
     "Department": "police_city",
@@ -9055,7 +9701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A648"
   },
   {
     "Department": "police_city",
@@ -9069,7 +9716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಣನಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A649"
   },
   {
     "Department": "police_city",
@@ -9083,7 +9731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A650"
   },
   {
     "Department": "police_city",
@@ -9097,7 +9746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A651"
   },
   {
     "Department": "police_city",
@@ -9111,7 +9761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A652"
   },
   {
     "Department": "police_city",
@@ -9125,7 +9776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A653"
   },
   {
     "Department": "police_city",
@@ -9139,7 +9791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A654"
   },
   {
     "Department": "police_city",
@@ -9153,7 +9806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A655"
   },
   {
     "Department": "police_city",
@@ -9167,7 +9821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A656"
   },
   {
     "Department": "police_city",
@@ -9181,7 +9836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೂಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A657"
   },
   {
     "Department": "police_city",
@@ -9195,7 +9851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A658"
   },
   {
     "Department": "police_city",
@@ -9209,7 +9866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A659"
   },
   {
     "Department": "police_city",
@@ -9223,7 +9881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A660"
   },
   {
     "Department": "police_city",
@@ -9237,7 +9896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಕೆ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A661"
   },
   {
     "Department": "police_city",
@@ -9251,7 +9911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಎಂ. ಹಿಲ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A662"
   },
   {
     "Department": "police_city",
@@ -9265,7 +9926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A663"
   },
   {
     "Department": "police_city",
@@ -9279,7 +9941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A664"
   },
   {
     "Department": "police_city",
@@ -9293,7 +9956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A665"
   },
   {
     "Department": "police_city",
@@ -9307,7 +9971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A666"
   },
   {
     "Department": "police_city",
@@ -9321,7 +9986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A667"
   },
   {
     "Department": "police_city",
@@ -9335,7 +10001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A668"
   },
   {
     "Department": "police_city",
@@ -9349,7 +10016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A669"
   },
   {
     "Department": "police_city",
@@ -9363,7 +10031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A670"
   },
   {
     "Department": "police_city",
@@ -9377,7 +10046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A671"
   },
   {
     "Department": "police_city",
@@ -9391,7 +10061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A672"
   },
   {
     "Department": "police_city",
@@ -9405,7 +10076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A673"
   },
   {
     "Department": "police_city",
@@ -9419,7 +10091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A674"
   },
   {
     "Department": "police_city",
@@ -9433,7 +10106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಂಬಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A675"
   },
   {
     "Department": "police_city",
@@ -9447,7 +10121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A676"
   },
   {
     "Department": "police_city",
@@ -9461,7 +10136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A677"
   },
   {
     "Department": "police_city",
@@ -9475,7 +10151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರತ್ತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A678"
   },
   {
     "Department": "police_city",
@@ -9489,7 +10166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರಿಕುಪ್ಪಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A679"
   },
   {
     "Department": "police_city",
@@ -9503,7 +10181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A680"
   },
   {
     "Department": "police_city",
@@ -9517,7 +10196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಡಿಗೇಶಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A681"
   },
   {
     "Department": "police_city",
@@ -9531,7 +10211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಕೋ ಲೇಔಟ್ ಬೆಂಗಳೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A682"
   },
   {
     "Department": "police_city",
@@ -9545,7 +10226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A683"
   },
   {
     "Department": "police_city",
@@ -9559,7 +10241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A684"
   },
   {
     "Department": "police_city",
@@ -9573,7 +10256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A685"
   },
   {
     "Department": "police_city",
@@ -9587,7 +10271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ ಗಿರಿಘಾಮ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A686"
   },
   {
     "Department": "police_city",
@@ -9601,7 +10286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A687"
   },
   {
     "Department": "police_city",
@@ -9615,7 +10301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಗಲಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A688"
   },
   {
     "Department": "police_city",
@@ -9629,7 +10316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A689"
   },
   {
     "Department": "police_city",
@@ -9643,7 +10331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A690"
   },
   {
     "Department": "police_city",
@@ -9657,7 +10346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A691"
   },
   {
     "Department": "police_city",
@@ -9671,7 +10361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A692"
   },
   {
     "Department": "police_city",
@@ -9685,7 +10376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪರಪ್ಪನ ಅಗ್ರಹಾರ",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A693"
   },
   {
     "Department": "police_city",
@@ -9699,7 +10391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಟನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A694"
   },
   {
     "Department": "police_city",
@@ -9713,7 +10406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾತಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A695"
   },
   {
     "Department": "police_city",
@@ -9727,7 +10421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A696"
   },
   {
     "Department": "police_city",
@@ -9741,7 +10436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A697"
   },
   {
     "Department": "police_city",
@@ -9755,7 +10451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A698"
   },
   {
     "Department": "police_city",
@@ -9769,7 +10466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಟ್ಟೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A699"
   },
   {
     "Department": "police_city",
@@ -9783,7 +10481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A700"
   },
   {
     "Department": "police_city",
@@ -9797,7 +10496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A701"
   },
   {
     "Department": "police_city",
@@ -9811,7 +10511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾನುಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A702"
   },
   {
     "Department": "police_city",
@@ -9825,7 +10526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A703"
   },
   {
     "Department": "police_city",
@@ -9839,7 +10541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಗೋಪಾಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A704"
   },
   {
     "Department": "police_city",
@@ -9853,7 +10556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A705"
   },
   {
     "Department": "police_city",
@@ -9867,7 +10571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A706"
   },
   {
     "Department": "police_city",
@@ -9881,7 +10586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A707"
   },
   {
     "Department": "police_city",
@@ -9895,7 +10601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A708"
   },
   {
     "Department": "police_city",
@@ -9909,7 +10616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಲ್ಪಾಡ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A709"
   },
   {
     "Department": "police_city",
@@ -9923,7 +10631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಬರ್ಟ್‌ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A710"
   },
   {
     "Department": "police_city",
@@ -9937,7 +10646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್.ಜೆ. ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A711"
   },
   {
     "Department": "police_city",
@@ -9951,7 +10661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷದಶಿವನಗರ್ Pಷ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A712"
   },
   {
     "Department": "police_city",
@@ -9965,7 +10676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಂಗಿರಾಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A713"
   },
   {
     "Department": "police_city",
@@ -9979,7 +10691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಿಗೆಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A714"
   },
   {
     "Department": "police_city",
@@ -9993,7 +10706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ ನಗರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A715"
   },
   {
     "Department": "police_city",
@@ -10007,7 +10721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂತೆಮರಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A716"
   },
   {
     "Department": "police_city",
@@ -10021,7 +10736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A717"
   },
   {
     "Department": "police_city",
@@ -10035,7 +10751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾತನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A718"
   },
   {
     "Department": "police_city",
@@ -10049,7 +10766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A719"
   },
   {
     "Department": "police_city",
@@ -10063,7 +10781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A720"
   },
   {
     "Department": "police_city",
@@ -10077,7 +10796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A721"
   },
   {
     "Department": "police_city",
@@ -10091,7 +10811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A722"
   },
   {
     "Department": "police_city",
@@ -10105,7 +10826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A723"
   },
   {
     "Department": "police_city",
@@ -10119,7 +10841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A724"
   },
   {
     "Department": "police_city",
@@ -10133,7 +10856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A725"
   },
   {
     "Department": "police_city",
@@ -10147,7 +10871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A726"
   },
   {
     "Department": "police_city",
@@ -10161,7 +10886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A727"
   },
   {
     "Department": "police_city",
@@ -10175,7 +10901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A728"
   },
   {
     "Department": "police_city",
@@ -10189,7 +10916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A729"
   },
   {
     "Department": "police_city",
@@ -10203,7 +10931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A730"
   },
   {
     "Department": "police_city",
@@ -10217,7 +10946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುದ್ದಗುಂಟೆಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A731"
   },
   {
     "Department": "police_city",
@@ -10231,7 +10961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗಟೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A732"
   },
   {
     "Department": "police_city",
@@ -10245,7 +10976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A733"
   },
   {
     "Department": "police_city",
@@ -10259,7 +10991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೈಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A734"
   },
   {
     "Department": "police_city",
@@ -10273,7 +11006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಕಾಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A735"
   },
   {
     "Department": "police_city",
@@ -10287,7 +11021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A736"
   },
   {
     "Department": "police_city",
@@ -10301,7 +11036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A737"
   },
   {
     "Department": "police_city",
@@ -10315,7 +11051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A738"
   },
   {
     "Department": "police_city",
@@ -10329,7 +11066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A739"
   },
   {
     "Department": "police_city",
@@ -10343,7 +11081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A740"
   },
   {
     "Department": "police_city",
@@ -10357,7 +11096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A741"
   },
   {
     "Department": "police_city",
@@ -10371,7 +11111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A742"
   },
   {
     "Department": "police_city",
@@ -10385,7 +11126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A743"
   },
   {
     "Department": "police_city",
@@ -10399,7 +11141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A744"
   },
   {
     "Department": "police_city",
@@ -10413,7 +11156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A745"
   },
   {
     "Department": "police_city",
@@ -10427,7 +11171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A746"
   },
   {
     "Department": "police_city",
@@ -10441,7 +11186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A747"
   },
   {
     "Department": "police_city",
@@ -10455,7 +11201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನಸೌಧ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A748"
   },
   {
     "Department": "police_city",
@@ -10469,7 +11216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A749"
   },
   {
     "Department": "police_city",
@@ -10483,7 +11231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A750"
   },
   {
     "Department": "police_city",
@@ -10497,7 +11246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A751"
   },
   {
     "Department": "police_city",
@@ -10511,7 +11261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವನಾಥಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A752"
   },
   {
     "Department": "police_city",
@@ -10525,7 +11276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವೇಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A753"
   },
   {
     "Department": "police_city",
@@ -10539,7 +11291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಯಾಲಿಕಾವಲ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A754"
   },
   {
     "Department": "police_city",
@@ -10553,7 +11306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A755"
   },
   {
     "Department": "police_city",
@@ -10567,7 +11321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A756"
   },
   {
     "Department": "police_city",
@@ -10581,7 +11336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A757"
   },
   {
     "Department": "police_city",
@@ -10595,7 +11351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A758"
   },
   {
     "Department": "police_city",
@@ -10609,7 +11366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A759"
   },
   {
     "Department": "police_city",
@@ -10623,7 +11381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A760"
   },
   {
     "Department": "police_city",
@@ -10637,7 +11396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A761"
   },
   {
     "Department": "police_city",
@@ -10651,7 +11411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಆರ್‌ಎಂಸಿ ಯಾರ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A762"
   },
   {
     "Department": "election_ac",
@@ -10665,7 +11426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಶಿವಣ್ಣ"
+    "NameKN": "ಬಿ ಶಿವಣ್ಣ",
+    "cellRef": "A763"
   },
   {
     "Department": "election_ac",
@@ -10679,7 +11441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಟಿಎಂ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ"
+    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ",
+    "cellRef": "A764"
   },
   {
     "Department": "election_ac",
@@ -10693,7 +11456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A765"
   },
   {
     "Department": "election_ac",
@@ -10707,7 +11471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
+    "NameKN": "ಎಂ ಕೃಷ್ಣಪ್ಪ",
+    "cellRef": "A766"
   },
   {
     "Department": "election_ac",
@@ -10721,7 +11486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A767"
   },
   {
     "Department": "election_ac",
@@ -10735,7 +11501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ ಎಲ್.ಎ"
+    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ LA",
+    "cellRef": "A768"
   },
   {
     "Department": "election_ac",
@@ -10749,7 +11516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ"
+    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ",
+    "cellRef": "A769"
   },
   {
     "Department": "election_ac",
@@ -10763,7 +11531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ"
+    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ",
+    "cellRef": "A770"
   },
   {
     "Department": "election_ac",
@@ -10777,7 +11546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ. ರಾಮಣ್ಣನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ರಘು"
+    "NameKN": "ಎಸ್ ರಘು",
+    "cellRef": "A771"
   },
   {
     "Department": "election_ac",
@@ -10791,7 +11561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಜೆಡ್ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್"
+    "NameKN": "BZ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್",
+    "cellRef": "A772"
   },
   {
     "Department": "election_ac",
@@ -10805,7 +11576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "MLA",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A773"
   },
   {
     "Department": "election_ac",
@@ -10819,7 +11591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್"
+    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್",
+    "cellRef": "A774"
   },
   {
     "Department": "election_ac",
@@ -10833,7 +11606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್"
+    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್",
+    "cellRef": "A775"
   },
   {
     "Department": "election_ac",
@@ -10847,7 +11621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A776"
   },
   {
     "Department": "election_ac",
@@ -10861,7 +11636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಮುನಿರಾಜು"
+    "NameKN": "ಎಸ್ ಮುನಿರಾಜು",
+    "cellRef": "A777"
   },
   {
     "Department": "election_ac",
@@ -10875,7 +11651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ. ಎಚ್. ಮುನಿಯಪ್ಪ"
+    "NameKN": "ಕೆ ಎಚ್ ಮುನಿಯಪ್ಪ",
+    "cellRef": "A778"
   },
   {
     "Department": "election_ac",
@@ -10889,7 +11666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್"
+    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್",
+    "cellRef": "A779"
   },
   {
     "Department": "election_ac",
@@ -10903,7 +11681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್"
+    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್",
+    "cellRef": "A780"
   },
   {
     "Department": "election_ac",
@@ -10917,7 +11696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A781"
   },
   {
     "Department": "election_ac",
@@ -10931,7 +11711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ"
+    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ",
+    "cellRef": "A782"
   },
   {
     "Department": "election_ac",
@@ -10945,7 +11726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A783"
   },
   {
     "Department": "election_ac",
@@ -10959,7 +11741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A784"
   },
   {
     "Department": "election_ac",
@@ -10973,7 +11756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎಸ್. ಸುರೇಶ ಬೈರತಿ"
+    "NameKN": "ಬಿ.ಎಸ್.ಸುರೇಶ ಬೈರತಿ",
+    "cellRef": "A785"
   },
   {
     "Department": "election_ac",
@@ -10987,7 +11771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ"
+    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ",
+    "cellRef": "A786"
   },
   {
     "Department": "election_ac",
@@ -11001,7 +11786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸಿ.ಕೆ. ರಾಮ ಮೂರ್ತಿ"
+    "NameKN": "ಸಿ ಕೆ ರಾಮ ಮೂರ್ತಿ",
+    "cellRef": "A787"
   },
   {
     "Department": "election_ac",
@@ -11015,7 +11801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎ. ಬಸವರಾಜ"
+    "NameKN": "ಬಿಎ ಬಸವರಾಜ",
+    "cellRef": "A788"
   },
   {
     "Department": "election_ac",
@@ -11029,7 +11816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಡಿ.ಕೆ. ಶಿವಕುಮಾರ್"
+    "NameKN": "ಡಿಕೆ ಶಿವಕುಮಾರ್",
+    "cellRef": "A789"
   },
   {
     "Department": "election_ac",
@@ -11043,7 +11831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A790"
   },
   {
     "Department": "election_ac",
@@ -11057,7 +11846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಚಿನ್ನದ ಕ್ಷೇತ್ರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A791"
   },
   {
     "Department": "election_ac",
@@ -11071,7 +11861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A792"
   },
   {
     "Department": "election_ac",
@@ -11085,7 +11876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಜಿ. ಪರಮೇಶ್ವರ"
+    "NameKN": "ಜಿ ಪರಮೇಶ್ವರ",
+    "cellRef": "A793"
   },
   {
     "Department": "election_ac",
@@ -11099,7 +11891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A794"
   },
   {
     "Department": "election_ac",
@@ -11113,7 +11906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A795"
   },
   {
     "Department": "election_ac",
@@ -11127,7 +11921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A796"
   },
   {
     "Department": "election_ac",
@@ -11141,7 +11936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಚ್.ಸಿ ಬಾಲಕೃಷ್ಣ"
+    "NameKN": "ಎಚ್ ಸಿ ಬಾಲಕೃಷ್ಣ",
+    "cellRef": "A797"
   },
   {
     "Department": "election_ac",
@@ -11155,7 +11951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮಂಜುಳಾ ಎಸ್"
+    "NameKN": "ಮಂಜುಳಾ ಎಸ್",
+    "cellRef": "A798"
   },
   {
     "Department": "election_ac",
@@ -11169,7 +11966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ"
+    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ",
+    "cellRef": "A799"
   },
   {
     "Department": "election_ac",
@@ -11183,7 +11981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A800"
   },
   {
     "Department": "election_ac",
@@ -11197,7 +11996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "MLA",
-    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿ.ಎನ್"
+    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿಎನ್",
+    "cellRef": "A801"
   },
   {
     "Department": "election_ac",
@@ -11211,7 +12011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಎನ್. ನಂಜೇಗೌಡ"
+    "NameKN": "ಕೆ.ಎನ್.ನಂಜೇಗೌಡ",
+    "cellRef": "A802"
   },
   {
     "Department": "election_ac",
@@ -11225,7 +12026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A803"
   },
   {
     "Department": "election_ac",
@@ -11239,7 +12041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A804"
   },
   {
     "Department": "election_ac",
@@ -11253,7 +12056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A805"
   },
   {
     "Department": "election_ac",
@@ -11267,7 +12071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್",
+    "cellRef": "A806"
   },
   {
     "Department": "election_ac",
@@ -11281,7 +12086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪದ್ಮನಾಬನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಆರ್. ಅಶೋಕ"
+    "NameKN": "ಆರ್ ಅಶೋಕ",
+    "cellRef": "A807"
   },
   {
     "Department": "election_ac",
@@ -11295,7 +12101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A808"
   },
   {
     "Department": "election_ac",
@@ -11309,7 +12116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎ.ಸಿ. ಶ್ರೀನಿವಾಸ"
+    "NameKN": "ಎಸಿ ಶ್ರೀನಿವಾಸ",
+    "cellRef": "A809"
   },
   {
     "Department": "election_ac",
@@ -11323,7 +12131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಸುರೇಶ್ ಕುಮಾರ್"
+    "NameKN": "ಎಸ್ ಸುರೇಶ್ ಕುಮಾರ್",
+    "cellRef": "A810"
   },
   {
     "Department": "election_ac",
@@ -11337,7 +12146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮುನಿರತ್ನ"
+    "NameKN": "ಮುನಿರತ್ನ",
+    "cellRef": "A811"
   },
   {
     "Department": "election_ac",
@@ -11351,7 +12161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "H.A. ಇಕ್ಬಾಲ್ ಹುಸೇನ್"
+    "NameKN": "HA ಇಕ್ಬಾಲ್ ಹುಸೇನ್",
+    "cellRef": "A812"
   },
   {
     "Department": "election_ac",
@@ -11365,7 +12176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ವಜ್ಞನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಜೆ. ಜಾರ್ಜ್"
+    "NameKN": "ಕೆಜೆ ಜಾರ್ಜ್",
+    "cellRef": "A813"
   },
   {
     "Department": "election_ac",
@@ -11379,7 +12191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎನ್.ಎ. ಹರಿಸ್"
+    "NameKN": "ಎನ್ಎ ಹರಿಸ್",
+    "cellRef": "A814"
   },
   {
     "Department": "election_ac",
@@ -11393,7 +12206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್"
+    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್",
+    "cellRef": "A815"
   },
   {
     "Department": "election_ac",
@@ -11407,7 +12221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎನ್. ರವಿಕುಮಾರ್"
+    "NameKN": "ಬಿಎನ್ ರವಿಕುಮಾರ್",
+    "cellRef": "A816"
   },
   {
     "Department": "election_ac",
@@ -11421,7 +12236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A817"
   },
   {
     "Department": "election_ac",
@@ -11435,7 +12251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A818"
   },
   {
     "Department": "election_ac",
@@ -11449,7 +12266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A819"
   },
   {
     "Department": "election_ac",
@@ -11463,7 +12281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A820"
   },
   {
     "Department": "election_ac",
@@ -11477,7 +12296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಸುರೇಶ್ ಗೌಡ"
+    "NameKN": "ಬಿ ಸುರೇಶ್ ಗೌಡ",
+    "cellRef": "A821"
   },
   {
     "Department": "election_ac",
@@ -11491,7 +12311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
+    "NameKN": "ಎಂ ಕೃಷ್ಣಪ್ಪ",
+    "cellRef": "A822"
   },
   {
     "Department": "election_ac",
@@ -11505,7 +12326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಆರ್ ವಿಶ್ವನಾಥ್"
+    "NameKN": "ಎಸ್ ಆರ್ ವಿಶ್ವನಾಥ್",
+    "cellRef": "A823"
   },
   {
     "Department": "election_ac",
@@ -11519,7 +12341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಟಿ. ಸೋಮಶೇಖರ್"
+    "NameKN": "ಎಸ್ ಟಿ ಸೋಮಶೇಖರ್",
+    "cellRef": "A824"
   },
   {
     "Department": "election_pc",
@@ -11533,7 +12356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಕೇಂದ್ರ",
     "DesignationKN": "MP",
-    "NameKN": "ಪಿ.ಸಿ. ಮೋಹನ್"
+    "NameKN": "ಪಿಸಿ ಮೋಹನ್",
+    "cellRef": "A825"
   },
   {
     "Department": "election_pc",
@@ -11547,7 +12371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
+    "cellRef": "A826"
   },
   {
     "Department": "election_pc",
@@ -11561,7 +12386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಸಿ. ಎನ್. ಮಂಜುನಾಥ್"
+    "NameKN": "ಸಿ ಎನ್ ಮಂಜುನಾಥ್",
+    "cellRef": "A827"
   },
   {
     "Department": "election_pc",
@@ -11575,7 +12401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MP",
-    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ"
+    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ",
+    "cellRef": "A828"
   },
   {
     "Department": "election_pc",
@@ -11589,7 +12416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A829"
   },
   {
     "Department": "election_pc",
@@ -11603,7 +12431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MP",
-    "NameKN": "ಕೆ. ಸುಧಾಕರ್"
+    "NameKN": "ಕೆ ಸುಧಾಕರ್",
+    "cellRef": "A830"
   },
   {
     "Department": "election_pc",
@@ -11617,7 +12446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A831"
   },
   {
     "Department": "election_pc",
@@ -11631,7 +12461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "MP",
-    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ. ಬಾಬು"
+    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ ಬಾಬು",
+    "cellRef": "A832"
   },
   {
     "Department": "election_pc",
@@ -11645,7 +12476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A833"
   },
   {
     "Department": "election_pc",
@@ -11659,7 +12491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "MP",
-    "NameKN": "ವಿ. ಸೋಮಣ್ಣ"
+    "NameKN": "ವಿ ಸೋಮಣ್ಣ",
+    "cellRef": "A834"
   },
   {
     "Department": "Pin Code",
@@ -11673,7 +12506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಚಿತ್ನಗರ - 560107",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A835"
   },
   {
     "Department": "Pin Code",
@@ -11687,7 +12521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ - 560030",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A836"
   },
   {
     "Department": "Pin Code",
@@ -11701,7 +12536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಎಫ್ ಸ್ಟೇಷನ್ ಯಲಹಂಕ - 560063",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A837"
   },
   {
     "Department": "Pin Code",
@@ -11715,7 +12551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ರಾಮ್ - 560007",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A838"
   },
   {
     "Department": "Pin Code",
@@ -11729,7 +12566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ - 562106",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A839"
   },
   {
     "Department": "Pin Code",
@@ -11743,7 +12581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಂಜನಾಪುರ - 560108",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A840"
   },
   {
     "Department": "Pin Code",
@@ -11757,7 +12596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಪಿಎಂಸಿ ಯಾರ್ಡ್ ಬಂಗಾರಪೇಟೆ - 563114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A841"
   },
   {
     "Department": "Pin Code",
@@ -11771,7 +12611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ - 562107",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A842"
   },
   {
     "Department": "Pin Code",
@@ -11785,7 +12626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಸ್ಟಿನ್ ಟೌನ್ - 560047",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A843"
   },
   {
     "Department": "Pin Code",
@@ -11799,7 +12641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವತಿ ಅಂಚೆ ಕಛೇರಿ - 562164",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A844"
   },
   {
     "Department": "Pin Code",
@@ -11813,7 +12656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಬೆಂಗಳೂರು) - 562149",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A845"
   },
   {
     "Department": "Pin Code",
@@ -11827,7 +12671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಕೃಷ್ಣಗಿರಿ) - 635103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A846"
   },
   {
     "Department": "Pin Code",
@@ -11841,7 +12686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ - 560050",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A847"
   },
   {
     "Department": "Pin Code",
@@ -11855,7 +12701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು GPO - 560001",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A848"
   },
   {
     "Department": "Pin Code",
@@ -11869,7 +12716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ - 560300",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A849"
   },
   {
     "Department": "Pin Code",
@@ -11883,7 +12731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ವಿಶ್ವವಿದ್ಯಾಲಯ - 560056",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A850"
   },
   {
     "Department": "Pin Code",
@@ -11897,7 +12746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೇರುಘಟ್ಟ - 560083",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A851"
   },
   {
     "Department": "Pin Code",
@@ -11911,7 +12761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ - 560004",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A852"
   },
   {
     "Department": "Pin Code",
@@ -11925,7 +12776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಟ್ಲಹಳ್ಳಿ - 563123",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A853"
   },
   {
     "Department": "Pin Code",
@@ -11939,7 +12791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು - 560114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A854"
   },
   {
     "Department": "Pin Code",
@@ -11953,7 +12806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳತ್ತೂರು - 635124",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A855"
   },
   {
     "Department": "Pin Code",
@@ -11967,7 +12821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು - 560103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A856"
   },
   {
     "Department": "Pin Code",
@@ -11981,7 +12836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆನ್ಸನ್ ಟೌನ್ - 560046",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A857"
   },
   {
     "Department": "Pin Code",
@@ -11995,7 +12851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆರಿಗೈ - 635105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A858"
   },
   {
     "Department": "Pin Code",
@@ -12009,7 +12866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟಹಲಸೂರು - 562157",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A859"
   },
   {
     "Department": "Pin Code",
@@ -12023,7 +12881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇವೂರು (ರಾಮನಗರ) - 562108",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A860"
   },
   {
     "Department": "Pin Code",
@@ -12037,7 +12896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತನಗರ - 563115",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A861"
   },
   {
     "Department": "Pin Code",
@@ -12051,7 +12911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ - 562109",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A862"
   },
   {
     "Department": "Pin Code",
@@ -12065,7 +12926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೋಲಾರೆ - 560116",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A863"
   },
   {
     "Department": "Pin Code",
@@ -12079,7 +12941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ (ಬೆಂಗಳೂರು) - 560068",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A864"
   },
   {
     "Department": "Pin Code",
@@ -12093,7 +12956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮಸಂದ್ರ ಇಂಡಸ್ಟ್ರಿಯಲ್ ಎಸ್ಟೇಟ್ - 560099",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A865"
   },
   {
     "Department": "Pin Code",
@@ -12107,7 +12971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೂದಿಕೋಟೆ - 563147",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A866"
   },
   {
     "Department": "Pin Code",
@@ -12121,7 +12986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬುರುಡುಗುಂಟೆ - 563159",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A867"
   },
   {
     "Department": "Pin Code",
@@ -12135,7 +13001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಮೆಲರಾಮ್ - 560035",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A868"
   },
   {
     "Department": "Pin Code",
@@ -12149,7 +13016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ರೀಫ್ಸ್ - 563117",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A869"
   },
   {
     "Department": "Pin Code",
@@ -12163,7 +13031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ (ಬೆಂಗಳೂರು) - 560018",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A870"
   },
   {
     "Department": "Pin Code",
@@ -12177,7 +13046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ - 560081",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A871"
   },
   {
     "Department": "Pin Code",
@@ -12191,7 +13061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ - 562160",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A872"
   },
   {
     "Department": "Pin Code",
@@ -12205,7 +13076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ - 562101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A873"
   },
   {
     "Department": "Pin Code",
@@ -12219,7 +13091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ - 560053",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A874"
   },
   {
     "Department": "Pin Code",
@@ -12233,7 +13106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ - 560090",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A875"
   },
   {
     "Department": "Pin Code",
@@ -12247,7 +13121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಸಂದ್ರ - 560061",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A876"
   },
   {
     "Department": "Pin Code",
@@ -12261,7 +13136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಮಾರುಕಟ್ಟೆ - 563125",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A877"
   },
   {
     "Department": "Pin Code",
@@ -12275,7 +13151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "CPC ಆದಾಯ ತೆರಿಗೆ ಇಲಾಖೆ - 560500",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A878"
   },
   {
     "Department": "Pin Code",
@@ -12289,7 +13166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿವಿ ರಾಮನ್ ನಗರ - 560093",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A879"
   },
   {
     "Department": "Pin Code",
@@ -12303,7 +13181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಲಸನೂರು - 563126",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A880"
   },
   {
     "Department": "Pin Code",
@@ -12317,7 +13196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇಶಿಹಳ್ಳಿ ಬಂಗಾರಪೇಟೆ - 563162",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A881"
   },
   {
     "Department": "Pin Code",
@@ -12331,7 +13211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ - 562110",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A882"
   },
   {
     "Department": "Pin Code",
@@ -12345,7 +13226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸ್ಪೇಟ್ - 562111",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A883"
   },
   {
     "Department": "Pin Code",
@@ -12359,7 +13241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಬಜಾರ್ - 561203",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A884"
   },
   {
     "Department": "Pin Code",
@@ -12373,7 +13256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ - 561204",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A885"
   },
   {
     "Department": "Pin Code",
@@ -12387,7 +13271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡದುನ್ನಸಂದ್ರ - 560117",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A886"
   },
   {
     "Department": "Pin Code",
@@ -12401,7 +13286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A887"
   },
   {
     "Department": "Pin Code",
@@ -12415,7 +13301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A888"
   },
   {
     "Department": "Pin Code",
@@ -12429,7 +13316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು - 560071",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A889"
   },
   {
     "Department": "Pin Code",
@@ -12443,7 +13331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "EPIP - 560066",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A890"
   },
   {
     "Department": "Pin Code",
@@ -12457,7 +13346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಸರ್ ಟೌನ್ - 560005",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A891"
   },
   {
     "Department": "Pin Code",
@@ -12471,7 +13361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗವಿಪುರಂ ವಿಸ್ತರಣೆ - 560019",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A892"
   },
   {
     "Department": "Pin Code",
@@ -12485,7 +13376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಯತ್ರಿನಗರ - 560021",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A893"
   },
   {
     "Department": "Pin Code",
@@ -12499,7 +13391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "GCEC ರಾಮನಗರ - 562159",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A894"
   },
   {
     "Department": "Pin Code",
@@ -12513,7 +13406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ (ಬೆಂಗಳೂರು) - 560085",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A895"
   },
   {
     "Department": "Pin Code",
@@ -12527,7 +13421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "GKVK - 560065",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A896"
   },
   {
     "Department": "Pin Code",
@@ -12541,7 +13436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ಎಲೆಕ್ಟ್ರಿಕ್ ಫ್ಯಾಕ್ಟರಿ - 560026",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A897"
   },
   {
     "Department": "Pin Code",
@@ -12555,7 +13451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ರೇಷ್ಮೆ ಫಾರ್ಮ್ - 562161",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A898"
   },
   {
     "Department": "Pin Code",
@@ -12569,7 +13466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಿಪಲ್ಲಿ - 563161",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A899"
   },
   {
     "Department": "Pin Code",
@@ -12583,7 +13481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೂಳೂರು - 572118",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A900"
   },
   {
     "Department": "Pin Code",
@@ -12597,7 +13496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HA ಫಾರ್ಮ್ - 560024",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A901"
   },
   {
     "Department": "Pin Code",
@@ -12611,7 +13511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL II ಹಂತ - 560008",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A902"
   },
   {
     "Department": "Pin Code",
@@ -12625,7 +13526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಂಪಿನಗರ - 560104",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A903"
   },
   {
     "Department": "Pin Code",
@@ -12639,7 +13541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ - 562112",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A904"
   },
   {
     "Department": "Pin Code",
@@ -12653,7 +13556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು - 572120",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A905"
   },
   {
     "Department": "Pin Code",
@@ -12667,7 +13571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೇರೋಹಳ್ಳಿ - 560091",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A906"
   },
   {
     "Department": "Pin Code",
@@ -12681,7 +13586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ - 560088",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A907"
   },
   {
     "Department": "Pin Code",
@@ -12695,7 +13601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸ್ಸರಘಟ್ಟ ಕೆರೆ - 560089",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A908"
   },
   {
     "Department": "Pin Code",
@@ -12709,7 +13616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಹಳ್ಳಿ SO - 572168",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A909"
   },
   {
     "Department": "Pin Code",
@@ -12723,7 +13631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HKP ರಸ್ತೆ - 560051",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A910"
   },
   {
     "Department": "Pin Code",
@@ -12737,7 +13646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳವನಹಳ್ಳಿ - 572121",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A911"
   },
   {
     "Department": "Pin Code",
@@ -12751,7 +13661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಗನೂರು - 562138",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A912"
   },
   {
     "Department": "Pin Code",
@@ -12765,7 +13676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನುಡಿಕೆ - 572122",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A913"
   },
   {
     "Department": "Pin Code",
@@ -12779,7 +13691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊರಮಾವು - 560113",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A914"
   },
   {
     "Department": "Pin Code",
@@ -12793,7 +13706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ - 562114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A915"
   },
   {
     "Department": "Pin Code",
@@ -12807,7 +13721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು - 561210",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A916"
   },
   {
     "Department": "Pin Code",
@@ -12821,7 +13736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಗೋಶಾಲೆ - 635110",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A917"
   },
   {
     "Department": "Pin Code",
@@ -12835,7 +13751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಇಂಡಲ್. ಸಂಕೀರ್ಣ - 635126",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A918"
   },
   {
     "Department": "Pin Code",
@@ -12849,7 +13766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್ - 560102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A919"
   },
   {
     "Department": "Pin Code",
@@ -12863,7 +13781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರು ದುರ್ಗ - 572123",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A920"
   },
   {
     "Department": "Pin Code",
@@ -12877,7 +13796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ (ಬೆಂಗಳೂರು) - 560038",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A921"
   },
   {
     "Department": "Pin Code",
@@ -12891,7 +13811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ - 560013",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A922"
   },
   {
     "Department": "Pin Code",
@@ -12905,7 +13826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪೂರ್ವ - 560014",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A923"
   },
   {
     "Department": "Pin Code",
@@ -12919,7 +13841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಶ್ಚಿಮ - 560015",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A924"
   },
   {
     "Department": "Pin Code",
@@ -12933,7 +13856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ - 560041",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A925"
   },
   {
     "Department": "Pin Code",
@@ -12947,7 +13871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪೂರ್ವ - 560069",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A926"
   },
   {
     "Department": "Pin Code",
@@ -12961,7 +13886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಎಕ್ಸ್ಟೆನ್ ತುಮಕೂರು - 572102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A927"
   },
   {
     "Department": "Pin Code",
@@ -12975,7 +13901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಶ್ಚಿಮ - 560070",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A928"
   },
   {
     "Department": "Pin Code",
@@ -12989,7 +13916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಂಗಾರ್ III ಬ್ಲಾಕ್ - 560011",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A929"
   },
   {
     "Department": "Pin Code",
@@ -13003,7 +13931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ - 560105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A930"
   },
   {
     "Department": "Pin Code",
@@ -13017,7 +13946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ - 560078",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A931"
   },
   {
     "Department": "Pin Code",
@@ -13031,7 +13961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ವಿಸ್ತರಣೆ ಸೋ - 560067",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A932"
   },
   {
     "Department": "Pin Code",
@@ -13045,7 +13976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೈವಾರ - 563128",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A933"
   },
   {
     "Department": "Pin Code",
@@ -13059,7 +13991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಯಾಣನಗರ - 560043",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A934"
   },
   {
     "Department": "Pin Code",
@@ -13073,7 +14006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ - 563129",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A935"
   },
   {
     "Department": "Pin Code",
@@ -13087,7 +14021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ - 562117",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A936"
   },
   {
     "Department": "Pin Code",
@@ -13101,7 +14036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ನಮಂಗಲ - 560115",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A937"
   },
   {
     "Department": "Pin Code",
@@ -13115,7 +14051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪನಹಳ್ಳಿ - 572126",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A938"
   },
   {
     "Department": "Pin Code",
@@ -13129,7 +14066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ - 560060",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A939"
   },
   {
     "Department": "Pin Code",
@@ -13143,7 +14081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ರಸ್ತೆ - 560009",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A940"
   },
   {
     "Department": "Pin Code",
@@ -13157,7 +14096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "KHB ಕಾಲೋನಿ - 560079",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A941"
   },
   {
     "Department": "Pin Code",
@@ -13171,7 +14111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡೇಹಳ್ಳಿ - 560112",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A942"
   },
   {
     "Department": "Pin Code",
@@ -13185,7 +14126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ - 562119",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A943"
   },
   {
     "Department": "Pin Code",
@@ -13199,7 +14141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ - 563101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A944"
   },
   {
     "Department": "Pin Code",
@@ -13213,7 +14156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ವಿಸ್ತರಣೆ - 563102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A945"
   },
   {
     "Department": "Pin Code",
@@ -13227,7 +14171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರ (ತುಮಕೂರು) - 572128",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A946"
   },
   {
     "Department": "Pin Code",
@@ -13241,7 +14186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ I ಬ್ಲಾಕ್ - 560034",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A947"
   },
   {
     "Department": "Pin Code",
@@ -13255,7 +14201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ VI ಬ್ಲಾಕ್ - 560095",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A948"
   },
   {
     "Department": "Pin Code",
@@ -13269,7 +14216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ - 572129",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A949"
   },
   {
     "Department": "Pin Code",
@@ -13283,7 +14231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು - 560077",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A950"
   },
   {
     "Department": "Pin Code",
@@ -13297,7 +14246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ - 560036",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A951"
   },
   {
     "Department": "Pin Code",
@@ -13311,7 +14261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ ಆರ್ ಎಸ್ - 560016",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A952"
   },
   {
     "Department": "Pin Code",
@@ -13325,7 +14276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು - 561101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A953"
   },
   {
     "Department": "Pin Code",
@@ -13339,7 +14291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ - 560111",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A954"
   },
   {
     "Department": "Pin Code",
@@ -13353,7 +14306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೋಡು - 560074",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A955"
   },
   {
     "Department": "Pin Code",
@@ -13367,7 +14321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಪ್ಪಂ - 517425",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A956"
   },
   {
     "Department": "Pin Code",
@@ -13381,7 +14336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುವೆಂಪುನಗರ - 572103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A957"
   },
   {
     "Department": "Pin Code",
@@ -13395,7 +14351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸಂದ್ರ - 572104",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A958"
   },
   {
     "Department": "Pin Code",
@@ -13409,7 +14366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ - 562162",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A959"
   },
   {
     "Department": "Pin Code",
@@ -13423,7 +14381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ - 562120",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A960"
   },
   {
     "Department": "Pin Code",
@@ -13437,7 +14396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ - 560023",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A961"
   },
   {
     "Department": "Pin Code",
@@ -13451,7 +14411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ - 560048",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A962"
   },
   {
     "Department": "Pin Code",
@@ -13465,7 +14426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ - 560003",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A963"
   },
   {
     "Department": "Pin Code",
@@ -13479,7 +14441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು - 563130",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A964"
   },
   {
     "Department": "Pin Code",
@@ -13493,7 +14456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ರೈಲು ನಿಲ್ದಾಣ - 563160",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A965"
   },
   {
     "Department": "Pin Code",
@@ -13507,7 +14471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೆನಹಳ್ಳಿ - 561211",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A966"
   },
   {
     "Department": "Pin Code",
@@ -13521,7 +14486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳವಾಡಿ - 562121",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A967"
   },
   {
     "Department": "Pin Code",
@@ -13535,7 +14501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳೂರು ಎಸ್‌ಒ - 572105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A968"
   },
   {
     "Department": "Pin Code",
@@ -13549,7 +14516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಸೇವಾನಗರ - 560033",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A969"
   },
   {
     "Department": "Pin Code",
@@ -13563,7 +14531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ - 563139",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A970"
   },
   {
     "Department": "Pin Code",
@@ -13577,7 +14546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಠಗೊಂಡಪಲ್ಲಿ - 635114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A971"
   },
   {
     "Department": "Pin Code",
@@ -13591,7 +14561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಳೆಕೋಟೆ - 561205",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A972"
   },
   {
     "Department": "Pin Code",
@@ -13605,7 +14576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೇಲೂರು (ಕೋಲಾರ) - 562102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A973"
   },
   {
     "Department": "Pin Code",
@@ -13619,7 +14591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ - 560076",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A974"
   },
   {
     "Department": "Pin Code",
@@ -13633,7 +14606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿಲ್ಕ್ ಕಾಲೋನಿ - 560055",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A975"
   },
   {
     "Department": "Pin Code",
@@ -13647,7 +14621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MSRIT - 560054",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A976"
   },
   {
     "Department": "Pin Code",
@@ -13661,7 +14636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರುಗಮಲೆ - 563146",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A977"
   },
   {
     "Department": "Pin Code",
@@ -13675,7 +14651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮ್ಯೂಸಿಯಂ ರಸ್ತೆ - 560025",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A978"
   },
   {
     "Department": "Pin Code",
@@ -13689,7 +14666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇನಹಳ್ಳಿ - 562163",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A979"
   },
   {
     "Department": "Pin Code",
@@ -13703,7 +14681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ - 560072",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A980"
   },
   {
     "Department": "Pin Code",
@@ -13717,7 +14696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಸಂದ್ರ (ಬೆಂಗಳೂರು) - 560073",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A981"
   },
   {
     "Department": "Pin Code",
@@ -13731,7 +14711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "NAL - 560017",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A982"
   },
   {
     "Department": "Pin Code",
@@ -13745,7 +14726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ - 562122",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A983"
   },
   {
     "Department": "Pin Code",
@@ -13759,7 +14741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ (ಕೋಲಾರ) - 562103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A984"
   },
   {
     "Department": "Pin Code",
@@ -13773,7 +14756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಣನ್ದಿನಿ ಳಯೋಉತ್ - ೫೬೦೦೯೬",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A985"
   },
   {
     "Department": "Pin Code",
@@ -13787,7 +14771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ - 563133",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A986"
   },
   {
     "Department": "Pin Code",
@@ -13801,7 +14786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಯಂಡಹಳ್ಳಿ - 560039",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A987"
   },
   {
     "Department": "Pin Code",
@@ -13815,7 +14801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ - 562123",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A988"
   },
   {
     "Department": "Pin Code",
@@ -13829,7 +14816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ತಿಪ್ಪಸಂದ್ರ - 560075",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A989"
   },
   {
     "Department": "Pin Code",
@@ -13843,7 +14831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಡಘಟ್ಟ - 571433",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A990"
   },
   {
     "Department": "Pin Code",
@@ -13857,7 +14846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ ವಿಸ್ತರಣೆ - 572106",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A991"
   },
   {
     "Department": "Pin Code",
@@ -13871,7 +14861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಮ್ - 563120",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A992"
   },
   {
     "Department": "Pin Code",
@@ -13885,7 +14876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ - 560057",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A993"
   },
   {
     "Department": "Pin Code",
@@ -13899,7 +14891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಸಣ್ಣ ಕೈಗಾರಿಕೆಗಳು - 560058",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A994"
   },
   {
     "Department": "Pin Code",
@@ -13913,7 +14906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೆರೇಸಂದ್ರ - 562104",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A995"
   },
   {
     "Department": "Pin Code",
@@ -13927,7 +14921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ - 560010",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A996"
   },
   {
     "Department": "Pin Code",
@@ -13941,7 +14936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ - 560098",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A997"
   },
   {
     "Department": "Pin Code",
@@ -13955,7 +14951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಮೇಶ್‌ನಗರ - 560037",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A998"
   },
   {
     "Department": "Pin Code",
@@ -13969,7 +14966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "RMV ವಿಸ್ತರಣೆ II ಹಂತ - 560094",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A999"
   },
   {
     "Department": "Pin Code",
@@ -13983,7 +14981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ - 560032",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1000"
   },
   {
     "Department": "Pin Code",
@@ -13997,7 +14996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "RV ನಿಕೇತನ್ - 560059",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1001"
   },
   {
     "Department": "Pin Code",
@@ -14011,7 +15011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ - 560080",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1002"
   },
   {
     "Department": "Pin Code",
@@ -14025,7 +15026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರನಗರ PO - 560092",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1003"
   },
   {
     "Department": "Pin Code",
@@ -14039,7 +15041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ - 562125",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1004"
   },
   {
     "Department": "Pin Code",
@@ -14053,7 +15056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ಸಂಸ್ಥೆ - 560012",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1005"
   },
   {
     "Department": "Pin Code",
@@ -14067,7 +15071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ - 560020",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1006"
   },
   {
     "Department": "Pin Code",
@@ -14081,7 +15086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ - 560027",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1007"
   },
   {
     "Department": "Pin Code",
@@ -14095,7 +15101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಗಟ್ಟಾ ಬಜಾರ್ - 562105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1008"
   },
   {
     "Department": "Pin Code",
@@ -14109,7 +15116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವನ್ ಚೆಟ್ಟಿ ಗಾರ್ಡನ್ಸ್ - 560042",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1009"
   },
   {
     "Department": "Pin Code",
@@ -14123,7 +15131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲೂರು - 562127",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1010"
   },
   {
     "Department": "Pin Code",
@@ -14137,7 +15146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀ ಜಯಚಾಮರಾಜೇಂದ್ರ ರಸ್ತೆ - 560002",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1011"
   },
   {
     "Department": "Pin Code",
@@ -14151,7 +15161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ - 563135",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1012"
   },
   {
     "Department": "Pin Code",
@@ -14165,7 +15176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಂಟ್ ಥಾಮಸ್ ಟೌನ್ - 560084",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1013"
   },
   {
     "Department": "Pin Code",
@@ -14179,7 +15191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗ್ಗನಹಳ್ಳಿ - 562128",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1014"
   },
   {
     "Department": "Pin Code",
@@ -14193,7 +15206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲೇಬೆಲೆ - 562129",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1015"
   },
   {
     "Department": "Pin Code",
@@ -14207,7 +15221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಮಾಕಾ - 563103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1016"
   },
   {
     "Department": "Pin Code",
@@ -14221,7 +15236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ - 560029",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1017"
   },
   {
     "Department": "Pin Code",
@@ -14235,7 +15251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ (ಬೆಂಗಳೂರು) - 562130",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1018"
   },
   {
     "Department": "Pin Code",
@@ -14249,7 +15266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ - 563137",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1019"
   },
   {
     "Department": "Pin Code",
@@ -14263,7 +15281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ - 560109",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1020"
   },
   {
     "Department": "Pin Code",
@@ -14277,7 +15296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಥಾಲಿ - 635118",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1021"
   },
   {
     "Department": "Pin Code",
@@ -14291,7 +15311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪ್ಪಸಂದ್ರ - 562131",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1022"
   },
   {
     "Department": "Pin Code",
@@ -14305,7 +15326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೊಂಡೇಭಾವಿ - 561213",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1023"
   },
   {
     "Department": "Pin Code",
@@ -14319,7 +15341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೋವಿನಕೆರೆ - 572138",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1024"
   },
   {
     "Department": "Pin Code",
@@ -14333,7 +15356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರಬೇತಿ ಕಮಾಂಡ್ IAF - 560006",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1025"
   },
   {
     "Department": "Pin Code",
@@ -14347,7 +15371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು - 572101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1026"
   },
   {
     "Department": "Pin Code",
@@ -14361,7 +15386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು - 562132",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1027"
   },
   {
     "Department": "Pin Code",
@@ -14375,7 +15401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉದಯಪುರ - 560082",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1028"
   },
   {
     "Department": "Pin Code",
@@ -14389,7 +15416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಲ್ಲಾಳು ಉಪನಗರ - 560110",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1029"
   },
   {
     "Department": "Pin Code",
@@ -14403,7 +15431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಡಿಗೆರೆ - 572140",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1030"
   },
   {
     "Department": "Pin Code",
@@ -14417,7 +15446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು - 560087",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1031"
   },
   {
     "Department": "Pin Code",
@@ -14431,7 +15461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತ ನಗರ - 560052",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1032"
   },
   {
     "Department": "Pin Code",
@@ -14445,7 +15476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರೇಗೌಡನದೊಡ್ಡಿ - 561201",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1033"
   },
   {
     "Department": "Pin Code",
@@ -14459,7 +15491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ - 563157",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1034"
   },
   {
     "Department": "Pin Code",
@@ -14473,7 +15506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಂಕಟೇಶಪುರ - 560045",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1035"
   },
   {
     "Department": "Pin Code",
@@ -14487,7 +15521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಪ್ಪನಪಲ್ಲಿ - 635121",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1036"
   },
   {
     "Department": "Pin Code",
@@ -14501,7 +15536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ - 560097",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1037"
   },
   {
     "Department": "Pin Code",
@@ -14515,7 +15551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ (ಬೆಂಗಳೂರು) - 560040",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1038"
   },
   {
     "Department": "Pin Code",
@@ -14529,7 +15566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ - 562135",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1039"
   },
   {
     "Department": "Pin Code",
@@ -14543,7 +15581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ಯಾನಗರ - 560049",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1040"
   },
   {
     "Department": "Pin Code",
@@ -14557,7 +15596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಸ್ಟ್ ಆಫ್ ಕಾರ್ಡ್ ರೋಡ್ II ಹಂತ - 560086",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1041"
   },
   {
     "Department": "Pin Code",
@@ -14571,7 +15611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಪ್ರೋ ಲಿಮಿಟೆಡ್ - 560100",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1042"
   },
   {
     "Department": "Pin Code",
@@ -14585,7 +15626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್ - 560064",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1043"
   },
   {
     "Department": "Pin Code",
@@ -14599,7 +15641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಬಜಾರ್ - 560022",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1044"
   },
   {
     "Department": "stamps_dro",
@@ -14613,7 +15656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1045"
   },
   {
     "Department": "stamps_dro",
@@ -14627,7 +15671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ."
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ",
+    "cellRef": "A1046"
   },
   {
     "Department": "stamps_dro",
@@ -14641,7 +15686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ. ಬೆಳಗಲಿ"
+    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ ಬೆಳಗಲಿ",
+    "cellRef": "A1047"
   },
   {
     "Department": "stamps_dro",
@@ -14655,7 +15701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1048"
   },
   {
     "Department": "stamps_dro",
@@ -14669,7 +15716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1049"
   },
   {
     "Department": "stamps_dro",
@@ -14683,7 +15731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1050"
   },
   {
     "Department": "stamps_dro",
@@ -14697,7 +15746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1051"
   },
   {
     "Department": "stamps_dro",
@@ -14711,7 +15761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1052"
   },
   {
     "Department": "stamps_dro",
@@ -14725,7 +15776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ",
+    "cellRef": "A1053"
   },
   {
     "Department": "stamps_dro",
@@ -14739,7 +15791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1054"
   },
   {
     "Department": "stamps_dro",
@@ -14753,7 +15806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1055"
   },
   {
     "Department": "stamps_dro",
@@ -14767,7 +15821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1056"
   },
   {
     "Department": "stamps_dro",
@@ -14781,7 +15836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1057"
   },
   {
     "Department": "stamps_dro",
@@ -14795,7 +15851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1058"
   },
   {
     "Department": "stamps_dro",
@@ -14809,7 +15866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎ.ಎನ್. ಭಾರತಿ"
+    "NameKN": "ಎಎನ್ ಭಾರತಿ",
+    "cellRef": "A1059"
   },
   {
     "Department": "stamps_dro",
@@ -14823,7 +15881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1060"
   },
   {
     "Department": "stamps_dro",
@@ -14837,7 +15896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1061"
   },
   {
     "Department": "stamps_dro",
@@ -14851,7 +15911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ.ಎಚ್. ಶಂಕರೇಗೌಡ"
+    "NameKN": "ಬಿ.ಎಚ್.ಶಂಕರೇಗೌಡ",
+    "cellRef": "A1062"
   },
   {
     "Department": "stamps_dro",
@@ -14865,7 +15926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಬುರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1063"
   },
   {
     "Department": "stamps_dro",
@@ -14879,7 +15941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1064"
   },
   {
     "Department": "stamps_dro",
@@ -14893,7 +15956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಗು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1065"
   },
   {
     "Department": "stamps_dro",
@@ -14907,7 +15971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎನ್. ಶ್ರೀನಿಧಿ"
+    "NameKN": "ಎನ್ ಶ್ರೀನಿಧಿ",
+    "cellRef": "A1066"
   },
   {
     "Department": "stamps_dro",
@@ -14921,7 +15986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1067"
   },
   {
     "Department": "stamps_dro",
@@ -14935,7 +16001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1068"
   },
   {
     "Department": "stamps_dro",
@@ -14949,7 +16016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1069"
   },
   {
     "Department": "stamps_dro",
@@ -14963,7 +16031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1070"
   },
   {
     "Department": "stamps_dro",
@@ -14977,7 +16046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1071"
   },
   {
     "Department": "stamps_dro",
@@ -14991,7 +16061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್"
+    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್",
+    "cellRef": "A1072"
   },
   {
     "Department": "stamps_dro",
@@ -15005,7 +16076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಂ. ಶ್ರೀದೇವಿ"
+    "NameKN": "ಎಂ ಶ್ರೀದೇವಿ",
+    "cellRef": "A1073"
   },
   {
     "Department": "stamps_dro",
@@ -15019,7 +16091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1074"
   },
   {
     "Department": "stamps_dro",
@@ -15033,7 +16106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಸ್.ಬಿ. ದವಳೇಶ್ವರ"
+    "NameKN": "ಎಸ್.ಬಿ.ದವಳೇಶ್ವರ",
+    "cellRef": "A1075"
   },
   {
     "Department": "stamps_dro",
@@ -15047,7 +16121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ. ಶ್ರೀಕಾಂತ್"
+    "NameKN": "ಬಿ ಶ್ರೀಕಾಂತ್",
+    "cellRef": "A1076"
   },
   {
     "Department": "stamps_dro",
@@ -15061,7 +16136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1077"
   },
   {
     "Department": "stamps_dro",
@@ -15075,7 +16151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1078"
   },
   {
     "Department": "stamps_sro",
@@ -15089,7 +16166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಫಜಲಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1079"
   },
   {
     "Department": "stamps_sro",
@@ -15103,7 +16181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಳಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1080"
   },
   {
     "Department": "stamps_sro",
@@ -15117,7 +16196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1081"
   },
   {
     "Department": "stamps_sro",
@@ -15131,7 +16211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ"
+    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ",
+    "cellRef": "A1082"
   },
   {
     "Department": "stamps_sro",
@@ -15145,7 +16226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಣ್ಣಿಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1083"
   },
   {
     "Department": "stamps_sro",
@@ -15159,7 +16241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಕಲಗೂಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1084"
   },
   {
     "Department": "stamps_sro",
@@ -15173,7 +16256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಸೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1085"
   },
   {
     "Department": "stamps_sro",
@@ -15187,7 +16271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಥಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1086"
   },
   {
     "Department": "stamps_sro",
@@ -15201,7 +16286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ"
+    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ",
+    "cellRef": "A1087"
   },
   {
     "Department": "stamps_sro",
@@ -15215,7 +16301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಔರಾದ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1088"
   },
   {
     "Department": "stamps_sro",
@@ -15229,7 +16316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾದಾಮಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1089"
   },
   {
     "Department": "stamps_sro",
@@ -15243,7 +16331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1090"
   },
   {
     "Department": "stamps_sro",
@@ -15257,7 +16346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1091"
   },
   {
     "Department": "stamps_sro",
@@ -15271,7 +16361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಲಹೊಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1092"
   },
   {
     "Department": "stamps_sro",
@@ -15285,7 +16376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1093"
   },
   {
     "Department": "stamps_sro",
@@ -15299,7 +16391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್",
+    "cellRef": "A1094"
   },
   {
     "Department": "stamps_sro",
@@ -15313,7 +16406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ"
+    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ",
+    "cellRef": "A1095"
   },
   {
     "Department": "stamps_sro",
@@ -15327,7 +16421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1096"
   },
   {
     "Department": "stamps_sro",
@@ -15341,7 +16436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1097"
   },
   {
     "Department": "stamps_sro",
@@ -15355,7 +16451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಾವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1098"
   },
   {
     "Department": "stamps_sro",
@@ -15369,7 +16466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1099"
   },
   {
     "Department": "stamps_sro",
@@ -15383,7 +16481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1100"
   },
   {
     "Department": "stamps_sro",
@@ -15397,7 +16496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಟವಾಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1101"
   },
   {
     "Department": "stamps_sro",
@@ -15411,7 +16511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವಕಲ್ಯಾಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1102"
   },
   {
     "Department": "stamps_sro",
@@ -15425,7 +16526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಬಾಗೇವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1103"
   },
   {
     "Department": "stamps_sro",
@@ -15439,7 +16541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎ. ರಾಘವೇಂದ್ರ"
+    "NameKN": "ಎ ರಾಘವೇಂದ್ರ",
+    "cellRef": "A1104"
   },
   {
     "Department": "stamps_sro",
@@ -15453,7 +16556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್. ಕಟ್ಟಿಮನಿ"
+    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್ ಕಟ್ಟಿಮನಿ",
+    "cellRef": "A1105"
   },
   {
     "Department": "stamps_sro",
@@ -15467,7 +16571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1106"
   },
   {
     "Department": "stamps_sro",
@@ -15481,7 +16586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1107"
   },
   {
     "Department": "stamps_sro",
@@ -15495,7 +16601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1108"
   },
   {
     "Department": "stamps_sro",
@@ -15509,7 +16616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ತಂಗಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1109"
   },
   {
     "Department": "stamps_sro",
@@ -15523,7 +16631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1110"
   },
   {
     "Department": "stamps_sro",
@@ -15537,7 +16646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟದಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1111"
   },
   {
     "Department": "stamps_sro",
@@ -15551,7 +16661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭದ್ರಾವತಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1112"
   },
   {
     "Department": "stamps_sro",
@@ -15565,7 +16676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1113"
   },
   {
     "Department": "stamps_sro",
@@ -15579,7 +16691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಟ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1114"
   },
   {
     "Department": "stamps_sro",
@@ -15593,7 +16706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1115"
   },
   {
     "Department": "stamps_sro",
@@ -15607,7 +16721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿದರಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್"
+    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್",
+    "cellRef": "A1116"
   },
   {
     "Department": "stamps_sro",
@@ -15621,7 +16736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1117"
   },
   {
     "Department": "stamps_sro",
@@ -15635,7 +16751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಳಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1118"
   },
   {
     "Department": "stamps_sro",
@@ -15649,7 +16766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಸನ್ನ ಜಿ"
+    "NameKN": "ಪ್ರಸನ್ನ ಜಿ",
+    "cellRef": "A1119"
   },
   {
     "Department": "stamps_sro",
@@ -15663,7 +16781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ರಹ್ಮಾವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1120"
   },
   {
     "Department": "stamps_sro",
@@ -15677,7 +16796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM ಲೇಔಟ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಾವ್ಯ ಕೆ. ಕೋರ"
+    "NameKN": "ಕಾವ್ಯ ಕೆ ಕೋರ",
+    "cellRef": "A1121"
   },
   {
     "Department": "stamps_sro",
@@ -15691,7 +16811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1122"
   },
   {
     "Department": "stamps_sro",
@@ -15705,7 +16826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ.ವಿ. ರವಿಕುಮಾರ್"
+    "NameKN": "ಕೆ ವಿ ರವಿಕುಮಾರ್",
+    "cellRef": "A1123"
   },
   {
     "Department": "stamps_sro",
@@ -15719,7 +16841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1124"
   },
   {
     "Department": "stamps_sro",
@@ -15733,7 +16856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1125"
   },
   {
     "Department": "stamps_sro",
@@ -15747,7 +16871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಉಮಾದೇವಿ ಎ.ಎಸ್"
+    "NameKN": "ಉಮಾದೇವಿ ಎಎಸ್",
+    "cellRef": "A1126"
   },
   {
     "Department": "stamps_sro",
@@ -15761,7 +16886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1127"
   },
   {
     "Department": "stamps_sro",
@@ -15775,7 +16901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1128"
   },
   {
     "Department": "stamps_sro",
@@ -15789,7 +16916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1129"
   },
   {
     "Department": "stamps_sro",
@@ -15803,7 +16931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1130"
   },
   {
     "Department": "stamps_sro",
@@ -15817,7 +16946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1131"
   },
   {
     "Department": "stamps_sro",
@@ -15831,7 +16961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1132"
   },
   {
     "Department": "stamps_sro",
@@ -15845,7 +16976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕೋಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1133"
   },
   {
     "Department": "stamps_sro",
@@ -15859,7 +16991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂಚೋಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1134"
   },
   {
     "Department": "stamps_sro",
@@ -15873,7 +17006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1135"
   },
   {
     "Department": "stamps_sro",
@@ -15887,7 +17021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1136"
   },
   {
     "Department": "stamps_sro",
@@ -15901,7 +17036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ತಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1137"
   },
   {
     "Department": "stamps_sro",
@@ -15915,7 +17051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸನಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ"
+    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ",
+    "cellRef": "A1138"
   },
   {
     "Department": "stamps_sro",
@@ -15929,7 +17066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1139"
   },
   {
     "Department": "stamps_sro",
@@ -15943,7 +17081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1140"
   },
   {
     "Department": "stamps_sro",
@@ -15957,7 +17096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್"
+    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್",
+    "cellRef": "A1141"
   },
   {
     "Department": "stamps_sro",
@@ -15971,7 +17111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1142"
   },
   {
     "Department": "stamps_sro",
@@ -15985,7 +17126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಎಚ್.ಎಸ್"
+    "NameKN": "ಸತೀಶ್ ಎಚ್ ಎಸ್",
+    "cellRef": "A1143"
   },
   {
     "Department": "stamps_sro",
@@ -15999,7 +17141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1144"
   },
   {
     "Department": "stamps_sro",
@@ -16013,7 +17156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಜೇಂದ್ರಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1145"
   },
   {
     "Department": "stamps_sro",
@@ -16027,7 +17171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ"
+    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ",
+    "cellRef": "A1146"
   },
   {
     "Department": "stamps_sro",
@@ -16041,7 +17186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ಕೆ. ಶಾಂತಮೂರ್ತಿ"
+    "NameKN": "ಎಂ.ಕೆ.ಶಾಂತಮೂರ್ತಿ",
+    "cellRef": "A1147"
   },
   {
     "Department": "stamps_sro",
@@ -16055,7 +17201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾವತಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1148"
   },
   {
     "Department": "stamps_sro",
@@ -16069,7 +17216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1149"
   },
   {
     "Department": "stamps_sro",
@@ -16083,7 +17231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋಕಾಕ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1150"
   },
   {
     "Department": "stamps_sro",
@@ -16097,7 +17246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1151"
   },
   {
     "Department": "stamps_sro",
@@ -16111,7 +17261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1152"
   },
   {
     "Department": "stamps_sro",
@@ -16125,7 +17276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಬರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1153"
   },
   {
     "Department": "stamps_sro",
@@ -16139,7 +17291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಳೇದಗುಡ್ಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1154"
   },
   {
     "Department": "stamps_sro",
@@ -16153,7 +17306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಂಡ್ಲುಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1155"
   },
   {
     "Department": "stamps_sro",
@@ -16167,7 +17321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಗರಿಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1156"
   },
   {
     "Department": "stamps_sro",
@@ -16181,7 +17336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಳಿಯಾಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1157"
   },
   {
     "Department": "stamps_sro",
@@ -16195,7 +17351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್"
+    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್",
+    "cellRef": "A1158"
   },
   {
     "Department": "stamps_sro",
@@ -16209,7 +17366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾನಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1159"
   },
   {
     "Department": "stamps_sro",
@@ -16223,7 +17381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1160"
   },
   {
     "Department": "stamps_sro",
@@ -16237,7 +17396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1161"
   },
   {
     "Department": "stamps_sro",
@@ -16251,7 +17411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಿಹರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1162"
   },
   {
     "Department": "stamps_sro",
@@ -16265,7 +17426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1163"
   },
   {
     "Department": "stamps_sro",
@@ -16279,7 +17441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1164"
   },
   {
     "Department": "stamps_sro",
@@ -16293,7 +17456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚೈತ್ರಾ ಬಿ.ಎ"
+    "NameKN": "ಚೈತ್ರಾ ಬಿಎ",
+    "cellRef": "A1165"
   },
   {
     "Department": "stamps_sro",
@@ -16307,7 +17471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗಡದೇವನ ಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1166"
   },
   {
     "Department": "stamps_sro",
@@ -16321,7 +17486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್"
+    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್",
+    "cellRef": "A1167"
   },
   {
     "Department": "stamps_sro",
@@ -16335,7 +17501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1168"
   },
   {
     "Department": "stamps_sro",
@@ -16349,7 +17516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರಿಯೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1169"
   },
   {
     "Department": "stamps_sro",
@@ -16363,7 +17531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳಲ್ಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1170"
   },
   {
     "Department": "stamps_sro",
@@ -16377,7 +17546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳೆನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1171"
   },
   {
     "Department": "stamps_sro",
@@ -16391,7 +17561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1172"
   },
   {
     "Department": "stamps_sro",
@@ -16405,7 +17576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1173"
   },
   {
     "Department": "stamps_sro",
@@ -16419,7 +17591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1174"
   },
   {
     "Department": "stamps_sro",
@@ -16433,7 +17606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿ. ಗೀತಾ"
+    "NameKN": "ವಿ ಗೀತಾ",
+    "cellRef": "A1175"
   },
   {
     "Department": "stamps_sro",
@@ -16447,7 +17621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1176"
   },
   {
     "Department": "stamps_sro",
@@ -16461,7 +17636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1177"
   },
   {
     "Department": "stamps_sro",
@@ -16475,7 +17651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ ಉತ್ತರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1178"
   },
   {
     "Department": "stamps_sro",
@@ -16489,7 +17666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ (ದಕ್ಷಿಣ)",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1179"
   },
   {
     "Department": "stamps_sro",
@@ -16503,7 +17681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಕ್ಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1180"
   },
   {
     "Department": "stamps_sro",
@@ -16517,7 +17696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1181"
   },
   {
     "Department": "stamps_sro",
@@ -16531,7 +17711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಮ್ನಾಬಾದ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1182"
   },
   {
     "Department": "stamps_sro",
@@ -16545,7 +17726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುನಗುಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1183"
   },
   {
     "Department": "stamps_sro",
@@ -16559,7 +17741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1184"
   },
   {
     "Department": "stamps_sro",
@@ -16573,7 +17756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1185"
   },
   {
     "Department": "stamps_sro",
@@ -16587,7 +17771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂವಿನ ಹಡಗಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1186"
   },
   {
     "Department": "stamps_sro",
@@ -16601,7 +17786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಳಕಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1187"
   },
   {
     "Department": "stamps_sro",
@@ -16615,7 +17801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1188"
   },
   {
     "Department": "stamps_sro",
@@ -16629,7 +17816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಿ.ಜೆ. ಪ್ರಭಾಕರ್"
+    "NameKN": "ಸಿಜೆ ಪ್ರಭಾಕರ್",
+    "cellRef": "A1189"
   },
   {
     "Department": "stamps_sro",
@@ -16643,7 +17831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1190"
   },
   {
     "Department": "stamps_sro",
@@ -16657,7 +17846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಸ್. ಎಸ್. ಸ್ವರ್ಣಲತಾ"
+    "NameKN": "ಎಸ್ ಎಸ್ ಸ್ವರ್ಣಲತಾ",
+    "cellRef": "A1191"
   },
   {
     "Department": "stamps_sro",
@@ -16671,7 +17861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಮಖಂಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1192"
   },
   {
     "Department": "stamps_sro",
@@ -16685,7 +17876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಬಿ. ಗುರು ರಾಘವೇಂದ್ರ"
+    "NameKN": "ಬಿ ಗುರು ರಾಘವೇಂದ್ರ",
+    "cellRef": "A1193"
   },
   {
     "Department": "stamps_sro",
@@ -16699,7 +17891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೇವರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1194"
   },
   {
     "Department": "stamps_sro",
@@ -16713,7 +17906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಜಲಿ ಸಿ"
+    "NameKN": "ಅಂಜಲಿ ಸಿ",
+    "cellRef": "A1195"
   },
   {
     "Department": "stamps_sro",
@@ -16727,7 +17921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ. ಆರ್. ದೇವರಾಜು"
+    "NameKN": "ಕೆ ಆರ್ ದೇವರಾಜು",
+    "cellRef": "A1196"
   },
   {
     "Department": "stamps_sro",
@@ -16741,7 +17936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1197"
   },
   {
     "Department": "stamps_sro",
@@ -16755,7 +17951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1198"
   },
   {
     "Department": "stamps_sro",
@@ -16769,7 +17966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ"
+    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ",
+    "cellRef": "A1199"
   },
   {
     "Department": "stamps_sro",
@@ -16783,7 +17981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಡೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1200"
   },
   {
     "Department": "stamps_sro",
@@ -16797,7 +17996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲಘಟಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1201"
   },
   {
     "Department": "stamps_sro",
@@ -16811,7 +18011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಂಪ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1202"
   },
   {
     "Department": "stamps_sro",
@@ -16825,7 +18026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1203"
   },
   {
     "Department": "stamps_sro",
@@ -16839,7 +18041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರಟಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1204"
   },
   {
     "Department": "stamps_sro",
@@ -16853,7 +18056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1205"
   },
   {
     "Department": "stamps_sro",
@@ -16867,7 +18071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1206"
   },
   {
     "Department": "stamps_sro",
@@ -16881,7 +18086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವೈ.ಎಚ್. ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೈ.ಎಚ್.ವೆಂಕಟೇಶ್",
+    "cellRef": "A1207"
   },
   {
     "Department": "stamps_sro",
@@ -16895,7 +18101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1208"
   },
   {
     "Department": "stamps_sro",
@@ -16909,7 +18116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಖಾನಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1209"
   },
   {
     "Department": "stamps_sro",
@@ -16923,7 +18131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1210"
   },
   {
     "Department": "stamps_sro",
@@ -16937,7 +18146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1211"
   },
   {
     "Department": "stamps_sro",
@@ -16951,7 +18161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1212"
   },
   {
     "Department": "stamps_sro",
@@ -16965,7 +18176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1213"
   },
   {
     "Department": "stamps_sro",
@@ -16979,7 +18191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1214"
   },
   {
     "Department": "stamps_sro",
@@ -16993,7 +18206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1215"
   },
   {
     "Department": "stamps_sro",
@@ -17007,7 +18221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಆರ್. ರಾಮಪ್ರಸಾದ್"
+    "NameKN": "ಆರ್ ರಾಮಪ್ರಸಾದ್",
+    "cellRef": "A1216"
   },
   {
     "Department": "stamps_sro",
@@ -17021,7 +18236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೇರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1217"
   },
   {
     "Department": "stamps_sro",
@@ -17035,7 +18251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೂಡ್ಲಿಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1218"
   },
   {
     "Department": "stamps_sro",
@@ -17049,7 +18266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಟಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1219"
   },
   {
     "Department": "stamps_sro",
@@ -17063,7 +18281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಗೋಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1220"
   },
   {
     "Department": "stamps_sro",
@@ -17077,7 +18296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1221"
   },
   {
     "Department": "stamps_sro",
@@ -17091,7 +18311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1222"
   },
   {
     "Department": "stamps_sro",
@@ -17105,7 +18326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುರುಗೋಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1223"
   },
   {
     "Department": "stamps_sro",
@@ -17119,7 +18341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಷ್ಟಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1224"
   },
   {
     "Department": "stamps_sro",
@@ -17133,7 +18356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್"
+    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್",
+    "cellRef": "A1225"
   },
   {
     "Department": "stamps_sro",
@@ -17147,7 +18371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1226"
   },
   {
     "Department": "stamps_sro",
@@ -17161,7 +18386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಷ್ಮೇಶ್ವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1227"
   },
   {
     "Department": "stamps_sro",
@@ -17175,7 +18401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗಶುಗರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1228"
   },
   {
     "Department": "stamps_sro",
@@ -17189,7 +18416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ವಿ. ಸತೀಶ್"
+    "NameKN": "ಎಂವಿ ಸತೀಶ್",
+    "cellRef": "A1229"
   },
   {
     "Department": "stamps_sro",
@@ -17203,7 +18431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1230"
   },
   {
     "Department": "stamps_sro",
@@ -17217,7 +18446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1231"
   },
   {
     "Department": "stamps_sro",
@@ -17231,7 +18461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1232"
   },
   {
     "Department": "stamps_sro",
@@ -17245,7 +18476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1233"
   },
   {
     "Department": "stamps_sro",
@@ -17259,7 +18491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಮ್ಯಾ ಎನ್"
+    "NameKN": "ರಮ್ಯಾ ಎನ್",
+    "cellRef": "A1234"
   },
   {
     "Department": "stamps_sro",
@@ -17273,7 +18506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1235"
   },
   {
     "Department": "stamps_sro",
@@ -17287,7 +18521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿಕ್ರಮ್ ಕೆ. ಮಗರ್"
+    "NameKN": "ವಿಕ್ರಮ್ ಕೆ ಮಗರ್",
+    "cellRef": "A1236"
   },
   {
     "Department": "stamps_sro",
@@ -17301,7 +18536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1237"
   },
   {
     "Department": "stamps_sro",
@@ -17315,7 +18551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1238"
   },
   {
     "Department": "stamps_sro",
@@ -17329,7 +18566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1239"
   },
   {
     "Department": "stamps_sro",
@@ -17343,7 +18581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ತಾಲೂಕು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1240"
   },
   {
     "Department": "stamps_sro",
@@ -17357,7 +18596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾನ್ವಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1241"
   },
   {
     "Department": "stamps_sro",
@@ -17371,7 +18611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿರ್ಲೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1242"
   },
   {
     "Department": "stamps_sro",
@@ -17385,7 +18626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೊಳಕಾಲ್ಮೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1243"
   },
   {
     "Department": "stamps_sro",
@@ -17399,7 +18641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಬಿದ್ರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1244"
   },
   {
     "Department": "stamps_sro",
@@ -17413,7 +18656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುದ್ದೇಬಿಹಾಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1245"
   },
   {
     "Department": "stamps_sro",
@@ -17427,7 +18671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಧೋಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1246"
   },
   {
     "Department": "stamps_sro",
@@ -17441,7 +18686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಿಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1247"
   },
   {
     "Department": "stamps_sro",
@@ -17455,7 +18701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1248"
   },
   {
     "Department": "stamps_sro",
@@ -17469,7 +18716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1249"
   },
   {
     "Department": "stamps_sro",
@@ -17483,7 +18731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡಗೋಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1250"
   },
   {
     "Department": "stamps_sro",
@@ -17497,7 +18746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡರಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1251"
   },
   {
     "Department": "stamps_sro",
@@ -17511,7 +18761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರಗೋಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1252"
   },
   {
     "Department": "stamps_sro",
@@ -17525,7 +18776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪೂರ್ವ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1253"
   },
   {
     "Department": "stamps_sro",
@@ -17539,7 +18791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1254"
   },
   {
     "Department": "stamps_sro",
@@ -17553,7 +18806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪಶ್ಚಿಮ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1255"
   },
   {
     "Department": "stamps_sro",
@@ -17567,7 +18821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು (ಉತ್ತರ)",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1256"
   },
   {
     "Department": "stamps_sro",
@@ -17581,7 +18836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1257"
   },
   {
     "Department": "stamps_sro",
@@ -17595,7 +18851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚಂಪಾ ಎಲ್"
+    "NameKN": "ಚಂಪಾ ಎಲ್",
+    "cellRef": "A1258"
   },
   {
     "Department": "stamps_sro",
@@ -17609,7 +18866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಜನಗೂಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1259"
   },
   {
     "Department": "stamps_sro",
@@ -17623,7 +18881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಗುಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1260"
   },
   {
     "Department": "stamps_sro",
@@ -17637,7 +18896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಿಂಹರಾಜಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1261"
   },
   {
     "Department": "stamps_sro",
@@ -17651,7 +18911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನವಲಗುಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1262"
   },
   {
     "Department": "stamps_sro",
@@ -17665,7 +18926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆ.ಪಿ"
+    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆಪಿ",
+    "cellRef": "A1263"
   },
   {
     "Department": "stamps_sro",
@@ -17679,7 +18941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಪ್ಪಾಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1264"
   },
   {
     "Department": "stamps_sro",
@@ -17693,7 +18956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನುಗ್ಗೇಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1265"
   },
   {
     "Department": "stamps_sro",
@@ -17707,7 +18971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾಂಡವಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1266"
   },
   {
     "Department": "stamps_sro",
@@ -17721,7 +18986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1267"
   },
   {
     "Department": "stamps_sro",
@@ -17735,7 +19001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕರಿಬಸವ ಗೌಡ"
+    "NameKN": "ಕರಿಬಸವ ಗೌಡ",
+    "cellRef": "A1268"
   },
   {
     "Department": "stamps_sro",
@@ -17749,7 +19016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿರಿಯಾಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1269"
   },
   {
     "Department": "stamps_sro",
@@ -17763,7 +19031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೊನ್ನಂಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1270"
   },
   {
     "Department": "stamps_sro",
@@ -17777,7 +19046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1271"
   },
   {
     "Department": "stamps_sro",
@@ -17791,7 +19061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಬಾಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1272"
   },
   {
     "Department": "stamps_sro",
@@ -17805,7 +19076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1273"
   },
   {
     "Department": "stamps_sro",
@@ -17819,7 +19091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ."
+    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ",
+    "cellRef": "A1274"
   },
   {
     "Department": "stamps_sro",
@@ -17833,7 +19106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1275"
   },
   {
     "Department": "stamps_sro",
@@ -17847,7 +19121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1276"
   },
   {
     "Department": "stamps_sro",
@@ -17861,7 +19136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಣಿಬೆನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1277"
   },
   {
     "Department": "stamps_sro",
@@ -17875,7 +19151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರೋಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1278"
   },
   {
     "Department": "stamps_sro",
@@ -17889,7 +19166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ. ಗಿರೀಶ್"
+    "NameKN": "ಎಂ ಗಿರೀಶ್",
+    "cellRef": "A1279"
   },
   {
     "Department": "stamps_sro",
@@ -17903,7 +19181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಲಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1280"
   },
   {
     "Department": "stamps_sro",
@@ -17917,7 +19196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1281"
   },
   {
     "Department": "stamps_sro",
@@ -17931,7 +19211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಕಲೇಶಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1282"
   },
   {
     "Department": "stamps_sro",
@@ -17945,7 +19226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಡೂರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1283"
   },
   {
     "Department": "stamps_sro",
@@ -17959,7 +19241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ"
+    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ",
+    "cellRef": "A1284"
   },
   {
     "Department": "stamps_sro",
@@ -17973,7 +19256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸವಣೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1285"
   },
   {
     "Department": "stamps_sro",
@@ -17987,7 +19271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಡಮ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1286"
   },
   {
     "Department": "stamps_sro",
@@ -18001,7 +19286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಹಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1287"
   },
   {
     "Department": "stamps_sro",
@@ -18015,7 +19301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರನಾರಾಯಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1288"
   },
   {
     "Department": "stamps_sro",
@@ -18029,7 +19316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಘವೇಂದ್ರ"
+    "NameKN": "ರಾಘವೇಂದ್ರ",
+    "cellRef": "A1289"
   },
   {
     "Department": "stamps_sro",
@@ -18043,7 +19331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1290"
   },
   {
     "Department": "stamps_sro",
@@ -18057,7 +19346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಗ್ಗೋನ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1291"
   },
   {
     "Department": "stamps_sro",
@@ -18071,7 +19361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಕಾರಿಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1292"
   },
   {
     "Department": "stamps_sro",
@@ -18085,7 +19376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1293"
   },
   {
     "Department": "stamps_sro",
@@ -18099,7 +19391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಗುಪ್ಪಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1294"
   },
   {
     "Department": "stamps_sro",
@@ -18113,7 +19406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಹಟ್ಟಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1295"
   },
   {
     "Department": "stamps_sro",
@@ -18127,7 +19421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅನಿತಾ ಜಿ. ಬಡಿಗೇರ್"
+    "NameKN": "ಅನಿತಾ ಜಿ ಬಡಿಗೇರ್",
+    "cellRef": "A1296"
   },
   {
     "Department": "stamps_sro",
@@ -18141,7 +19436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೋರಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1297"
   },
   {
     "Department": "stamps_sro",
@@ -18155,7 +19451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೃಂಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1298"
   },
   {
     "Department": "stamps_sro",
@@ -18169,7 +19466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1299"
   },
   {
     "Department": "stamps_sro",
@@ -18183,7 +19481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂದಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1300"
   },
   {
     "Department": "stamps_sro",
@@ -18197,7 +19496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂಧನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1301"
   },
   {
     "Department": "stamps_sro",
@@ -18211,7 +19511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1302"
   },
   {
     "Department": "stamps_sro",
@@ -18225,7 +19526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರ್ಸಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1303"
   },
   {
     "Department": "stamps_sro",
@@ -18239,7 +19541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಮವಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1304"
   },
   {
     "Department": "stamps_sro",
@@ -18253,7 +19556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೊರಬ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1305"
   },
   {
     "Department": "stamps_sro",
@@ -18267,7 +19571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೌದತ್ತಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1306"
   },
   {
     "Department": "stamps_sro",
@@ -18281,7 +19586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1307"
   },
   {
     "Department": "stamps_sro",
@@ -18295,7 +19601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಮಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಚ್. ಎಸ್. ಅರವಿಂದ್"
+    "NameKN": "ಎಚ್ ಎಸ್ ಅರವಿಂದ್",
+    "cellRef": "A1308"
   },
   {
     "Department": "stamps_sro",
@@ -18309,7 +19616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಂಗಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1309"
   },
   {
     "Department": "stamps_sro",
@@ -18323,7 +19631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1310"
   },
   {
     "Department": "stamps_sro",
@@ -18337,7 +19646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1311"
   },
   {
     "Department": "stamps_sro",
@@ -18351,7 +19661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1312"
   },
   {
     "Department": "stamps_sro",
@@ -18365,7 +19676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್"
+    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್",
+    "cellRef": "A1313"
   },
   {
     "Department": "stamps_sro",
@@ -18379,7 +19691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೇರಾಡಲ್\\r\\n",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1314"
   },
   {
     "Department": "stamps_sro",
@@ -18393,7 +19706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೀರ್ಥಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1315"
   },
   {
     "Department": "stamps_sro",
@@ -18407,7 +19721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪಟೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1316"
   },
   {
     "Department": "stamps_sro",
@@ -18421,7 +19736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1317"
   },
   {
     "Department": "stamps_sro",
@@ -18435,7 +19751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುರುವೇಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1318"
   },
   {
     "Department": "stamps_sro",
@@ -18449,7 +19766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1319"
   },
   {
     "Department": "stamps_sro",
@@ -18463,7 +19781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ"
+    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ",
+    "cellRef": "A1320"
   },
   {
     "Department": "stamps_sro",
@@ -18477,7 +19796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರಾಜಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1321"
   },
   {
     "Department": "stamps_sro",
@@ -18491,7 +19811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಮೀಳಾ ಜಿ.ಜೆ"
+    "NameKN": "ಪ್ರಮೀಳಾ ಜಿಜೆ",
+    "cellRef": "A1322"
   },
   {
     "Department": "stamps_sro",
@@ -18505,7 +19826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಟ್ಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1323"
   },
   {
     "Department": "stamps_sro",
@@ -18519,7 +19841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1324"
   },
   {
     "Department": "stamps_sro",
@@ -18533,7 +19856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್"
+    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್",
+    "cellRef": "A1325"
   },
   {
     "Department": "stamps_sro",
@@ -18547,7 +19871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1326"
   },
   {
     "Department": "stamps_sro",
@@ -18561,7 +19886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯೆಲ್ಬುರ್ಗಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1327"
   },
   {
     "Department": "stamps_sro",
@@ -18575,7 +19901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲ್ಲಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1328"
   },
   {
     "Department": "stamps_sro",
@@ -18589,7 +19916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವತಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸುರೇಶ್ ಜಿ"
+    "NameKN": "ಸುರೇಶ್ ಜಿ",
+    "cellRef": "A1329"
   },
   {
     "Department": "police_traffic",
@@ -18603,7 +19931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1330"
   },
   {
     "Department": "police_traffic",
@@ -18617,7 +19946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1331"
   },
   {
     "Department": "police_traffic",
@@ -18631,7 +19961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1332"
   },
   {
     "Department": "police_traffic",
@@ -18645,7 +19976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1333"
   },
   {
     "Department": "police_traffic",
@@ -18659,7 +19991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1334"
   },
   {
     "Department": "police_traffic",
@@ -18673,7 +20006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1335"
   },
   {
     "Department": "police_traffic",
@@ -18687,7 +20021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1336"
   },
   {
     "Department": "police_traffic",
@@ -18701,7 +20036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1337"
   },
   {
     "Department": "police_traffic",
@@ -18715,7 +20051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1338"
   },
   {
     "Department": "police_traffic",
@@ -18729,7 +20066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1339"
   },
   {
     "Department": "police_traffic",
@@ -18743,7 +20081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1340"
   },
   {
     "Department": "police_traffic",
@@ -18757,7 +20096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1341"
   },
   {
     "Department": "police_traffic",
@@ -18771,7 +20111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1342"
   },
   {
     "Department": "police_traffic",
@@ -18785,7 +20126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1343"
   },
   {
     "Department": "police_traffic",
@@ -18799,7 +20141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1344"
   },
   {
     "Department": "police_traffic",
@@ -18813,7 +20156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1345"
   },
   {
     "Department": "police_traffic",
@@ -18827,7 +20171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1346"
   },
   {
     "Department": "police_traffic",
@@ -18841,7 +20186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1347"
   },
   {
     "Department": "police_traffic",
@@ -18855,7 +20201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1348"
   },
   {
     "Department": "police_traffic",
@@ -18869,7 +20216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1349"
   },
   {
     "Department": "police_traffic",
@@ -18883,7 +20231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1350"
   },
   {
     "Department": "police_traffic",
@@ -18897,7 +20246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1351"
   },
   {
     "Department": "police_traffic",
@@ -18911,7 +20261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1352"
   },
   {
     "Department": "police_traffic",
@@ -18925,7 +20276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1353"
   },
   {
     "Department": "police_traffic",
@@ -18939,7 +20291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1354"
   },
   {
     "Department": "police_traffic",
@@ -18953,7 +20306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1355"
   },
   {
     "Department": "police_traffic",
@@ -18967,7 +20321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1356"
   },
   {
     "Department": "police_traffic",
@@ -18981,7 +20336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1357"
   },
   {
     "Department": "police_traffic",
@@ -18995,7 +20351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1358"
   },
   {
     "Department": "police_traffic",
@@ -19009,7 +20366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1359"
   },
   {
     "Department": "police_traffic",
@@ -19023,7 +20381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1360"
   },
   {
     "Department": "police_traffic",
@@ -19037,7 +20396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ ಬೆಂಗಳೂರು PS",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1361"
   },
   {
     "Department": "police_traffic",
@@ -19051,7 +20411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1362"
   },
   {
     "Department": "police_traffic",
@@ -19065,7 +20426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1363"
   },
   {
     "Department": "police_traffic",
@@ -19079,7 +20441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1364"
   },
   {
     "Department": "police_traffic",
@@ -19093,7 +20456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1365"
   },
   {
     "Department": "police_traffic",
@@ -19107,7 +20471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1366"
   },
   {
     "Department": "police_traffic",
@@ -19121,7 +20486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1367"
   },
   {
     "Department": "police_traffic",
@@ -19135,7 +20501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1368"
   },
   {
     "Department": "police_traffic",
@@ -19149,7 +20516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1369"
   },
   {
     "Department": "police_traffic",
@@ -19163,7 +20531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1370"
   },
   {
     "Department": "police_traffic",
@@ -19177,7 +20546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1371"
   },
   {
     "Department": "police_traffic",
@@ -19191,7 +20561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1372"
   },
   {
     "Department": "police_traffic",
@@ -19205,7 +20576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1373"
   },
   {
     "Department": "police_traffic",
@@ -19219,6 +20591,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1374"
   }
 ]

--- a/scripts/xls2json.py
+++ b/scripts/xls2json.py
@@ -8,6 +8,9 @@ df2 = pd.read_excel('./officials/master-list.xlsx', sheet_name=1)
 # Merge the two dataframes by row number
 df = pd.concat([df1, df2], axis=1)
 
+# Add cell references
+df['cellRef'] = df.index.map(lambda x: f'A{x+2}')  # +2 because Excel is 1-based and has header
+
 # Rename columns
 df = df.rename(columns={
     'Area (Kannada)': 'AreaKN',

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -1,19 +1,20 @@
 {
-    "page_title": "BLR City Officials",
-    "toggle_language": "ಕನ್ನಡ",
-    "search_placeholder": "Search",
+  "page_title": "BLR City Officials",
+  "toggle_language": "ಕನ್ನಡ",
+  "search_placeholder": "Search",
 
-    "footer_data": "Data",
-    "footer_code": "Code",
-    "footer_betanyc": "Inspired by BetaNYC",
+  "footer_data": "Data",
+  "footer_code": "Code",
+  "footer_betanyc": "Inspired by BetaNYC",
 
-    "introduction": "Select location on map, search by address or pick a boundary",
+  "introduction": "Select location on map, search by address or pick a boundary",
 
-    "filter_placeholder": "Filter",
-    "download_geojson": "Download GeoJSON",
-    
-    "details_title": "Officials",
-    "details_source": "Source",
-    "details_error": "Found an error? Help us improve the accuracy of this information by leaving a comment on the",
-    "details_google_sheet": "Google Sheet"
+  "filter_placeholder": "Filter",
+  "download_geojson": "Download GeoJSON",
+
+  "details_title": "Officials",
+  "details_source": "Source",
+  "details_error": "Found an error? Help us improve the accuracy of this information by leaving a comment on the",
+  "details_google_sheet": "Google Sheet",
+  "details_suggest_edit": "Suggest an edit"
 }

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -16,5 +16,5 @@
   "details_source": "Source",
   "details_error": "Found an error? Help us improve the accuracy of this information by leaving a comment on the",
   "details_google_sheet": "Google Sheet",
-  "details_suggest_edit": "Suggest an edit"
+  "details_add_comment": "Add a comment"
 }

--- a/src/assets/locales/kn.json
+++ b/src/assets/locales/kn.json
@@ -1,19 +1,20 @@
 {
-    "page_title": "ಬೆಂಗಳೂರು ನಗರ ಅಧಿಕಾರಿಗಳು",
-    "toggle_language": "English",
-    "search_placeholder": "ಹುಡುಕು",
+  "page_title": "ಬೆಂಗಳೂರು ನಗರ ಅಧಿಕಾರಿಗಳು",
+  "toggle_language": "English",
+  "search_placeholder": "ಹುಡುಕು",
 
-    "footer_data": "ಡೇಟಾ",
-    "footer_code": "ಕೋಡ್",
-    "footer_betanyc": "BetaNYC ಪ್ರೇರಿತ",
+  "footer_data": "ಡೇಟಾ",
+  "footer_code": "ಕೋಡ್",
+  "footer_betanyc": "BetaNYC ಪ್ರೇರಿತ",
 
-    "introduction": "ನಕ್ಷೆಯಲ್ಲಿ ಸ್ಥಳವನ್ನು ಆಯ್ಕೆಮಾಡಿ, ವಿಳಾಸದ ಮೂಲಕ ಹುಡುಕಿ ಅಥವಾ ಗಡಿಯನ್ನು ಆರಿಸಿ",
+  "introduction": "ನಕ್ಷೆಯಲ್ಲಿ ಸ್ಥಳವನ್ನು ಆಯ್ಕೆಮಾಡಿ, ವಿಳಾಸದ ಮೂಲಕ ಹುಡುಕಿ ಅಥವಾ ಗಡಿಯನ್ನು ಆರಿಸಿ",
 
-    "filter_placeholder": "ಫಿಲ್ಟರ್",
-    "download_geojson": "GeoJSON ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ",
-    
-    "details_title": "ಅಧಿಕಾರಿಗಳು",
-    "details_source": "ಮೂಲ",
-    "details_error": "ದೋಷ ಕಂಡುಬಂದಿದೆಯೇ? ಈ ಮಾಹಿತಿಯ ನಿಖರತೆಯನ್ನು ಸುಧಾರಿಸಲು ನಮಗೆ ಸಹಾಯ ಮಾಡಿ",
-    "details_google_sheet": "Google Sheet"
+  "filter_placeholder": "ಫಿಲ್ಟರ್",
+  "download_geojson": "GeoJSON ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ",
+
+  "details_title": "ಅಧಿಕಾರಿಗಳು",
+  "details_source": "ಮೂಲ",
+  "details_error": "ದೋಷ ಕಂಡುಬಂದಿದೆಯೇ? ಈ ಮಾಹಿತಿಯ ನಿಖರತೆಯನ್ನು ಸುಧಾರಿಸಲು ನಮಗೆ ಸಹಾಯ ಮಾಡಿ",
+  "details_google_sheet": "Google Sheet",
+  "details_suggest_edit": "ಸಂಪಾದಿಸಿ"
 }

--- a/src/assets/locales/kn.json
+++ b/src/assets/locales/kn.json
@@ -16,5 +16,5 @@
   "details_source": "ಮೂಲ",
   "details_error": "ದೋಷ ಕಂಡುಬಂದಿದೆಯೇ? ಈ ಮಾಹಿತಿಯ ನಿಖರತೆಯನ್ನು ಸುಧಾರಿಸಲು ನಮಗೆ ಸಹಾಯ ಮಾಡಿ",
   "details_google_sheet": "Google Sheet",
-  "details_suggest_edit": "ಸಂಪಾದಿಸಿ"
+  "details_add_comment": "ಅಭಿಪ್ರಾಯ ಸೇರಿಸಿ"
 }

--- a/src/components/Sidebar/DistrictDetails.svelte
+++ b/src/components/Sidebar/DistrictDetails.svelte
@@ -38,6 +38,20 @@
       selectedBoundaryMap.set(null);
     }
   }
+
+  let currentOfficials: any = null;
+
+  $: {
+    if ($selectedBoundaryMap && $selectedDistrict) {
+      const officials = getOfficialDetails(
+        $selectedBoundaryMap,
+        $selectedDistrict
+      );
+      currentOfficials = officials;
+    } else {
+      currentOfficials = null;
+    }
+  }
 </script>
 
 <SidebarHeader
@@ -209,7 +223,11 @@
   <p class="text-gray-600 dark:text-gray-400">
     {$_('details_error')}
     <a
-      href="https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit"
+      href={currentOfficials
+        ? Array.isArray(currentOfficials)
+          ? `https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit#gid=1265603145&range=${currentOfficials[0].cellRef}`
+          : `https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit#gid=1265603145&range=${currentOfficials.cellRef}`
+        : 'https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit#gid=1265603145'}
       target="_blank"
       rel="noopener noreferrer"
       class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline font-medium"

--- a/src/components/Sidebar/DistrictDetails.svelte
+++ b/src/components/Sidebar/DistrictDetails.svelte
@@ -219,34 +219,35 @@
     {/await}
   {/if}
 {/if}
-
-<div class="mt-4 pb-4 text-xs bg-white dark:bg-neutral-900 p-4">
-  <div class="flex flex-col gap-2 items-start justify-between">
-    <span class="text-gray-600 dark:text-gray-400">
-      {$_('details_error')}
-      {$_('details_google_sheet')}
-    </span>
-    <a
-      href={currentOfficials
-        ? Array.isArray(currentOfficials)
-          ? `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}&range=${currentOfficials[0].cellRef}`
-          : `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}&range=${currentOfficials.cellRef}`
-        : `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}`}
-      target="_blank"
-      rel="noopener noreferrer"
-      class="inline-flex items-center px-1 py-1.5 text-xs rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800 transition-colors"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="h-4 w-4 mr-1.5"
-        viewBox="0 0 20 20"
-        fill="currentColor"
+<div class="px-4 mt-4 pb-4">
+  <div class="bg-white dark:bg-neutral-900 p-4">
+    <div class="flex flex-col gap-4 items-center text-center">
+      <p class="text-sm text-gray-600 dark:text-gray-400">
+        {$_('details_error')}
+        {$_('details_google_sheet')}
+      </p>
+      <a
+        href={currentOfficials
+          ? Array.isArray(currentOfficials)
+            ? `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}&range=${currentOfficials[0].cellRef}`
+            : `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}&range=${currentOfficials.cellRef}`
+          : `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center px-3 py-1 text-sm rounded bg-gray-50 dark:bg-neutral-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-neutral-600 border border-gray-200 dark:border-neutral-600 transition-colors max-w-full"
       >
-        <path
-          d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
-        />
-      </svg>
-      {$_('details_suggest_edit')}
-    </a>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-5 w-5 mr-2"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
+          />
+        </svg>
+        {$_('details_add_comment')}
+      </a>
+    </div>
   </div>
 </div>

--- a/src/components/Sidebar/DistrictDetails.svelte
+++ b/src/components/Sidebar/DistrictDetails.svelte
@@ -220,8 +220,11 @@
 {/if}
 
 <div class="mt-4 pb-4 text-xs bg-white dark:bg-neutral-900 p-4">
-  <p class="text-gray-600 dark:text-gray-400">
-    {$_('details_error')}
+  <div class="flex flex-col gap-2 items-start justify-between">
+    <span class="text-gray-600 dark:text-gray-400">
+      {$_('details_error')}
+      {$_('details_google_sheet')}
+    </span>
     <a
       href={currentOfficials
         ? Array.isArray(currentOfficials)
@@ -230,8 +233,19 @@
         : 'https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit#gid=1265603145'}
       target="_blank"
       rel="noopener noreferrer"
-      class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline font-medium"
-      >{$_('details_google_sheet')}</a
+      class="inline-flex items-center px-1 py-1.5 text-xs rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800 transition-colors"
     >
-  </p>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-4 w-4 mr-1.5"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+      >
+        <path
+          d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
+        />
+      </svg>
+      {$_('details_suggest_edit')}
+    </a>
+  </div>
 </div>

--- a/src/components/Sidebar/DistrictDetails.svelte
+++ b/src/components/Sidebar/DistrictDetails.svelte
@@ -11,6 +11,7 @@
     mapStore
   } from '../../stores';
   import { getOfficialDetails, resetZoom } from '../../helpers/helpers';
+  import pkg from '../../../package.json';
 
   function getDistrictTitle(
     boundaryId: string | null,
@@ -228,9 +229,9 @@
     <a
       href={currentOfficials
         ? Array.isArray(currentOfficials)
-          ? `https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit#gid=1265603145&range=${currentOfficials[0].cellRef}`
-          : `https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit#gid=1265603145&range=${currentOfficials.cellRef}`
-        : 'https://docs.google.com/spreadsheets/d/1lsXt4nXsz9k52bW79KxSLRK3Lg30z8U9AcuPNUHUVNY/edit#gid=1265603145'}
+          ? `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}&range=${currentOfficials[0].cellRef}`
+          : `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}&range=${currentOfficials.cellRef}`
+        : `https://docs.google.com/spreadsheets/d/${pkg.config.googleSheet.id}/edit#gid=${pkg.config.googleSheet.gid}`}
       target="_blank"
       rel="noopener noreferrer"
       class="inline-flex items-center px-1 py-1.5 text-xs rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 text-blue-600 dark:text-blue-400 border border-blue-200 dark:border-blue-800 transition-colors"

--- a/src/officials.json
+++ b/src/officials.json
@@ -11,7 +11,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ ಎನ್"
+    "NameKN": "ಶಿವಶಂಕರ ಎನ್",
+    "cellRef": "A2"
   },
   {
     "Department": "admin_district",
@@ -25,7 +26,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ನಗರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಜಗದೀಶ ಜಿ"
+    "NameKN": "ಜಗದೀಶ ಜಿ",
+    "cellRef": "A3"
   },
   {
     "Department": "admin_district",
@@ -39,7 +41,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A4"
   },
   {
     "Department": "admin_district",
@@ -53,7 +56,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A5"
   },
   {
     "Department": "admin_district",
@@ -67,7 +71,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A6"
   },
   {
     "Department": "admin_district",
@@ -81,7 +86,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A7"
   },
   {
     "Department": "admin_district",
@@ -95,7 +101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A8"
   },
   {
     "Department": "admin_district",
@@ -109,7 +116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A9"
   },
   {
     "Department": "admin_district",
@@ -123,7 +131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A10"
   },
   {
     "Department": "admin_taluk",
@@ -137,7 +146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಪಿ ದಿನೇಶ್"
+    "NameKN": "ಪಿ ದಿನೇಶ್",
+    "cellRef": "A11"
   },
   {
     "Department": "admin_taluk",
@@ -151,7 +161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A12"
   },
   {
     "Department": "admin_taluk",
@@ -165,7 +176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಪೂರ್ವ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ರಾಜೀವ್"
+    "NameKN": "ಅಜಿತ್ ರೈ ಸಾರೋಕೆ",
+    "cellRef": "A13"
   },
   {
     "Department": "admin_taluk",
@@ -179,7 +191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಬಾಲಕೃಷ್ಣ"
+    "NameKN": "ಬಾಲಕೃಷ್ಣ",
+    "cellRef": "A14"
   },
   {
     "Department": "admin_taluk",
@@ -193,7 +206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ"
+    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ",
+    "cellRef": "A15"
   },
   {
     "Department": "admin_taluk",
@@ -207,7 +221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A16"
   },
   {
     "Department": "admin_taluk",
@@ -221,7 +236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A17"
   },
   {
     "Department": "admin_taluk",
@@ -235,7 +251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A18"
   },
   {
     "Department": "admin_taluk",
@@ -249,7 +266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A19"
   },
   {
     "Department": "admin_taluk",
@@ -263,7 +281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A20"
   },
   {
     "Department": "admin_taluk",
@@ -277,7 +296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A21"
   },
   {
     "Department": "admin_taluk",
@@ -291,7 +311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A22"
   },
   {
     "Department": "admin_taluk",
@@ -305,7 +326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A23"
   },
   {
     "Department": "admin_taluk",
@@ -319,7 +341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A24"
   },
   {
     "Department": "admin_taluk",
@@ -333,7 +356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A25"
   },
   {
     "Department": "admin_taluk",
@@ -347,7 +371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A26"
   },
   {
     "Department": "admin_taluk",
@@ -361,7 +386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A27"
   },
   {
     "Department": "admin_taluk",
@@ -375,7 +401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A28"
   },
   {
     "Department": "admin_taluk",
@@ -389,7 +416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A29"
   },
   {
     "Department": "admin_taluk",
@@ -403,7 +431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A30"
   },
   {
     "Department": "admin_taluk",
@@ -417,7 +446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ಎಫ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A31"
   },
   {
     "Department": "admin_taluk",
@@ -431,7 +461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A32"
   },
   {
     "Department": "admin_taluk",
@@ -445,7 +476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A33"
   },
   {
     "Department": "admin_taluk",
@@ -459,7 +491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A34"
   },
   {
     "Department": "admin_taluk",
@@ -473,7 +506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A35"
   },
   {
     "Department": "admin_taluk",
@@ -487,7 +521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A36"
   },
   {
     "Department": "admin_taluk",
@@ -501,7 +536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A37"
   },
   {
     "Department": "admin_taluk",
@@ -515,7 +551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A38"
   },
   {
     "Department": "admin_taluk",
@@ -529,7 +566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A39"
   },
   {
     "Department": "admin_taluk",
@@ -543,7 +581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A40"
   },
   {
     "Department": "admin_taluk",
@@ -557,7 +596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A41"
   },
   {
     "Department": "admin_taluk",
@@ -571,7 +611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A42"
   },
   {
     "Department": "admin_taluk",
@@ -585,7 +626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A43"
   },
   {
     "Department": "admin_taluk",
@@ -599,7 +641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A44"
   },
   {
     "Department": "admin_taluk",
@@ -613,7 +656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A45"
   },
   {
     "Department": "admin_taluk",
@@ -627,7 +671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A46"
   },
   {
     "Department": "admin_taluk",
@@ -641,7 +686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A47"
   },
   {
     "Department": "admin_taluk",
@@ -655,7 +701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A48"
   },
   {
     "Department": "admin_taluk",
@@ -669,7 +716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A49"
   },
   {
     "Department": "admin_taluk",
@@ -683,7 +731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A50"
   },
   {
     "Department": "admin_taluk",
@@ -697,7 +746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A51"
   },
   {
     "Department": "admin_taluk",
@@ -711,7 +761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A52"
   },
   {
     "Department": "admin_taluk",
@@ -725,7 +776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
+    "NameKN": "ನರಶಿಮಾಮೂರ್ತಿ",
+    "cellRef": "A53"
   },
   {
     "Department": "bbmp_wards",
@@ -739,7 +791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ"
+    "NameKN": "ಅಕ್ಷತಾ",
+    "cellRef": "A54"
   },
   {
     "Department": "bbmp_wards",
@@ -753,7 +806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್"
+    "NameKN": "ರವಿಕುಮಾರ್",
+    "cellRef": "A55"
   },
   {
     "Department": "bbmp_wards",
@@ -767,7 +821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್. ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಿ. ಶ್ರೀನಿವಾಸ ಮೂರ್ತಿ"
+    "NameKN": "ಜಿ ಶ್ರೀನಿವಾಸಮೂರ್ತಿ",
+    "cellRef": "A56"
   },
   {
     "Department": "bbmp_wards",
@@ -781,7 +836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಗರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ"
+    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ",
+    "cellRef": "A57"
   },
   {
     "Department": "bbmp_wards",
@@ -795,7 +851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್"
+    "NameKN": "ಸೋಮಶೇಖರ್",
+    "cellRef": "A58"
   },
   {
     "Department": "bbmp_wards",
@@ -809,7 +866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಂಜನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು"
+    "NameKN": "ರಘು",
+    "cellRef": "A59"
   },
   {
     "Department": "bbmp_wards",
@@ -823,7 +881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಮನೆ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜ್ ಕುಮಾರ್"
+    "NameKN": "ರಾಜ್ ಕುಮಾರ್",
+    "cellRef": "A60"
   },
   {
     "Department": "bbmp_wards",
@@ -837,7 +896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೇಖ್ ಅಹಮದ್"
+    "NameKN": "ಶೇಖ್ ಅಹಮದ್",
+    "cellRef": "A61"
   },
   {
     "Department": "bbmp_wards",
@@ -851,7 +911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜ್ಯೋತಿ"
+    "NameKN": "ಜ್ಯೋತಿ",
+    "cellRef": "A62"
   },
   {
     "Department": "bbmp_wards",
@@ -865,7 +926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಟ್ಟೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ"
+    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ",
+    "cellRef": "A63"
   },
   {
     "Department": "bbmp_wards",
@@ -879,7 +941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್"
+    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್",
+    "cellRef": "A64"
   },
   {
     "Department": "bbmp_wards",
@@ -893,7 +956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಜಾದ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್"
+    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್",
+    "cellRef": "A65"
   },
   {
     "Department": "bbmp_wards",
@@ -907,7 +971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿ ವೆಂಕಟ ರೆಡ್ಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ"
+    "NameKN": "ಮಮತಾ",
+    "cellRef": "A66"
   },
   {
     "Department": "bbmp_wards",
@@ -921,7 +986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
+    "cellRef": "A67"
   },
   {
     "Department": "bbmp_wards",
@@ -935,7 +1001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ"
+    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ",
+    "cellRef": "A68"
   },
   {
     "Department": "bbmp_wards",
@@ -949,7 +1016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಮಾ"
+    "NameKN": "ಸುಮಾ",
+    "cellRef": "A69"
   },
   {
     "Department": "bbmp_wards",
@@ -963,7 +1031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಡೆ ಮಠ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪೂರ್ಣಿಮಾ"
+    "NameKN": "ಪೂರ್ಣಿಮಾ",
+    "cellRef": "A70"
   },
   {
     "Department": "bbmp_wards",
@@ -977,7 +1046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ."
+    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ",
+    "cellRef": "A71"
   },
   {
     "Department": "bbmp_wards",
@@ -991,7 +1061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೆಂಕಟೇಶ್",
+    "cellRef": "A72"
   },
   {
     "Department": "bbmp_wards",
@@ -1005,7 +1076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನೀಲಕಂಠಯ್ಯ"
+    "NameKN": "ನೀಲಕಂಠಯ್ಯ",
+    "cellRef": "A73"
   },
   {
     "Department": "bbmp_wards",
@@ -1019,7 +1091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A74"
   },
   {
     "Department": "bbmp_wards",
@@ -1033,7 +1106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ"
+    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ",
+    "cellRef": "A75"
   },
   {
     "Department": "bbmp_wards",
@@ -1047,7 +1121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಾವಿತ್ರಿ"
+    "NameKN": "ಸಾವಿತ್ರಿ",
+    "cellRef": "A76"
   },
   {
     "Department": "bbmp_wards",
@@ -1061,7 +1136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಳೇಕಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A77"
   },
   {
     "Department": "bbmp_wards",
@@ -1075,7 +1151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿನ್ನಿಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್"
+    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್",
+    "cellRef": "A78"
   },
   {
     "Department": "bbmp_wards",
@@ -1089,7 +1166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್ ದೇವಾ"
+    "NameKN": "ರಮೇಶ್ ದೇವಾ",
+    "cellRef": "A79"
   },
   {
     "Department": "bbmp_wards",
@@ -1103,7 +1181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿ ಟಿ ಎಂ ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕಲಾ"
+    "NameKN": "ಶಶಿಕಲಾ",
+    "cellRef": "A80"
   },
   {
     "Department": "bbmp_wards",
@@ -1117,7 +1196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಕುಮಾರ್"
+    "NameKN": "ಶಿವಕುಮಾರ್",
+    "cellRef": "A81"
   },
   {
     "Department": "bbmp_wards",
@@ -1131,7 +1211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅನುಷಾ"
+    "NameKN": "ಅನುಷಾ",
+    "cellRef": "A82"
   },
   {
     "Department": "bbmp_wards",
@@ -1145,7 +1226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಿ.ಎನ್. ರಾಘವೇಂದ್ರ"
+    "NameKN": "ಬಿಎನ್ ರಾಘವೇಂದ್ರ",
+    "cellRef": "A83"
   },
   {
     "Department": "bbmp_wards",
@@ -1159,7 +1241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ ವಿ ರಾಮನ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ"
+    "NameKN": "ರವಿ",
+    "cellRef": "A84"
   },
   {
     "Department": "bbmp_wards",
@@ -1173,7 +1256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಲವಾದಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಸಂತ್"
+    "NameKN": "ವಸಂತ್",
+    "cellRef": "A85"
   },
   {
     "Department": "bbmp_wards",
@@ -1187,7 +1271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ"
+    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ",
+    "cellRef": "A86"
   },
   {
     "Department": "bbmp_wards",
@@ -1201,7 +1286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೌಮ್ಯಾ"
+    "NameKN": "ಸೌಮ್ಯಾ",
+    "cellRef": "A87"
   },
   {
     "Department": "bbmp_wards",
@@ -1215,7 +1301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮುಂಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಯನತಾರಾ ಡಾ."
+    "NameKN": "ನಯನತಾರಾ ಡಾ",
+    "cellRef": "A88"
   },
   {
     "Department": "bbmp_wards",
@@ -1229,7 +1316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರಾಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾರತಿ"
+    "NameKN": "ಭಾರತಿ",
+    "cellRef": "A89"
   },
   {
     "Department": "bbmp_wards",
@@ -1243,7 +1331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ"
+    "NameKN": "ಶಂಕರಪ್ಪ",
+    "cellRef": "A90"
   },
   {
     "Department": "bbmp_wards",
@@ -1257,7 +1346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್"
+    "NameKN": "ಶರತ್",
+    "cellRef": "A91"
   },
   {
     "Department": "bbmp_wards",
@@ -1271,7 +1361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯದುಕೃಷ್ಣ"
+    "NameKN": "ಯದುಕೃಷ್ಣ",
+    "cellRef": "A92"
   },
   {
     "Department": "bbmp_wards",
@@ -1285,7 +1376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೊಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ"
+    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ",
+    "cellRef": "A93"
   },
   {
     "Department": "bbmp_wards",
@@ -1299,7 +1391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೌಡೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪಾಪರೆಡ್ಡಿ"
+    "NameKN": "ಪಾಪರೆಡ್ಡಿ",
+    "cellRef": "A94"
   },
   {
     "Department": "bbmp_wards",
@@ -1313,7 +1406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೌಡೇಶ್ವರಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೆ.ಜಿ. ಸುಂದರೇಶ್"
+    "NameKN": "ಕೆ ಜಿ ಸುಂದರೇಶ್",
+    "cellRef": "A95"
   },
   {
     "Department": "bbmp_wards",
@@ -1327,7 +1421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಟನ್ ಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು"
+    "NameKN": "ರಾಜು",
+    "cellRef": "A96"
   },
   {
     "Department": "bbmp_wards",
@@ -1341,7 +1436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಕ್ಸ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ"
+    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ",
+    "cellRef": "A97"
   },
   {
     "Department": "bbmp_wards",
@@ -1355,7 +1451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದತ್ತಾತ್ರೇಯ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್"
+    "NameKN": "ವಿಶ್ವನಾಥ್",
+    "cellRef": "A98"
   },
   {
     "Department": "bbmp_wards",
@@ -1369,7 +1466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಯಾನಂದ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮು"
+    "NameKN": "ರಾಮು",
+    "cellRef": "A99"
   },
   {
     "Department": "bbmp_wards",
@@ -1383,7 +1481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೀಪಾಂಜಲಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು"
+    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು",
+    "cellRef": "A100"
   },
   {
     "Department": "bbmp_wards",
@@ -1397,7 +1496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಗಿರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್"
+    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್",
+    "cellRef": "A101"
   },
   {
     "Department": "bbmp_wards",
@@ -1411,7 +1511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವರ ಜೀವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್"
+    "NameKN": "ಉಮೇಶ್",
+    "cellRef": "A102"
   },
   {
     "Department": "bbmp_wards",
@@ -1425,7 +1526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವರಾಜ್ ಅರಸ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ"
+    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ",
+    "cellRef": "A103"
   },
   {
     "Department": "bbmp_wards",
@@ -1439,7 +1541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿತ್ಯ ಕೆ.ಎ."
+    "NameKN": "ನಿತ್ಯ ಕೆಎ",
+    "cellRef": "A104"
   },
   {
     "Department": "bbmp_wards",
@@ -1453,7 +1556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧರ್ಮರಾಯ ಸ್ವಾಮಿ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಲು ರಾಥೋರ್"
+    "NameKN": "ವಲು ರಾಥೋರ್",
+    "cellRef": "A105"
   },
   {
     "Department": "bbmp_wards",
@@ -1467,7 +1571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ಬಿದರಕಲ್ಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಿದ್ಧರಾಜ್"
+    "NameKN": "ಸಿದ್ದರಾಜು",
+    "cellRef": "A106"
   },
   {
     "Department": "bbmp_wards",
@@ -1481,7 +1586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ಬೊಮ್ಮಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬೀರೇಶ್"
+    "NameKN": "ಬೀರೇಶ್",
+    "cellRef": "A107"
   },
   {
     "Department": "bbmp_wards",
@@ -1495,7 +1601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ಗಣಪತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗಸ್ವಾಮಿ"
+    "NameKN": "ರಂಗಸ್ವಾಮಿ",
+    "cellRef": "A108"
   },
   {
     "Department": "bbmp_wards",
@@ -1509,7 +1616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡ ನೆಕ್ಕುಂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್"
+    "NameKN": "ರವಿಕುಮಾರ್",
+    "cellRef": "A109"
   },
   {
     "Department": "bbmp_wards",
@@ -1523,7 +1631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪ್ಪುರಾಜ್"
+    "NameKN": "ಅಪ್ಪುರಾಜ್",
+    "cellRef": "A110"
   },
   {
     "Department": "bbmp_wards",
@@ -1537,7 +1646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಡಾ. ಪುನೀತ್ ರಾಜ್ ಕುಮಾರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ"
+    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ",
+    "cellRef": "A111"
   },
   {
     "Department": "bbmp_wards",
@@ -1551,7 +1661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಡಾ. ರಾಜ್ ಕುಮಾರ್ ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್"
+    "NameKN": "ಪ್ರಕಾಶ್",
+    "cellRef": "A112"
   },
   {
     "Department": "bbmp_wards",
@@ -1565,7 +1676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಈಜಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನುಪಮಾ"
+    "NameKN": "ಡಾ.ಅನುಪಮಾ",
+    "cellRef": "A113"
   },
   {
     "Department": "bbmp_wards",
@@ -1579,7 +1691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಲಿ ಆಂಜನೇಯ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶಿಲ್ಪಾ"
+    "NameKN": "ಡಾ.ಶಿಲ್ಪಾ",
+    "cellRef": "A114"
   },
   {
     "Department": "bbmp_wards",
@@ -1593,7 +1706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿಯಪ್ಪ"
+    "NameKN": "ಮುನಿಯಪ್ಪ",
+    "cellRef": "A115"
   },
   {
     "Department": "bbmp_wards",
@@ -1607,7 +1721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಣೇಶ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್"
+    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್",
+    "cellRef": "A116"
   },
   {
     "Department": "bbmp_wards",
@@ -1621,7 +1736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಭಿಲಾಷ್"
+    "NameKN": "ಅಭಿಲಾಷ್",
+    "cellRef": "A117"
   },
   {
     "Department": "bbmp_wards",
@@ -1635,7 +1751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗರುಡಾಚಾರ್ ಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೂಪ್ರಧಾ"
+    "NameKN": "ಭೂಪ್ರದ",
+    "cellRef": "A118"
   },
   {
     "Department": "bbmp_wards",
@@ -1649,7 +1766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗವಿ ಗಂಗಾಧರೇಶ್ವರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು"
+    "NameKN": "ರಘು",
+    "cellRef": "A119"
   },
   {
     "Department": "bbmp_wards",
@@ -1663,7 +1781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಯಿತ್ರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಕುಮಾರ್"
+    "NameKN": "ರಾಜಕುಮಾರ್",
+    "cellRef": "A120"
   },
   {
     "Department": "bbmp_wards",
@@ -1677,7 +1796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಘರೇಭಾವಿಪಾಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A121"
   },
   {
     "Department": "bbmp_wards",
@@ -1691,7 +1811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೊಟ್ಟಿಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ"
+    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ",
+    "cellRef": "A122"
   },
   {
     "Department": "bbmp_wards",
@@ -1705,7 +1826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್"
+    "NameKN": "ಉಮೇಶ್",
+    "cellRef": "A123"
   },
   {
     "Department": "bbmp_wards",
@@ -1719,7 +1841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುರಪ್ಪನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್"
+    "NameKN": "ಸಂತೋಷ್",
+    "cellRef": "A124"
   },
   {
     "Department": "bbmp_wards",
@@ -1733,7 +1856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A125"
   },
   {
     "Department": "bbmp_wards",
@@ -1747,7 +1871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಂಪಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗರಾಜು"
+    "NameKN": "ರಂಗರಾಜು",
+    "cellRef": "A126"
   },
   {
     "Department": "bbmp_wards",
@@ -1761,7 +1886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HBR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರವಿಕುಮಾರ್"
+    "NameKN": "ಡಾ.ರವಿಕುಮಾರ್",
+    "cellRef": "A127"
   },
   {
     "Department": "bbmp_wards",
@@ -1775,7 +1901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಕೆಂಪಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ"
+    "NameKN": "ಅಕ್ಷತಾ",
+    "cellRef": "A128"
   },
   {
     "Department": "bbmp_wards",
@@ -1789,7 +1916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಇಮ್ರಾನ್"
+    "NameKN": "ಇಮ್ರಾನ್",
+    "cellRef": "A129"
   },
   {
     "Department": "bbmp_wards",
@@ -1803,7 +1931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹನುಮಂತ ನಾಯಕ್"
+    "NameKN": "ಹನುಮಂತ ನಾಯಕ್",
+    "cellRef": "A130"
   },
   {
     "Department": "bbmp_wards",
@@ -1817,7 +1946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಮ್ಮಿಗೆಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ"
+    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ",
+    "cellRef": "A131"
   },
   {
     "Department": "bbmp_wards",
@@ -1831,7 +1961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಈರಣ್ಣ"
+    "NameKN": "ಈರಣ್ಣ",
+    "cellRef": "A132"
   },
   {
     "Department": "bbmp_wards",
@@ -1845,7 +1976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೇರೋಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A133"
   },
   {
     "Department": "bbmp_wards",
@@ -1859,7 +1991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎನ್. ಎಸ್. ನಾಗೇಂದ್ರ"
+    "NameKN": "ಎನ್ ಎಸ್ ನಾಗೇಂದ್ರ",
+    "cellRef": "A134"
   },
   {
     "Department": "bbmp_wards",
@@ -1873,7 +2006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಗಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಧರ್"
+    "NameKN": "ಶಶಿಧರ್",
+    "cellRef": "A135"
   },
   {
     "Department": "bbmp_wards",
@@ -1887,7 +2021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊರಮಾವು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A136"
   },
   {
     "Department": "bbmp_wards",
@@ -1901,7 +2036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ರಸ್ತೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A137"
   },
   {
     "Department": "bbmp_wards",
@@ -1915,7 +2051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
+    "cellRef": "A138"
   },
   {
     "Department": "bbmp_wards",
@@ -1929,7 +2066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲೋಹಿತ್"
+    "NameKN": "ಲೋಹಿತ್",
+    "cellRef": "A139"
   },
   {
     "Department": "bbmp_wards",
@@ -1943,7 +2081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಯ್ಸಳ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
+    "cellRef": "A140"
   },
   {
     "Department": "bbmp_wards",
@@ -1957,7 +2096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು"
+    "NameKN": "ರಾಜು",
+    "cellRef": "A141"
   },
   {
     "Department": "bbmp_wards",
@@ -1971,7 +2111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್"
+    "NameKN": "ಪ್ರಕಾಶ್",
+    "cellRef": "A142"
   },
   {
     "Department": "bbmp_wards",
@@ -1985,7 +2126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A143"
   },
   {
     "Department": "bbmp_wards",
@@ -1999,7 +2141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಳಿಮಾವು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A144"
   },
   {
     "Department": "bbmp_wards",
@@ -2013,7 +2156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಬ್ಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A145"
   },
   {
     "Department": "bbmp_wards",
@@ -2027,7 +2171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ ಪಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫಜಲ್ ಅಹಮದ್"
+    "NameKN": "ಫಜಲ್ ಅಹಮದ್",
+    "cellRef": "A146"
   },
   {
     "Department": "bbmp_wards",
@@ -2041,7 +2186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರು"
+    "NameKN": "ಚಂದ್ರು",
+    "cellRef": "A147"
   },
   {
     "Department": "bbmp_wards",
@@ -2055,7 +2201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರುಣ್"
+    "NameKN": "ವರುಣ್",
+    "cellRef": "A148"
   },
   {
     "Department": "bbmp_wards",
@@ -2069,7 +2216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರ್"
+    "NameKN": "ವಿಶ್ವೇಶ್ವರ್",
+    "cellRef": "A149"
   },
   {
     "Department": "bbmp_wards",
@@ -2083,7 +2231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜರಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್"
+    "NameKN": "ನಾಗೇಶ್",
+    "cellRef": "A150"
   },
   {
     "Department": "bbmp_wards",
@@ -2097,7 +2246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಚಾಮರಾಜೇಂದ್ರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಷ್ಣುಕಾಂತ್"
+    "NameKN": "ವಿಷ್ಣುಕಾಂತ್",
+    "cellRef": "A151"
   },
   {
     "Department": "bbmp_wards",
@@ -2111,7 +2261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪೂರ್ವ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಚಿಕೇತ್"
+    "NameKN": "ನಚಿಕೇತ್",
+    "cellRef": "A152"
   },
   {
     "Department": "bbmp_wards",
@@ -2125,7 +2276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನಭೀಮ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ"
+    "NameKN": "ಶಿವಶಂಕರ",
+    "cellRef": "A153"
   },
   {
     "Department": "bbmp_wards",
@@ -2139,7 +2291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜ್ಞಾನ ಭಾರತಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರನಾರಾಯಣ್"
+    "NameKN": "ವರನಾರಾಯಣ",
+    "cellRef": "A154"
   },
   {
     "Department": "bbmp_wards",
@@ -2153,7 +2306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೋಗುಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಧನ್ಯ ಕುಮಾರ್"
+    "NameKN": "ಡಾ.ಧನ್ಯ ಕುಮಾರ್",
+    "cellRef": "A155"
   },
   {
     "Department": "bbmp_wards",
@@ -2167,7 +2321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿಲ್ಪಾ"
+    "NameKN": "ಶಿಲ್ಪಾ",
+    "cellRef": "A156"
   },
   {
     "Department": "bbmp_wards",
@@ -2181,7 +2336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್"
+    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್",
+    "cellRef": "A157"
   },
   {
     "Department": "bbmp_wards",
@@ -2195,7 +2351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ",
+    "cellRef": "A158"
   },
   {
     "Department": "bbmp_wards",
@@ -2209,7 +2366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ"
+    "NameKN": "ಮಮತಾ",
+    "cellRef": "A159"
   },
   {
     "Department": "bbmp_wards",
@@ -2223,7 +2381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡು ಮಲ್ಲೇಶ್ವರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹರ್ಷ ನಾಯಕ್"
+    "NameKN": "ಹರ್ಷ ನಾಯಕ್",
+    "cellRef": "A160"
   },
   {
     "Department": "bbmp_wards",
@@ -2237,7 +2396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉದಯ್ ಚೌಗಲೆ"
+    "NameKN": "ಉದಯ್ ಚೌಗಲೆ",
+    "cellRef": "A161"
   },
   {
     "Department": "bbmp_wards",
@@ -2251,7 +2411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ",
+    "cellRef": "A162"
   },
   {
     "Department": "bbmp_wards",
@@ -2265,7 +2426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಗ್ಗದಾಸನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ"
+    "NameKN": "ಮಂಜುಳಾ",
+    "cellRef": "A163"
   },
   {
     "Department": "bbmp_wards",
@@ -2279,7 +2441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಳೇನ ಅಗ್ರಹಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A164"
   },
   {
     "Department": "bbmp_wards",
@@ -2293,7 +2456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ"
+    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ",
+    "cellRef": "A165"
   },
   {
     "Department": "bbmp_wards",
@@ -2307,7 +2471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಸವರಾಜ"
+    "NameKN": "ಬಸವರಾಜ",
+    "cellRef": "A166"
   },
   {
     "Department": "bbmp_wards",
@@ -2321,7 +2486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮ್ಮಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ್"
+    "NameKN": "ಡಾ.ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ",
+    "cellRef": "A167"
   },
   {
     "Department": "bbmp_wards",
@@ -2335,7 +2501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಕುಮಾರ್"
+    "NameKN": "ವಿಜಯಕುಮಾರ್",
+    "cellRef": "A168"
   },
   {
     "Department": "bbmp_wards",
@@ -2349,7 +2516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ದೇವಿಕಾ ರಾಣಿ "
+    "NameKN": "ದೇವಿಕಾ ರಾಣಿ ಡಾ",
+    "cellRef": "A169"
   },
   {
     "Department": "bbmp_wards",
@@ -2363,7 +2531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ"
+    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ",
+    "cellRef": "A170"
   },
   {
     "Department": "bbmp_wards",
@@ -2377,7 +2546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾವೇರಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೆಂಕಟೇಶ್",
+    "cellRef": "A171"
   },
   {
     "Department": "bbmp_wards",
@@ -2391,7 +2561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫರ್ಜಾನಾ"
+    "NameKN": "ಫರ್ಜಾನಾ",
+    "cellRef": "A172"
   },
   {
     "Department": "bbmp_wards",
@@ -2405,7 +2576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪೇಗೌಡ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ"
+    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ",
+    "cellRef": "A173"
   },
   {
     "Department": "bbmp_wards",
@@ -2419,7 +2591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ"
+    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ",
+    "cellRef": "A174"
   },
   {
     "Department": "bbmp_wards",
@@ -2433,7 +2606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A175"
   },
   {
     "Department": "bbmp_wards",
@@ -2447,7 +2621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್"
+    "NameKN": "ಪ್ರದೀಪ್",
+    "cellRef": "A176"
   },
   {
     "Department": "bbmp_wards",
@@ -2461,7 +2636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಗಿಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್"
+    "NameKN": "ರಂಗನಾಥ್",
+    "cellRef": "A177"
   },
   {
     "Department": "bbmp_wards",
@@ -2475,7 +2651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಣನಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಮ್"
+    "NameKN": "ಜಯರಾಮ್",
+    "cellRef": "A178"
   },
   {
     "Department": "bbmp_wards",
@@ -2489,7 +2666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊನೆನ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ"
+    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ",
+    "cellRef": "A179"
   },
   {
     "Department": "bbmp_wards",
@@ -2503,7 +2681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A180"
   },
   {
     "Department": "bbmp_wards",
@@ -2517,7 +2696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಟ್ಟಿಗೆಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ"
+    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ",
+    "cellRef": "A181"
   },
   {
     "Department": "bbmp_wards",
@@ -2531,7 +2711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೂಡ್ಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A182"
   },
   {
     "Department": "bbmp_wards",
@@ -2545,7 +2726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
+    "cellRef": "A183"
   },
   {
     "Department": "bbmp_wards",
@@ -2559,7 +2741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಶಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ"
+    "NameKN": "ಡಾ.ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ",
+    "cellRef": "A184"
   },
   {
     "Department": "bbmp_wards",
@@ -2573,7 +2756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುವೆಂಪು ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ. ಧಾರೇಶ್ವರ್"
+    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ ಧಾರೇಶ್ವರ",
+    "cellRef": "A185"
   },
   {
     "Department": "bbmp_wards",
@@ -2587,7 +2771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ"
+    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ",
+    "cellRef": "A186"
   },
   {
     "Department": "bbmp_wards",
@@ -2601,7 +2786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್"
+    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್",
+    "cellRef": "A187"
   },
   {
     "Department": "bbmp_wards",
@@ -2615,7 +2801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಷ್ಮೀದೇವಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್"
+    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್",
+    "cellRef": "A188"
   },
   {
     "Department": "bbmp_wards",
@@ -2629,7 +2816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗಧೀರನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A189"
   },
   {
     "Department": "bbmp_wards",
@@ -2643,7 +2831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A190"
   },
   {
     "Department": "bbmp_wards",
@@ -2657,7 +2846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾಂತೇಶ್"
+    "NameKN": "ಮಹಾಂತೇಶ",
+    "cellRef": "A191"
   },
   {
     "Department": "bbmp_wards",
@@ -2671,7 +2861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮೀಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್"
+    "NameKN": "ನಾಗೇಶ್",
+    "cellRef": "A192"
   },
   {
     "Department": "bbmp_wards",
@@ -2685,7 +2876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳತಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕುಮಾರ್"
+    "NameKN": "ಶಶಿಕುಮಾರ್",
+    "cellRef": "A193"
   },
   {
     "Department": "bbmp_wards",
@@ -2699,7 +2891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೀಮಾ ನಾಯಕ್"
+    "NameKN": "ಭೀಮಾ ನಾಯಕ್",
+    "cellRef": "A194"
   },
   {
     "Department": "bbmp_wards",
@@ -2713,7 +2906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ"
+    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ",
+    "cellRef": "A195"
   },
   {
     "Department": "bbmp_wards",
@@ -2727,7 +2921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಮ್ಮನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಗೋಪಾಲ್"
+    "NameKN": "ರಾಜಗೋಪಾಲ್",
+    "cellRef": "A196"
   },
   {
     "Department": "bbmp_wards",
@@ -2741,7 +2936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮನೋರಾಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A197"
   },
   {
     "Department": "bbmp_wards",
@@ -2755,7 +2951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರತ್ತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರಾಕೇಶ್"
+    "NameKN": "ಡಾ.ರಾಕೇಶ್",
+    "cellRef": "A198"
   },
   {
     "Department": "bbmp_wards",
@@ -2769,7 +2966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ"
+    "NameKN": "ಡಾ.ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ",
+    "cellRef": "A199"
   },
   {
     "Department": "bbmp_wards",
@@ -2783,7 +2981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ"
+    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ",
+    "cellRef": "A200"
   },
   {
     "Department": "bbmp_wards",
@@ -2797,7 +2996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಸೇವಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣ ಗೌಡ"
+    "NameKN": "ಕೃಷ್ಣ ಗೌಡ",
+    "cellRef": "A201"
   },
   {
     "Department": "bbmp_wards",
@@ -2811,7 +3011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿರ್ಮಲಾ"
+    "NameKN": "ನಿರ್ಮಲಾ",
+    "cellRef": "A202"
   },
   {
     "Department": "bbmp_wards",
@@ -2825,7 +3026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್"
+    "NameKN": "ಸೋಮಶೇಖರ್",
+    "cellRef": "A203"
   },
   {
     "Department": "bbmp_wards",
@@ -2839,7 +3041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುನೆಕೊಳ್ಳಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ"
+    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ",
+    "cellRef": "A204"
   },
   {
     "Department": "bbmp_wards",
@@ -2853,7 +3056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುನೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೇವರಾಜ್ಯ"
+    "NameKN": "ದೇವರಾಜ್ಯ",
+    "cellRef": "A205"
   },
   {
     "Department": "bbmp_wards",
@@ -2867,7 +3071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಮಂದಯ್ಯ"
+    "NameKN": "ಸಮಂದಯ್ಯ",
+    "cellRef": "A206"
   },
   {
     "Department": "bbmp_wards",
@@ -2881,7 +3086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇವನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A207"
   },
   {
     "Department": "bbmp_wards",
@@ -2895,7 +3101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗನಾಥಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A208"
   },
   {
     "Department": "bbmp_wards",
@@ -2909,7 +3116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ"
+    "NameKN": "ಮಂಜುಳಾ",
+    "cellRef": "A209"
   },
   {
     "Department": "bbmp_wards",
@@ -2923,7 +3131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚರಣ್ ರಾಜ್"
+    "NameKN": "ಚರಣ್ ರಾಜ್",
+    "cellRef": "A210"
   },
   {
     "Department": "bbmp_wards",
@@ -2937,7 +3146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗವಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅತೀಫ್ ಅಹಮದ್"
+    "NameKN": "ಅತೀಫ್ ಅಹಮದ್",
+    "cellRef": "A211"
   },
   {
     "Department": "bbmp_wards",
@@ -2951,7 +3161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಲಗದರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗಭೂಷಣ"
+    "NameKN": "ನಾಗಭೂಷಣ",
+    "cellRef": "A212"
   },
   {
     "Department": "bbmp_wards",
@@ -2965,7 +3176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಲ್ವಡಿ ಕೃಷ್ಣರಾಜ ಒಡೆಯರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್"
+    "NameKN": "ಸುರೇಶ್",
+    "cellRef": "A213"
   },
   {
     "Department": "bbmp_wards",
@@ -2979,7 +3191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಯಂಡಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ"
+    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ",
+    "cellRef": "A214"
   },
   {
     "Department": "bbmp_wards",
@@ -2993,7 +3206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ಗುಡ್ಡದಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್"
+    "NameKN": "ಸಂತೋಷ್",
+    "cellRef": "A215"
   },
   {
     "Department": "bbmp_wards",
@@ -3007,7 +3221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ತಿಪ್ಪಸಂದರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ"
+    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ",
+    "cellRef": "A216"
   },
   {
     "Department": "bbmp_wards",
@@ -3021,7 +3236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೀಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿರೆಡ್ಡಿ"
+    "NameKN": "ಮುನಿರೆಡ್ಡಿ",
+    "cellRef": "A217"
   },
   {
     "Department": "bbmp_wards",
@@ -3035,7 +3251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಓಕಳಿಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A218"
   },
   {
     "Department": "bbmp_wards",
@@ -3049,7 +3266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾದರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆಯಿಷಾ"
+    "NameKN": "ಆಯಿಷಾ",
+    "cellRef": "A219"
   },
   {
     "Department": "bbmp_wards",
@@ -3063,7 +3281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪದ್ಮನಾಭ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೀಪಶ್ರೀ"
+    "NameKN": "ದೀಪಶ್ರೀ",
+    "cellRef": "A220"
   },
   {
     "Department": "bbmp_wards",
@@ -3077,7 +3296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್"
+    "NameKN": "ಸುರೇಶ್",
+    "cellRef": "A221"
   },
   {
     "Department": "bbmp_wards",
@@ -3091,7 +3311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಕೈಗಾರಿಕಾ ಪ್ರದೇಶ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್"
+    "NameKN": "ಜಯಶಂಕರ್",
+    "cellRef": "A222"
   },
   {
     "Department": "bbmp_wards",
@@ -3105,7 +3326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಿಕೇಶಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೆಂಕಟೇಶ್",
+    "cellRef": "A223"
   },
   {
     "Department": "bbmp_wards",
@@ -3119,7 +3341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಟ್ಟೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ"
+    "NameKN": "ರವಿ",
+    "cellRef": "A224"
   },
   {
     "Department": "bbmp_wards",
@@ -3133,7 +3356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಧಾಕೃಷ್ಣ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪದ್ಮರಾಜ್"
+    "NameKN": "ಪದ್ಮರಾಜ್",
+    "cellRef": "A225"
   },
   {
     "Department": "bbmp_wards",
@@ -3147,7 +3371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಗೋಪಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ"
+    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ",
+    "cellRef": "A226"
   },
   {
     "Department": "bbmp_wards",
@@ -3161,7 +3386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗಂಗಾಧರ್"
+    "NameKN": "ಗಂಗಾಧರ್",
+    "cellRef": "A227"
   },
   {
     "Department": "bbmp_wards",
@@ -3175,7 +3401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಮಹಲ್ ಗುಟ್ಟಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುಹಮ್ಮದ್ ಹಾಲಿ ಪಿಂಚಾರ್"
+    "NameKN": "ಮುಹಮ್ಮದ್ ಹಳ್ಳಿ ಪಿಂಚಾರ್",
+    "cellRef": "A228"
   },
   {
     "Department": "bbmp_wards",
@@ -3189,7 +3416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ"
+    "NameKN": "ಶಂಕರಪ್ಪ",
+    "cellRef": "A229"
   },
   {
     "Department": "bbmp_wards",
@@ -3203,7 +3431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜೀವ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್"
+    "NameKN": "ರಂಗನಾಥ್",
+    "cellRef": "A230"
   },
   {
     "Department": "bbmp_wards",
@@ -3217,7 +3446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ"
+    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ",
+    "cellRef": "A231"
   },
   {
     "Department": "bbmp_wards",
@@ -3231,7 +3461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಸ್ವಾಮಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್",
+    "cellRef": "A232"
   },
   {
     "Department": "bbmp_wards",
@@ -3245,7 +3476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್"
+    "NameKN": "ಉಮೇಶ್",
+    "cellRef": "A233"
   },
   {
     "Department": "bbmp_wards",
@@ -3259,7 +3491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "RBI ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A234"
   },
   {
     "Department": "bbmp_wards",
@@ -3273,7 +3506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ ಕೆ ಗಾರ್ಡನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿವಡ್ಡರ್"
+    "NameKN": "ರವಿವಡ್ಡರ್",
+    "cellRef": "A235"
   },
   {
     "Department": "bbmp_wards",
@@ -3287,7 +3521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಗಾಯರಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ"
+    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ",
+    "cellRef": "A236"
   },
   {
     "Department": "bbmp_wards",
@@ -3301,7 +3536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಂಗಿರಾಮ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A237"
   },
   {
     "Department": "bbmp_wards",
@@ -3315,7 +3551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಾಧವ್ ರಾವ್"
+    "NameKN": "ಮಾಧವ್ ರಾವ್",
+    "cellRef": "A238"
   },
   {
     "Department": "bbmp_wards",
@@ -3329,7 +3566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾರಕ್ಕಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್"
+    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್",
+    "cellRef": "A239"
   },
   {
     "Department": "bbmp_wards",
@@ -3343,7 +3581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಕಾಂಬರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಖಾ"
+    "NameKN": "ರೇಖಾ",
+    "cellRef": "A240"
   },
   {
     "Department": "bbmp_wards",
@@ -3357,7 +3596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಕ್ತಿ ಗಣಪತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಧು"
+    "NameKN": "ಮಧು",
+    "cellRef": "A241"
   },
   {
     "Department": "bbmp_wards",
@@ -3371,7 +3611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರ್ ಮಟ್ಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್",
+    "cellRef": "A242"
   },
   {
     "Department": "bbmp_wards",
@@ -3385,7 +3626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್"
+    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್",
+    "cellRef": "A243"
   },
   {
     "Department": "bbmp_wards",
@@ -3399,7 +3641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಯಶೋವರ್ದನ್"
+    "NameKN": "ಯಶೋವರ್ದನ್ ಡಾ",
+    "cellRef": "A244"
   },
   {
     "Department": "bbmp_wards",
@@ -3413,7 +3656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮದಾಸ್"
+    "NameKN": "ರಾಮದಾಸ್",
+    "cellRef": "A245"
   },
   {
     "Department": "bbmp_wards",
@@ -3427,7 +3671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಲ್ವರ್ ಜೂಬ್ಲಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
+    "cellRef": "A246"
   },
   {
     "Department": "bbmp_wards",
@@ -3441,7 +3686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಮೇಶ್ವರ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ"
+    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ",
+    "cellRef": "A247"
   },
   {
     "Department": "bbmp_wards",
@@ -3455,7 +3701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀಗಂಧದಕಾವಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಘವೇಂದ್ರ"
+    "NameKN": "ರಾಘವೇಂದ್ರ",
+    "cellRef": "A248"
   },
   {
     "Department": "bbmp_wards",
@@ -3469,7 +3716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಣ್ಣ"
+    "NameKN": "ಶಿವಣ್ಣ",
+    "cellRef": "A249"
   },
   {
     "Department": "bbmp_wards",
@@ -3483,7 +3731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಮಮಂದಿರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಲಾ"
+    "NameKN": "ಶಾಂತಲಾ",
+    "cellRef": "A250"
   },
   {
     "Department": "bbmp_wards",
@@ -3497,7 +3746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ಬಯ್ಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ"
+    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ",
+    "cellRef": "A251"
   },
   {
     "Department": "bbmp_wards",
@@ -3511,7 +3761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಭಾಷ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್"
+    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್",
+    "cellRef": "A252"
   },
   {
     "Department": "bbmp_wards",
@@ -3525,7 +3776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A253"
   },
   {
     "Department": "bbmp_wards",
@@ -3539,7 +3791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮನೋಹರ್"
+    "NameKN": "ಮನೋಹರ್",
+    "cellRef": "A254"
   },
   {
     "Department": "bbmp_wards",
@@ -3553,7 +3806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುದ್ದಗುಂಟೆ ಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್"
+    "NameKN": "ವಿಶ್ವನಾಥ್",
+    "cellRef": "A255"
   },
   {
     "Department": "bbmp_wards",
@@ -3567,7 +3821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
+    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ",
+    "cellRef": "A256"
   },
   {
     "Department": "bbmp_wards",
@@ -3581,7 +3836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಂಕೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಕೋಮಲ್ ಕೆ.ಆರ್"
+    "NameKN": "ಡಾ.ಕೋಮಲ್ ಕೆ.ಆರ್",
+    "cellRef": "A257"
   },
   {
     "Department": "bbmp_wards",
@@ -3595,7 +3851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸ್ವಾಮಿ ವಿವೇಕಾನಂದ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಗೌಡ"
+    "NameKN": "ಚನ್ನಗೌಡ",
+    "cellRef": "A258"
   },
   {
     "Department": "bbmp_wards",
@@ -3609,7 +3866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್"
+    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್",
+    "cellRef": "A259"
   },
   {
     "Department": "bbmp_wards",
@@ -3623,7 +3881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಥಣಿಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾದೇವ"
+    "NameKN": "ಮಹಾದೇವ",
+    "cellRef": "A260"
   },
   {
     "Department": "bbmp_wards",
@@ -3637,7 +3896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಲ್ಲಾಳು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಾಮರಾಜು"
+    "NameKN": "ಚಾಮರಾಜು",
+    "cellRef": "A261"
   },
   {
     "Department": "bbmp_wards",
@@ -3651,7 +3911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪರ್ಣಾ"
+    "NameKN": "ಅಪರ್ಣಾ",
+    "cellRef": "A262"
   },
   {
     "Department": "bbmp_wards",
@@ -3665,7 +3926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೋಹಿತ್"
+    "NameKN": "ರೋಹಿತ್",
+    "cellRef": "A263"
   },
   {
     "Department": "bbmp_wards",
@@ -3679,7 +3941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವನ್ನಾರಪೇಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್"
+    "NameKN": "ರಮೇಶ್",
+    "cellRef": "A264"
   },
   {
     "Department": "bbmp_wards",
@@ -3693,7 +3956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಜ್"
+    "NameKN": "ಜಯರಾಜ್",
+    "cellRef": "A265"
   },
   {
     "Department": "bbmp_wards",
@@ -3707,7 +3971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಪ್ಪ"
+    "NameKN": "ಕೃಷ್ಣಪ್ಪ",
+    "cellRef": "A266"
   },
   {
     "Department": "bbmp_wards",
@@ -3721,7 +3986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಣ್ಣ"
+    "NameKN": "ರಾಜಣ್ಣ",
+    "cellRef": "A267"
   },
   {
     "Department": "bbmp_wards",
@@ -3735,7 +4001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾಪೀಠ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಟರಾಜ್"
+    "NameKN": "ನಟರಾಜ್",
+    "cellRef": "A268"
   },
   {
     "Department": "bbmp_wards",
@@ -3749,7 +4016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A269"
   },
   {
     "Department": "bbmp_wards",
@@ -3763,7 +4031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್"
+    "NameKN": "ಜಯಶಂಕರ್",
+    "cellRef": "A270"
   },
   {
     "Department": "bbmp_wards",
@@ -3777,7 +4046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಿನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಶೀಲಾ ಎನ್."
+    "NameKN": "ಸುಶೀಲಾ ಎನ್",
+    "cellRef": "A271"
   },
   {
     "Department": "bbmp_wards",
@@ -3791,7 +4061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್ ಕುಮಾರ್"
+    "NameKN": "ಶರತ್ ಕುಮಾರ್",
+    "cellRef": "A272"
   },
   {
     "Department": "bbmp_wards",
@@ -3805,7 +4076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವೇಶ್ವರ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್"
+    "NameKN": "ಡಾ.ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್",
+    "cellRef": "A273"
   },
   {
     "Department": "bbmp_wards",
@@ -3819,7 +4091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವನಾಥ ನಾಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರುದ್ರಮುನಿ"
+    "NameKN": "ರುದ್ರಮುನಿ",
+    "cellRef": "A274"
   },
   {
     "Department": "bbmp_wards",
@@ -3833,7 +4106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೃಷಭಾವತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್",
+    "cellRef": "A275"
   },
   {
     "Department": "bbmp_wards",
@@ -3847,7 +4121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್ ಫೀಲ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರುರಾಜ್"
+    "NameKN": "ಗುರುರಾಜ್",
+    "cellRef": "A276"
   },
   {
     "Department": "bbmp_wards",
@@ -3861,7 +4136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಡಿಯೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸನ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸನ್",
+    "cellRef": "A277"
   },
   {
     "Department": "bbmp_wards",
@@ -3875,7 +4151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ"
+    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ",
+    "cellRef": "A278"
   },
   {
     "Department": "bbmp_wards",
@@ -3889,7 +4166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯೆಲ್ಚೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಪ್ರಕಾಶ್"
+    "NameKN": "ಜಯಪ್ರಕಾಶ್",
+    "cellRef": "A279"
   },
   {
     "Department": "bbmp_wards",
@@ -3903,7 +4181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗೀತಾ"
+    "NameKN": "ಗೀತಾ",
+    "cellRef": "A280"
   },
   {
     "Department": "bbmp_zone",
@@ -3917,7 +4196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ರಮ್ಯಾ ಎಸ್."
+    "NameKN": "ರಮ್ಯಾ ಎಸ್",
+    "cellRef": "A281"
   },
   {
     "Department": "bbmp_zone",
@@ -3931,7 +4211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಹೆಚ್ .ಸಿ. ಗಿರೀಶ್"
+    "NameKN": "ಹೆಚ್ ಸಿ ಗಿರೀಶ್",
+    "cellRef": "A282"
   },
   {
     "Department": "bbmp_zone",
@@ -3945,7 +4226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್."
+    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್",
+    "cellRef": "A283"
   },
   {
     "Department": "bbmp_zone",
@@ -3959,7 +4241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕೆ.ಎನ್. ರಮೇಶ್"
+    "NameKN": "ಕೆ ಎನ್ ರಮೇಶ್",
+    "cellRef": "A284"
   },
   {
     "Department": "bbmp_zone",
@@ -3973,7 +4256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸತೀಶ ಬಿ.ಸಿ"
+    "NameKN": "ಸತೀಶ ಬಿ ಸಿ",
+    "cellRef": "A285"
   },
   {
     "Department": "bbmp_zone",
@@ -3987,7 +4271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್"
+    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್",
+    "cellRef": "A286"
   },
   {
     "Department": "bbmp_zone",
@@ -4001,7 +4286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಅರ್ಚನಾ ಎಂ.ಎಸ್"
+    "NameKN": "ಅರ್ಚನಾ ಎಂ ಎಸ್",
+    "cellRef": "A287"
   },
   {
     "Department": "bbmp_zone",
@@ -4015,7 +4301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕರೀಗೌಡ"
+    "NameKN": "ಕರೀಗೌಡ",
+    "cellRef": "A288"
   },
   {
     "Department": "bescom_division",
@@ -4029,7 +4316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A289"
   },
   {
     "Department": "bescom_division",
@@ -4043,7 +4331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A290"
   },
   {
     "Department": "bescom_division",
@@ -4057,7 +4346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A291"
   },
   {
     "Department": "bescom_division",
@@ -4071,7 +4361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A292"
   },
   {
     "Department": "bescom_division",
@@ -4085,7 +4376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A293"
   },
   {
     "Department": "bescom_division",
@@ -4099,7 +4391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A294"
   },
   {
     "Department": "bescom_division",
@@ -4113,7 +4406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A295"
   },
   {
     "Department": "bescom_division",
@@ -4127,7 +4421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A296"
   },
   {
     "Department": "bescom_division",
@@ -4141,7 +4436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A297"
   },
   {
     "Department": "bescom_division",
@@ -4155,7 +4451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A298"
   },
   {
     "Department": "bescom_division",
@@ -4169,7 +4466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A299"
   },
   {
     "Department": "bescom_division",
@@ -4183,7 +4481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A300"
   },
   {
     "Department": "bescom_division",
@@ -4197,7 +4496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A301"
   },
   {
     "Department": "bescom_division",
@@ -4211,7 +4511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A302"
   },
   {
     "Department": "bescom_division",
@@ -4225,7 +4526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A303"
   },
   {
     "Department": "bescom_division",
@@ -4239,7 +4541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A304"
   },
   {
     "Department": "bescom_division",
@@ -4253,7 +4556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A305"
   },
   {
     "Department": "bescom_division",
@@ -4267,7 +4571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A306"
   },
   {
     "Department": "bescom_division",
@@ -4281,7 +4586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A307"
   },
   {
     "Department": "bescom_division",
@@ -4295,7 +4601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A308"
   },
   {
     "Department": "bescom_division",
@@ -4309,7 +4616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A309"
   },
   {
     "Department": "bescom_division",
@@ -4323,7 +4631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A310"
   },
   {
     "Department": "bescom_division",
@@ -4337,7 +4646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A311"
   },
   {
     "Department": "bescom_division",
@@ -4351,7 +4661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನ ಸೌಧ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A312"
   },
   {
     "Department": "bescom_division",
@@ -4365,7 +4676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A313"
   },
   {
     "Department": "bescom_division",
@@ -4379,7 +4691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A314"
   },
   {
     "Department": "bescom_subdivision",
@@ -4393,7 +4706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A315"
   },
   {
     "Department": "bescom_subdivision",
@@ -4407,7 +4721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A316"
   },
   {
     "Department": "bescom_subdivision",
@@ -4421,7 +4736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ1 ರಾಜಾಜಿನಗರ 2ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A317"
   },
   {
     "Department": "bescom_subdivision",
@@ -4435,7 +4751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C2 ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A318"
   },
   {
     "Department": "bescom_subdivision",
@@ -4449,7 +4766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C3 ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A319"
   },
   {
     "Department": "bescom_subdivision",
@@ -4463,7 +4781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C4 ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A320"
   },
   {
     "Department": "bescom_subdivision",
@@ -4477,7 +4796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C5 ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A321"
   },
   {
     "Department": "bescom_subdivision",
@@ -4491,7 +4811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ6 ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A322"
   },
   {
     "Department": "bescom_subdivision",
@@ -4505,7 +4826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ7 ಯಲಹಂಕ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A323"
   },
   {
     "Department": "bescom_subdivision",
@@ -4519,7 +4841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "C8 ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A324"
   },
   {
     "Department": "bescom_subdivision",
@@ -4533,7 +4856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ9 ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A325"
   },
   {
     "Department": "bescom_subdivision",
@@ -4547,7 +4871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A326"
   },
   {
     "Department": "bescom_subdivision",
@@ -4561,7 +4886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A327"
   },
   {
     "Department": "bescom_subdivision",
@@ -4575,7 +4901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A328"
   },
   {
     "Department": "bescom_subdivision",
@@ -4589,7 +4916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A329"
   },
   {
     "Department": "bescom_subdivision",
@@ -4603,7 +4931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ1 ಪಿಳ್ಳಣ್ಣ ಗಾರ್ಡನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A330"
   },
   {
     "Department": "bescom_subdivision",
@@ -4617,7 +4946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ10 ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A331"
   },
   {
     "Department": "bescom_subdivision",
@@ -4631,7 +4961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 11 ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A332"
   },
   {
     "Department": "bescom_subdivision",
@@ -4645,7 +4976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 12 ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A333"
   },
   {
     "Department": "bescom_subdivision",
@@ -4659,7 +4991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ2 ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A334"
   },
   {
     "Department": "bescom_subdivision",
@@ -4673,7 +5006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E3 MG ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A335"
   },
   {
     "Department": "bescom_subdivision",
@@ -4687,7 +5021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E4 ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A336"
   },
   {
     "Department": "bescom_subdivision",
@@ -4701,7 +5036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E5 ಕುಕ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A337"
   },
   {
     "Department": "bescom_subdivision",
@@ -4715,7 +5051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ6 ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A338"
   },
   {
     "Department": "bescom_subdivision",
@@ -4729,7 +5066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E7 ದೂರವಾಣಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A339"
   },
   {
     "Department": "bescom_subdivision",
@@ -4743,7 +5081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E8 ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A340"
   },
   {
     "Department": "bescom_subdivision",
@@ -4757,7 +5096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "E9 ನಾಗವಾರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A341"
   },
   {
     "Department": "bescom_subdivision",
@@ -4771,7 +5111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A342"
   },
   {
     "Department": "bescom_subdivision",
@@ -4785,7 +5126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A343"
   },
   {
     "Department": "bescom_subdivision",
@@ -4799,7 +5141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 1 ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A344"
   },
   {
     "Department": "bescom_subdivision",
@@ -4813,7 +5156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 2 ಅಂಜನನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A345"
   },
   {
     "Department": "bescom_subdivision",
@@ -4827,7 +5171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 3 ಕಗ್ಗಲಿಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A346"
   },
   {
     "Department": "bescom_subdivision",
@@ -4841,7 +5186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "K4 RR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A347"
   },
   {
     "Department": "bescom_subdivision",
@@ -4855,7 +5201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A348"
   },
   {
     "Department": "bescom_subdivision",
@@ -4869,7 +5216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A349"
   },
   {
     "Department": "bescom_subdivision",
@@ -4883,7 +5231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A350"
   },
   {
     "Department": "bescom_subdivision",
@@ -4897,7 +5246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A351"
   },
   {
     "Department": "bescom_subdivision",
@@ -4911,7 +5261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A352"
   },
   {
     "Department": "bescom_subdivision",
@@ -4925,7 +5276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N1 ವೆಸ್ಟ್ ಕಾರ್ಡ್ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A353"
   },
   {
     "Department": "bescom_subdivision",
@@ -4939,7 +5291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N10 ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A354"
   },
   {
     "Department": "bescom_subdivision",
@@ -4953,7 +5306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N2 KHB ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A355"
   },
   {
     "Department": "bescom_subdivision",
@@ -4967,7 +5321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 3 ಬಸವೇಶ್ವರನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A356"
   },
   {
     "Department": "bescom_subdivision",
@@ -4981,7 +5336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N4 ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A357"
   },
   {
     "Department": "bescom_subdivision",
@@ -4995,7 +5351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N5 SRS ಗೇಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A358"
   },
   {
     "Department": "bescom_subdivision",
@@ -5009,7 +5366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N6 ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A359"
   },
   {
     "Department": "bescom_subdivision",
@@ -5023,7 +5381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N7 ಕುರುಬರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A360"
   },
   {
     "Department": "bescom_subdivision",
@@ -5037,7 +5396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 8 ಉಳ್ಳಾಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A361"
   },
   {
     "Department": "bescom_subdivision",
@@ -5051,7 +5411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "N9 ಸೋಲದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A362"
   },
   {
     "Department": "bescom_subdivision",
@@ -5065,7 +5426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A363"
   },
   {
     "Department": "bescom_subdivision",
@@ -5079,7 +5441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 1 ಜಯನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A364"
   },
   {
     "Department": "bescom_subdivision",
@@ -5093,7 +5456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 10 ಬನ್ನೇರುಘಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A365"
   },
   {
     "Department": "bescom_subdivision",
@@ -5107,7 +5471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S11 HSR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A366"
   },
   {
     "Department": "bescom_subdivision",
@@ -5121,7 +5486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 12 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A367"
   },
   {
     "Department": "bescom_subdivision",
@@ -5135,7 +5501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 13 ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A368"
   },
   {
     "Department": "bescom_subdivision",
@@ -5149,7 +5516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 14 ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A369"
   },
   {
     "Department": "bescom_subdivision",
@@ -5163,7 +5531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 15 ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A370"
   },
   {
     "Department": "bescom_subdivision",
@@ -5177,7 +5546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S16 ಮಡಿವಾಳ SDO",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A371"
   },
   {
     "Department": "bescom_subdivision",
@@ -5191,7 +5561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S17 HAL",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A372"
   },
   {
     "Department": "bescom_subdivision",
@@ -5205,7 +5576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S18 ಚಿಕ್ಕ ಕಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A373"
   },
   {
     "Department": "bescom_subdivision",
@@ -5219,7 +5591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 19 ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A374"
   },
   {
     "Department": "bescom_subdivision",
@@ -5233,7 +5606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 2 ವಿಲ್ಸ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A375"
   },
   {
     "Department": "bescom_subdivision",
@@ -5247,7 +5621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷ್೨೦ ಆಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A376"
   },
   {
     "Department": "bescom_subdivision",
@@ -5261,7 +5636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S3 ಆಸ್ಟಿನ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A377"
   },
   {
     "Department": "bescom_subdivision",
@@ -5275,7 +5651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S4 ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A378"
   },
   {
     "Department": "bescom_subdivision",
@@ -5289,7 +5666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S5 ISRO ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A379"
   },
   {
     "Department": "bescom_subdivision",
@@ -5303,7 +5681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 6 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A380"
   },
   {
     "Department": "bescom_subdivision",
@@ -5317,7 +5696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್7 ಮುರುಗೇಶಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A381"
   },
   {
     "Department": "bescom_subdivision",
@@ -5331,7 +5711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 8 ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A382"
   },
   {
     "Department": "bescom_subdivision",
@@ -5345,7 +5726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "S9 ಬನಶಂಕರಿ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A383"
   },
   {
     "Department": "bescom_subdivision",
@@ -5359,7 +5741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A384"
   },
   {
     "Department": "bescom_subdivision",
@@ -5373,7 +5756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ1",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A385"
   },
   {
     "Department": "bescom_subdivision",
@@ -5387,7 +5771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ2",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A386"
   },
   {
     "Department": "bescom_subdivision",
@@ -5401,7 +5786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ3 (ಕ್ಯಾತ್ಸಂದ್ರ)",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A387"
   },
   {
     "Department": "bescom_subdivision",
@@ -5415,7 +5801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W1 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A388"
   },
   {
     "Department": "bescom_subdivision",
@@ -5429,7 +5816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W2 ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A389"
   },
   {
     "Department": "bescom_subdivision",
@@ -5443,7 +5831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W3 ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A390"
   },
   {
     "Department": "bescom_subdivision",
@@ -5457,7 +5846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W4 AR ವೃತ್ತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A391"
   },
   {
     "Department": "bescom_subdivision",
@@ -5471,7 +5861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W5 ಕಬ್ಬನ್‌ಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A392"
   },
   {
     "Department": "bescom_subdivision",
@@ -5485,7 +5876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W6 ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A393"
   },
   {
     "Department": "bescom_subdivision",
@@ -5499,7 +5891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W7 ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A394"
   },
   {
     "Department": "bescom_subdivision",
@@ -5513,7 +5906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "W8 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A395"
   },
   {
     "Department": "bwssb_division",
@@ -5527,7 +5921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇಂದ್ರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ"
+    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ",
+    "cellRef": "A396"
   },
   {
     "Department": "bwssb_division",
@@ -5541,7 +5936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್"
+    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್",
+    "cellRef": "A397"
   },
   {
     "Department": "bwssb_division",
@@ -5555,7 +5951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಜಯಪ್ರಕಾಶ್"
+    "NameKN": "ಜಯಪ್ರಕಾಶ್",
+    "cellRef": "A398"
   },
   {
     "Department": "bwssb_division",
@@ -5569,7 +5966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಈಶಾನ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ"
+    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ",
+    "cellRef": "A399"
   },
   {
     "Department": "bwssb_division",
@@ -5583,7 +5981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A400"
   },
   {
     "Department": "bwssb_division",
@@ -5597,7 +5996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A401"
   },
   {
     "Department": "bwssb_division",
@@ -5611,7 +6011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A402"
   },
   {
     "Department": "bwssb_division",
@@ -5625,7 +6026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಹರಿನಾಥ್ ಆರ್"
+    "NameKN": "ಹರಿನಾಥ್ ಆರ್",
+    "cellRef": "A403"
   },
   {
     "Department": "bwssb_division",
@@ -5639,7 +6041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್"
+    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್",
+    "cellRef": "A404"
   },
   {
     "Department": "bwssb_division",
@@ -5653,7 +6056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್."
+    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್",
+    "cellRef": "A405"
   },
   {
     "Department": "bwssb_division",
@@ -5667,7 +6071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A406"
   },
   {
     "Department": "bwssb_division",
@@ -5681,7 +6086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗರಾಜ್ ಕೆ."
+    "NameKN": "ನಾಗರಾಜ್ ಕೆ",
+    "cellRef": "A407"
   },
   {
     "Department": "bwssb_division",
@@ -5695,7 +6101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಬಸವರಾಜ ಎನ್."
+    "NameKN": "ಬಸವರಾಜ ಎನ್",
+    "cellRef": "A408"
   },
   {
     "Department": "bwssb_division",
@@ -5709,7 +6116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೈಋತ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಸ್ನೇಹಾ ವಿ."
+    "NameKN": "ಸ್ನೇಹಾ ವಿ",
+    "cellRef": "A409"
   },
   {
     "Department": "bwssb_division",
@@ -5723,7 +6131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಟಿ. ಚಂದ್ರಶೇಖರ್ ಪ್ರಸಾದ್"
+    "NameKN": "ಟಿ ಚಂದ್ರಶೇಖರ ಪ್ರಸಾದ್",
+    "cellRef": "A410"
   },
   {
     "Department": "bwssb_service_station",
@@ -5737,7 +6146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A411"
   },
   {
     "Department": "bwssb_service_station",
@@ -5751,7 +6161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ"
+    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ",
+    "cellRef": "A412"
   },
   {
     "Department": "bwssb_service_station",
@@ -5765,7 +6176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್"
+    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್",
+    "cellRef": "A413"
   },
   {
     "Department": "bwssb_service_station",
@@ -5779,7 +6191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
+    "cellRef": "A414"
   },
   {
     "Department": "bwssb_service_station",
@@ -5793,7 +6206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನಂದ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್"
+    "NameKN": " ಕುಮಾರ್",
+    "cellRef": "A415"
   },
   {
     "Department": "bwssb_service_station",
@@ -5807,7 +6221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A416"
   },
   {
     "Department": "bwssb_service_station",
@@ -5821,7 +6236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಶ್ವನಾಥ್"
+    "NameKN": " ವಿಶ್ವನಾಥ್",
+    "cellRef": "A417"
   },
   {
     "Department": "bwssb_service_station",
@@ -5835,7 +6251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಹುಬಲಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
+    "cellRef": "A418"
   },
   {
     "Department": "bwssb_service_station",
@@ -5849,7 +6266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪೂರ್ಣಿಮಾ"
+    "NameKN": " ಪೂರ್ಣಿಮಾ",
+    "cellRef": "A419"
   },
   {
     "Department": "bwssb_service_station",
@@ -5863,7 +6281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A420"
   },
   {
     "Department": "bwssb_service_station",
@@ -5877,7 +6296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A421"
   },
   {
     "Department": "bwssb_service_station",
@@ -5891,7 +6311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನಪ ಪಾರ್ಕ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A422"
   },
   {
     "Department": "bwssb_service_station",
@@ -5905,7 +6326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A423"
   },
   {
     "Department": "bwssb_service_station",
@@ -5919,7 +6341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A424"
   },
   {
     "Department": "bwssb_service_station",
@@ -5933,7 +6356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BEML ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A425"
   },
   {
     "Department": "bwssb_service_station",
@@ -5947,7 +6371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಷ್ಯಂ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್"
+    "NameKN": " ಕಿಶೋರ್",
+    "cellRef": "A426"
   },
   {
     "Department": "bwssb_service_station",
@@ -5961,7 +6386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-I",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A427"
   },
   {
     "Department": "bwssb_service_station",
@@ -5975,7 +6401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-II",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A428"
   },
   {
     "Department": "bwssb_service_station",
@@ -5989,7 +6416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM I & II",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ.ಪಿ."
+    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ ಪಿ",
+    "cellRef": "A429"
   },
   {
     "Department": "bwssb_service_station",
@@ -6003,7 +6431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ"
+    "NameKN": " ಶ್ರೀಜಾ",
+    "cellRef": "A430"
   },
   {
     "Department": "bwssb_service_station",
@@ -6017,7 +6446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ.ರಾಮನ್ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A431"
   },
   {
     "Department": "bwssb_service_station",
@@ -6031,7 +6461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ / ಹೊರಮಾವು / ಕಲ್ಕೆರೆ / ಕೊತ್ತನೂರು-ಬೈರತಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್"
+    "NameKN": " ಆನಂದ್",
+    "cellRef": "A432"
   },
   {
     "Department": "bwssb_service_station",
@@ -6045,7 +6476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ"
+    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ",
+    "cellRef": "A433"
   },
   {
     "Department": "bwssb_service_station",
@@ -6059,7 +6491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ"
+    "NameKN": " ರಾಮೇಗೌಡ",
+    "cellRef": "A434"
   },
   {
     "Department": "bwssb_service_station",
@@ -6073,7 +6506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಾಲಭಾಗ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ"
+    "NameKN": " ಸೀಮಾ",
+    "cellRef": "A435"
   },
   {
     "Department": "bwssb_service_station",
@@ -6087,7 +6521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "CLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಡಿ.ಎಸ್. ರಂಗಯ್ಯ"
+    "NameKN": " ಡಿ ಎಸ್ ರಂಗಯ್ಯ",
+    "cellRef": "A436"
   },
   {
     "Department": "bwssb_service_station",
@@ -6101,7 +6536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲ್ಸ್ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಶ್ ಎಸ್.ಡಿ"
+    "NameKN": " ರಾಜೇಶ್ ಎಸ್ ಡಿ",
+    "cellRef": "A437"
   },
   {
     "Department": "bwssb_service_station",
@@ -6115,7 +6551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಗಿರಿ I&II",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A438"
   },
   {
     "Department": "bwssb_service_station",
@@ -6129,7 +6566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು"
+    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು",
+    "cellRef": "A439"
   },
   {
     "Department": "bwssb_service_station",
@@ -6143,7 +6581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡನೆಕುಂದಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A440"
   },
   {
     "Department": "bwssb_service_station",
@@ -6157,7 +6596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಮತಾ ಎಂ.ಎಚ್"
+    "NameKN": " ಮಮತಾ ಎಂ ಎಚ್",
+    "cellRef": "A441"
   },
   {
     "Department": "bwssb_service_station",
@@ -6171,7 +6611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಜರ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್"
+    "NameKN": " ರಾಹುಲ್",
+    "cellRef": "A442"
   },
   {
     "Department": "bwssb_service_station",
@@ -6185,7 +6626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನ ಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A443"
   },
   {
     "Department": "bwssb_service_station",
@@ -6199,7 +6641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್"
+    "NameKN": " ಕುಮಾರ್",
+    "cellRef": "A444"
   },
   {
     "Department": "bwssb_service_station",
@@ -6213,7 +6656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
+    "NameKN": " ಉಷಾ ಸಿ ಆರ್",
+    "cellRef": "A445"
   },
   {
     "Department": "bwssb_service_station",
@@ -6227,7 +6671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A446"
   },
   {
     "Department": "bwssb_service_station",
@@ -6241,7 +6686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಂಜನ್"
+    "NameKN": " ರಂಜನ್",
+    "cellRef": "A447"
   },
   {
     "Department": "bwssb_service_station",
@@ -6255,7 +6701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
+    "cellRef": "A448"
   },
   {
     "Department": "bwssb_service_station",
@@ -6269,7 +6716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಡಿಶ್"
+    "NameKN": " ನಾಡಿಶ್",
+    "cellRef": "A449"
   },
   {
     "Department": "bwssb_service_station",
@@ -6283,7 +6731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HGR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್"
+    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್",
+    "cellRef": "A450"
   },
   {
     "Department": "bwssb_service_station",
@@ -6297,7 +6746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ"
+    "NameKN": " ಶ್ರೀಜಾ",
+    "cellRef": "A451"
   },
   {
     "Department": "bwssb_service_station",
@@ -6311,7 +6761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕುಮಾರ್"
+    "NameKN": " ರವಿ ಕುಮಾರ್",
+    "cellRef": "A452"
   },
   {
     "Department": "bwssb_service_station",
@@ -6325,7 +6776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸ್ವಾತಿ"
+    "NameKN": " ಸ್ವಾತಿ",
+    "cellRef": "A453"
   },
   {
     "Department": "bwssb_service_station",
@@ -6339,7 +6791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಧರ್ ಎಸ್"
+    "NameKN": " ಶ್ರೀಧರ್.ಎಸ್",
+    "cellRef": "A454"
   },
   {
     "Department": "bwssb_service_station",
@@ -6353,7 +6806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HRBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
+    "cellRef": "A455"
   },
   {
     "Department": "bwssb_service_station",
@@ -6367,7 +6821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A456"
   },
   {
     "Department": "bwssb_service_station",
@@ -6381,7 +6836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಐಡಿಯಲ್ ಹೋಮ್ಸ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
+    "cellRef": "A457"
   },
   {
     "Department": "bwssb_service_station",
@@ -6395,7 +6851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಶಿ ಕುಮಾರ್"
+    "NameKN": " ಶಶಿ ಕುಮಾರ್",
+    "cellRef": "A458"
   },
   {
     "Department": "bwssb_service_station",
@@ -6409,7 +6866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಸ್ರೋ ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A459"
   },
   {
     "Department": "bwssb_service_station",
@@ -6423,7 +6881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಟ್ಟಮಡು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಿಂಗರಾಜು"
+    "NameKN": " ಲಿಂಗರಾಜು",
+    "cellRef": "A460"
   },
   {
     "Department": "bwssb_service_station",
@@ -6437,7 +6896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ ಜೆ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ"
+    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ",
+    "cellRef": "A461"
   },
   {
     "Department": "bwssb_service_station",
@@ -6451,7 +6911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರದೀಪ್"
+    "NameKN": " ಪ್ರದೀಪ್",
+    "cellRef": "A462"
   },
   {
     "Department": "bwssb_service_station",
@@ -6465,7 +6926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಮಹಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ"
+    "NameKN": " ಜಯಶ್ರೀ",
+    "cellRef": "A463"
   },
   {
     "Department": "bwssb_service_station",
@@ -6479,7 +6941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ 'ಟಿ' ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ"
+    "NameKN": " ಲಕ್ಷ್ಮಿ",
+    "cellRef": "A464"
   },
   {
     "Department": "bwssb_service_station",
@@ -6493,7 +6956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ"
+    "NameKN": " ಶ್ರೀಜಾ",
+    "cellRef": "A465"
   },
   {
     "Department": "bwssb_service_station",
@@ -6507,7 +6971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಬಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A466"
   },
   {
     "Department": "bwssb_service_station",
@@ -6521,7 +6986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾನ್ಸನ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ"
+    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ",
+    "cellRef": "A467"
   },
   {
     "Department": "bwssb_service_station",
@@ -6535,7 +7001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 1ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ"
+    "NameKN": " ಲಕ್ಷ್ಮಿ",
+    "cellRef": "A468"
   },
   {
     "Department": "bwssb_service_station",
@@ -6549,7 +7016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ರಮ್"
+    "NameKN": " ಅಕ್ರಮ್",
+    "cellRef": "A469"
   },
   {
     "Department": "bwssb_service_station",
@@ -6563,7 +7031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 3ನೇ ಹಂತ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A470"
   },
   {
     "Department": "bwssb_service_station",
@@ -6577,7 +7046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A471"
   },
   {
     "Department": "bwssb_service_station",
@@ -6591,7 +7061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪುರಂ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A472"
   },
   {
     "Department": "bwssb_service_station",
@@ -6605,7 +7076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ/ ಕಮಲಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಿವಕುಮಾರ್"
+    "NameKN": " ಶಿವಕುಮಾರ್",
+    "cellRef": "A473"
   },
   {
     "Department": "bwssb_service_station",
@@ -6619,7 +7091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮುದಾ"
+    "NameKN": " ಕುಮುದಾ",
+    "cellRef": "A474"
   },
   {
     "Department": "bwssb_service_station",
@@ -6633,7 +7106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
+    "cellRef": "A475"
   },
   {
     "Department": "bwssb_service_station",
@@ -6647,7 +7121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇತಮಾರನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ"
+    "NameKN": " ಪುಷ್ಪಾ",
+    "cellRef": "A476"
   },
   {
     "Department": "bwssb_service_station",
@@ -6661,7 +7136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ಟವರ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ"
+    "NameKN": " ಜಯಶ್ರೀ",
+    "cellRef": "A477"
   },
   {
     "Department": "bwssb_service_station",
@@ -6675,7 +7151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಕಾಸ್ ಡಿ.ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್.ಆರ್"
+    "NameKN": " ವಿಕಾಸ್ ಡಿ ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್ ಆರ್",
+    "cellRef": "A478"
   },
   {
     "Department": "bwssb_service_station",
@@ -6689,7 +7166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A479"
   },
   {
     "Department": "bwssb_service_station",
@@ -6703,7 +7181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A480"
   },
   {
     "Department": "bwssb_service_station",
@@ -6717,7 +7196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A481"
   },
   {
     "Department": "bwssb_service_station",
@@ -6731,7 +7211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಜಾನನ"
+    "NameKN": " ಗಜಾನನ",
+    "cellRef": "A482"
   },
   {
     "Department": "bwssb_service_station",
@@ -6745,7 +7226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರುದಿನ್ನೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ಷಯ್ ಸಿ"
+    "NameKN": " ಅಕ್ಷಯ್ ಸಿ",
+    "cellRef": "A483"
   },
   {
     "Department": "bwssb_service_station",
@@ -6759,7 +7241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
+    "cellRef": "A484"
   },
   {
     "Department": "bwssb_service_station",
@@ -6773,7 +7256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರೀತಿ ಜೆ"
+    "NameKN": " ಪ್ರೀತಿ ಜೆ",
+    "cellRef": "A485"
   },
   {
     "Department": "bwssb_service_station",
@@ -6787,7 +7271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಜಿನಿ ಎ"
+    "NameKN": " ರಜಿನಿ ಎ",
+    "cellRef": "A486"
   },
   {
     "Department": "bwssb_service_station",
@@ -6801,7 +7286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "LLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ"
+    "NameKN": " ಸೀಮಾ",
+    "cellRef": "A487"
   },
   {
     "Department": "bwssb_service_station",
@@ -6815,7 +7301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಚಲಿಬೆಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
+    "cellRef": "A488"
   },
   {
     "Department": "bwssb_service_station",
@@ -6829,7 +7316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್"
+    "NameKN": " ದಿನೇಶ್",
+    "cellRef": "A489"
   },
   {
     "Department": "bwssb_service_station",
@@ -6843,7 +7331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಯೂಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ"
+    "NameKN": " ಪುಷ್ಪಾ",
+    "cellRef": "A490"
   },
   {
     "Department": "bwssb_service_station",
@@ -6857,7 +7346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾನಾ"
+    "NameKN": " ಸುಹಾನಾ",
+    "cellRef": "A491"
   },
   {
     "Department": "bwssb_service_station",
@@ -6871,7 +7361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MEI ಲೇಔಟ್ (ದಾಸರಹಳ್ಳಿ)",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
+    "cellRef": "A492"
   },
   {
     "Department": "bwssb_service_station",
@@ -6885,7 +7376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MNK ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ",
+    "cellRef": "A493"
   },
   {
     "Department": "bwssb_service_station",
@@ -6899,7 +7391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಲ ಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸತೀಶ್ ಟಿ"
+    "NameKN": " ಸತೀಶ್ ಟಿ",
+    "cellRef": "A494"
   },
   {
     "Department": "bwssb_service_station",
@@ -6913,7 +7406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೌಂಟ್ ಜಾಯ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುದರ್ಶನ್ ಡಿ.ಎನ್"
+    "NameKN": " ಸುದರ್ಶನ್ ಡಿ ಎನ್",
+    "cellRef": "A495"
   },
   {
     "Department": "bwssb_service_station",
@@ -6927,7 +7421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್"
+    "NameKN": " ದಿನೇಶ್",
+    "cellRef": "A496"
   },
   {
     "Department": "bwssb_service_station",
@@ -6941,7 +7436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹರ್ಷ ವಿ"
+    "NameKN": " ಹರ್ಷ ವಿ",
+    "cellRef": "A497"
   },
   {
     "Department": "bwssb_service_station",
@@ -6955,7 +7451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗೇಂದ್ರ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
+    "NameKN": " ಉಷಾ ಸಿ ಆರ್",
+    "cellRef": "A498"
   },
   {
     "Department": "bwssb_service_station",
@@ -6969,7 +7466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದುಷ್ಯಂತ್"
+    "NameKN": " ದುಷ್ಯಂತ್",
+    "cellRef": "A499"
   },
   {
     "Department": "bwssb_service_station",
@@ -6983,7 +7481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ BEL ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ"
+    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ",
+    "cellRef": "A500"
   },
   {
     "Department": "bwssb_service_station",
@@ -6997,7 +7496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "OMBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ"
+    "NameKN": " ಮಂಜುನಾಥ",
+    "cellRef": "A501"
   },
   {
     "Department": "bwssb_service_station",
@@ -7011,7 +7511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಣೇಶ್"
+    "NameKN": " ಗಣೇಶ್",
+    "cellRef": "A502"
   },
   {
     "Department": "bwssb_service_station",
@@ -7025,7 +7526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಂದೀಪ್"
+    "NameKN": " ಸಂದೀಪ್",
+    "cellRef": "A503"
   },
   {
     "Department": "bwssb_service_station",
@@ -7039,7 +7541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್"
+    "NameKN": " ರಾಹುಲ್",
+    "cellRef": "A504"
   },
   {
     "Department": "bwssb_service_station",
@@ -7053,7 +7556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
+    "cellRef": "A505"
   },
   {
     "Department": "bwssb_service_station",
@@ -7067,7 +7571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಪಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶೇಖರ್"
+    "NameKN": " ಶೇಖರ್",
+    "cellRef": "A506"
   },
   {
     "Department": "bwssb_service_station",
@@ -7081,7 +7586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ"
+    "NameKN": " ಪುಷ್ಪಾ",
+    "cellRef": "A507"
   },
   {
     "Department": "bwssb_service_station",
@@ -7095,7 +7601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್"
+    "NameKN": " ಆನಂದ್",
+    "cellRef": "A508"
   },
   {
     "Department": "bwssb_service_station",
@@ -7109,7 +7616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್"
+    "NameKN": " ಕುಮಾರ್",
+    "cellRef": "A509"
   },
   {
     "Department": "bwssb_service_station",
@@ -7123,7 +7631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಚಿಂತನ ಕೆ"
+    "NameKN": " ಚಿಂತನ ಕೆ",
+    "cellRef": "A510"
   },
   {
     "Department": "bwssb_service_station",
@@ -7137,7 +7646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ್ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
+    "cellRef": "A511"
   },
   {
     "Department": "bwssb_service_station",
@@ -7151,7 +7661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಿದ್ದರಾಜು"
+    "NameKN": " ಸಿದ್ದರಾಜು",
+    "cellRef": "A512"
   },
   {
     "Department": "bwssb_service_station",
@@ -7165,7 +7676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಧಾಮ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾಸ್"
+    "NameKN": " ಸುಹಾಸ್",
+    "cellRef": "A513"
   },
   {
     "Department": "bwssb_service_station",
@@ -7179,7 +7691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕಿರಣ್ (ಐ/ಸಿ)"
+    "NameKN": " ರವಿ ಕಿರಣ್ (i/c)",
+    "cellRef": "A514"
   },
   {
     "Department": "bwssb_service_station",
@@ -7193,7 +7706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ"
+    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ",
+    "cellRef": "A515"
   },
   {
     "Department": "bwssb_service_station",
@@ -7207,7 +7721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್"
+    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್",
+    "cellRef": "A516"
   },
   {
     "Department": "bwssb_service_station",
@@ -7221,7 +7736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯ್ ನಗರ OHT",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A517"
   },
   {
     "Department": "bwssb_service_station",
@@ -7235,7 +7751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ಆ.ರ್"
+    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ ಆರ್",
+    "cellRef": "A518"
   },
   {
     "Department": "bwssb_service_station",
@@ -7249,7 +7766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್"
+    "NameKN": " ಆನಂದ್",
+    "cellRef": "A519"
   },
   {
     "Department": "bwssb_service_station",
@@ -7263,7 +7781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಬಡಾವಣೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A520"
   },
   {
     "Department": "bwssb_service_station",
@@ -7277,7 +7796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ OHT",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ ಬಿ"
+    "NameKN": " ರಾಮೇಗೌಡ ಬಿ",
+    "cellRef": "A521"
   },
   {
     "Department": "bwssb_service_station",
@@ -7291,7 +7811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವಿ ಪುರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಪ್ರಹ್ಲಾದ್"
+    "NameKN": " ಪ್ರಹ್ಲಾದ",
+    "cellRef": "A522"
   },
   {
     "Department": "bwssb_service_station",
@@ -7305,7 +7826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "WCR-I",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
+    "cellRef": "A523"
   },
   {
     "Department": "bwssb_service_station",
@@ -7319,7 +7841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು"
+    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು",
+    "cellRef": "A524"
   },
   {
     "Department": "bwssb_service_station",
@@ -7333,7 +7856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಓಲ್ಡ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ.ಬಿ"
+    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ ಬಿ",
+    "cellRef": "A525"
   },
   {
     "Department": "bwssb_service_station",
@@ -7347,7 +7871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್"
+    "NameKN": " ಕಿಶೋರ್",
+    "cellRef": "A526"
   },
   {
     "Department": "police_city",
@@ -7361,7 +7886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A527"
   },
   {
     "Department": "police_city",
@@ -7375,7 +7901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A528"
   },
   {
     "Department": "police_city",
@@ -7389,7 +7916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A529"
   },
   {
     "Department": "police_city",
@@ -7403,7 +7931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A530"
   },
   {
     "Department": "police_city",
@@ -7417,7 +7946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಂಡರ್ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A531"
   },
   {
     "Department": "police_city",
@@ -7431,7 +7961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A532"
   },
   {
     "Department": "police_city",
@@ -7445,7 +7976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A533"
   },
   {
     "Department": "police_city",
@@ -7459,7 +7991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನುಗೊಂಡನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A534"
   },
   {
     "Department": "police_city",
@@ -7473,7 +8006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A535"
   },
   {
     "Department": "police_city",
@@ -7487,7 +8021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A536"
   },
   {
     "Department": "police_city",
@@ -7501,7 +8036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A537"
   },
   {
     "Department": "police_city",
@@ -7515,7 +8051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಡವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A538"
   },
   {
     "Department": "police_city",
@@ -7529,7 +8066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಗುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A539"
   },
   {
     "Department": "police_city",
@@ -7543,7 +8081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A540"
   },
   {
     "Department": "police_city",
@@ -7557,7 +8096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A541"
   },
   {
     "Department": "police_city",
@@ -7571,7 +8111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A542"
   },
   {
     "Department": "police_city",
@@ -7585,7 +8126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A543"
   },
   {
     "Department": "police_city",
@@ -7599,7 +8141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಡೆಪಾಳ್ಯ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A544"
   },
   {
     "Department": "police_city",
@@ -7613,7 +8156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A545"
   },
   {
     "Department": "police_city",
@@ -7627,7 +8171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A546"
   },
   {
     "Department": "police_city",
@@ -7641,7 +8186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವೇಶ್ವರ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A547"
   },
   {
     "Department": "police_city",
@@ -7655,7 +8201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A548"
   },
   {
     "Department": "police_city",
@@ -7669,7 +8216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A549"
   },
   {
     "Department": "police_city",
@@ -7683,7 +8231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಕವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A550"
   },
   {
     "Department": "police_city",
@@ -7697,7 +8246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A551"
   },
   {
     "Department": "police_city",
@@ -7711,7 +8261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಾವಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A552"
   },
   {
     "Department": "police_city",
@@ -7725,7 +8276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಇಎಂಎಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A553"
   },
   {
     "Department": "police_city",
@@ -7739,7 +8291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಸಗರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A554"
   },
   {
     "Department": "police_city",
@@ -7753,7 +8306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇತಮಂಗಲ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A555"
   },
   {
     "Department": "police_city",
@@ -7767,7 +8321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A556"
   },
   {
     "Department": "police_city",
@@ -7781,7 +8336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A557"
   },
   {
     "Department": "police_city",
@@ -7795,7 +8351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A558"
   },
   {
     "Department": "police_city",
@@ -7809,7 +8366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A559"
   },
   {
     "Department": "police_city",
@@ -7823,7 +8381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A560"
   },
   {
     "Department": "police_city",
@@ -7837,7 +8396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A561"
   },
   {
     "Department": "police_city",
@@ -7851,7 +8411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ಕೆ.ಅಚ್ಚುಕಟ್ಟು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A562"
   },
   {
     "Department": "police_city",
@@ -7865,7 +8426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A563"
   },
   {
     "Department": "police_city",
@@ -7879,7 +8441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A564"
   },
   {
     "Department": "police_city",
@@ -7893,7 +8456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ ರೀಫ್ಸ್ PS",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A565"
   },
   {
     "Department": "police_city",
@@ -7907,7 +8471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರಾ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A566"
   },
   {
     "Department": "police_city",
@@ -7921,7 +8486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A567"
   },
   {
     "Department": "police_city",
@@ -7935,7 +8501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A568"
   },
   {
     "Department": "police_city",
@@ -7949,7 +8516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A569"
   },
   {
     "Department": "police_city",
@@ -7963,7 +8531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A570"
   },
   {
     "Department": "police_city",
@@ -7977,7 +8546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A571"
   },
   {
     "Department": "police_city",
@@ -7991,7 +8561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A572"
   },
   {
     "Department": "police_city",
@@ -8005,7 +8576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A573"
   },
   {
     "Department": "police_city",
@@ -8019,7 +8591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A574"
   },
   {
     "Department": "police_city",
@@ -8033,7 +8606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A575"
   },
   {
     "Department": "police_city",
@@ -8047,7 +8621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A576"
   },
   {
     "Department": "police_city",
@@ -8061,7 +8636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A577"
   },
   {
     "Department": "police_city",
@@ -8075,7 +8651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮರ್ಷಿಯಲ್ ಸ್ಟ್ರೀಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A578"
   },
   {
     "Department": "police_city",
@@ -8089,7 +8666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಟನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A579"
   },
   {
     "Department": "police_city",
@@ -8103,7 +8681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A580"
   },
   {
     "Department": "police_city",
@@ -8117,7 +8696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A581"
   },
   {
     "Department": "police_city",
@@ -8131,7 +8711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಜೀವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A582"
   },
   {
     "Department": "police_city",
@@ -8145,7 +8726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಿಬ್ಬೂರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A583"
   },
   {
     "Department": "police_city",
@@ -8159,7 +8741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A584"
   },
   {
     "Department": "police_city",
@@ -8173,7 +8756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A585"
   },
   {
     "Department": "police_city",
@@ -8187,7 +8771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A586"
   },
   {
     "Department": "police_city",
@@ -8201,7 +8786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A587"
   },
   {
     "Department": "police_city",
@@ -8215,7 +8801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A588"
   },
   {
     "Department": "police_city",
@@ -8229,7 +8816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಮ್ಮಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A589"
   },
   {
     "Department": "police_city",
@@ -8243,7 +8831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A590"
   },
   {
     "Department": "police_city",
@@ -8257,7 +8846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A591"
   },
   {
     "Department": "police_city",
@@ -8271,7 +8861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A592"
   },
   {
     "Department": "police_city",
@@ -8285,7 +8876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A593"
   },
   {
     "Department": "police_city",
@@ -8299,7 +8891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A594"
   },
   {
     "Department": "police_city",
@@ -8313,7 +8906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A595"
   },
   {
     "Department": "police_city",
@@ -8327,7 +8921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A596"
   },
   {
     "Department": "police_city",
@@ -8341,7 +8936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A597"
   },
   {
     "Department": "police_city",
@@ -8355,7 +8951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಪೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A598"
   },
   {
     "Department": "police_city",
@@ -8369,7 +8966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A599"
   },
   {
     "Department": "police_city",
@@ -8383,7 +8981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A600"
   },
   {
     "Department": "police_city",
@@ -8397,7 +8996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಗೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A601"
   },
   {
     "Department": "police_city",
@@ -8411,7 +9011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A602"
   },
   {
     "Department": "police_city",
@@ -8425,7 +9026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A603"
   },
   {
     "Department": "police_city",
@@ -8439,7 +9041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನುಮತಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A604"
   },
   {
     "Department": "police_city",
@@ -8453,7 +9056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A605"
   },
   {
     "Department": "police_city",
@@ -8467,7 +9071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A606"
   },
   {
     "Department": "police_city",
@@ -8481,7 +9086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A607"
   },
   {
     "Department": "police_city",
@@ -8495,7 +9101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A608"
   },
   {
     "Department": "police_city",
@@ -8509,7 +9116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A609"
   },
   {
     "Department": "police_city",
@@ -8523,7 +9131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A610"
   },
   {
     "Department": "police_city",
@@ -8537,7 +9146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A611"
   },
   {
     "Department": "police_city",
@@ -8551,7 +9161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A612"
   },
   {
     "Department": "police_city",
@@ -8565,7 +9176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಳಿಮಾವು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A613"
   },
   {
     "Department": "police_city",
@@ -8579,7 +9191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A614"
   },
   {
     "Department": "police_city",
@@ -8593,7 +9206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಜೂರ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A615"
   },
   {
     "Department": "police_city",
@@ -8607,7 +9221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A616"
   },
   {
     "Department": "police_city",
@@ -8621,7 +9236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ.ಸಿ.ನಗರಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A617"
   },
   {
     "Department": "police_city",
@@ -8635,7 +9251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಜೀವನರಾಮ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A618"
   },
   {
     "Department": "police_city",
@@ -8649,7 +9266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A619"
   },
   {
     "Department": "police_city",
@@ -8663,7 +9281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A620"
   },
   {
     "Department": "police_city",
@@ -8677,7 +9296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಪ್ರಕಾಶ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A621"
   },
   {
     "Department": "police_city",
@@ -8691,7 +9311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A622"
   },
   {
     "Department": "police_city",
@@ -8705,7 +9326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A623"
   },
   {
     "Department": "police_city",
@@ -8719,7 +9341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜ್ಞಾನಭಾರತಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A624"
   },
   {
     "Department": "police_city",
@@ -8733,7 +9356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಜಿ.ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A625"
   },
   {
     "Department": "police_city",
@@ -8747,7 +9371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಎಂ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A626"
   },
   {
     "Department": "police_city",
@@ -8761,7 +9386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A627"
   },
   {
     "Department": "police_city",
@@ -8775,7 +9401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A628"
   },
   {
     "Department": "police_city",
@@ -8789,7 +9416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A629"
   },
   {
     "Department": "police_city",
@@ -8803,7 +9431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಗ್ಗಲೀಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A630"
   },
   {
     "Department": "police_city",
@@ -8817,7 +9446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಲಂಬೆಳ್ಳ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A631"
   },
   {
     "Department": "police_city",
@@ -8831,7 +9461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A632"
   },
   {
     "Department": "police_city",
@@ -8845,7 +9476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A633"
   },
   {
     "Department": "police_city",
@@ -8859,7 +9491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A634"
   },
   {
     "Department": "police_city",
@@ -8873,7 +9506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A635"
   },
   {
     "Department": "police_city",
@@ -8887,7 +9521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪೇಗೌಡ ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A636"
   },
   {
     "Department": "police_city",
@@ -8901,7 +9536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಚಾರ್ಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A637"
   },
   {
     "Department": "police_city",
@@ -8915,7 +9551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A638"
   },
   {
     "Department": "police_city",
@@ -8929,7 +9566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಸ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A639"
   },
   {
     "Department": "police_city",
@@ -8943,7 +9581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿರುಗಾವಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A640"
   },
   {
     "Department": "police_city",
@@ -8957,7 +9596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A641"
   },
   {
     "Department": "police_city",
@@ -8971,7 +9611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A642"
   },
   {
     "Department": "police_city",
@@ -8985,7 +9626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A643"
   },
   {
     "Department": "police_city",
@@ -8999,7 +9641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A644"
   },
   {
     "Department": "police_city",
@@ -9013,7 +9656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A645"
   },
   {
     "Department": "police_city",
@@ -9027,7 +9671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A646"
   },
   {
     "Department": "police_city",
@@ -9041,7 +9686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A647"
   },
   {
     "Department": "police_city",
@@ -9055,7 +9701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A648"
   },
   {
     "Department": "police_city",
@@ -9069,7 +9716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಣನಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A649"
   },
   {
     "Department": "police_city",
@@ -9083,7 +9731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A650"
   },
   {
     "Department": "police_city",
@@ -9097,7 +9746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A651"
   },
   {
     "Department": "police_city",
@@ -9111,7 +9761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A652"
   },
   {
     "Department": "police_city",
@@ -9125,7 +9776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A653"
   },
   {
     "Department": "police_city",
@@ -9139,7 +9791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A654"
   },
   {
     "Department": "police_city",
@@ -9153,7 +9806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A655"
   },
   {
     "Department": "police_city",
@@ -9167,7 +9821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A656"
   },
   {
     "Department": "police_city",
@@ -9181,7 +9836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೂಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A657"
   },
   {
     "Department": "police_city",
@@ -9195,7 +9851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A658"
   },
   {
     "Department": "police_city",
@@ -9209,7 +9866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A659"
   },
   {
     "Department": "police_city",
@@ -9223,7 +9881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A660"
   },
   {
     "Department": "police_city",
@@ -9237,7 +9896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಕೆ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A661"
   },
   {
     "Department": "police_city",
@@ -9251,7 +9911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಎಂ. ಹಿಲ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A662"
   },
   {
     "Department": "police_city",
@@ -9265,7 +9926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A663"
   },
   {
     "Department": "police_city",
@@ -9279,7 +9941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A664"
   },
   {
     "Department": "police_city",
@@ -9293,7 +9956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A665"
   },
   {
     "Department": "police_city",
@@ -9307,7 +9971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A666"
   },
   {
     "Department": "police_city",
@@ -9321,7 +9986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A667"
   },
   {
     "Department": "police_city",
@@ -9335,7 +10001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A668"
   },
   {
     "Department": "police_city",
@@ -9349,7 +10016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A669"
   },
   {
     "Department": "police_city",
@@ -9363,7 +10031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A670"
   },
   {
     "Department": "police_city",
@@ -9377,7 +10046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A671"
   },
   {
     "Department": "police_city",
@@ -9391,7 +10061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A672"
   },
   {
     "Department": "police_city",
@@ -9405,7 +10076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A673"
   },
   {
     "Department": "police_city",
@@ -9419,7 +10091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A674"
   },
   {
     "Department": "police_city",
@@ -9433,7 +10106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಂಬಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A675"
   },
   {
     "Department": "police_city",
@@ -9447,7 +10121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A676"
   },
   {
     "Department": "police_city",
@@ -9461,7 +10136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A677"
   },
   {
     "Department": "police_city",
@@ -9475,7 +10151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರತ್ತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A678"
   },
   {
     "Department": "police_city",
@@ -9489,7 +10166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರಿಕುಪ್ಪಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A679"
   },
   {
     "Department": "police_city",
@@ -9503,7 +10181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A680"
   },
   {
     "Department": "police_city",
@@ -9517,7 +10196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಡಿಗೇಶಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A681"
   },
   {
     "Department": "police_city",
@@ -9531,7 +10211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಕೋ ಲೇಔಟ್ ಬೆಂಗಳೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A682"
   },
   {
     "Department": "police_city",
@@ -9545,7 +10226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A683"
   },
   {
     "Department": "police_city",
@@ -9559,7 +10241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A684"
   },
   {
     "Department": "police_city",
@@ -9573,7 +10256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A685"
   },
   {
     "Department": "police_city",
@@ -9587,7 +10271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ ಗಿರಿಘಾಮ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A686"
   },
   {
     "Department": "police_city",
@@ -9601,7 +10286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A687"
   },
   {
     "Department": "police_city",
@@ -9615,7 +10301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಗಲಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A688"
   },
   {
     "Department": "police_city",
@@ -9629,7 +10316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A689"
   },
   {
     "Department": "police_city",
@@ -9643,7 +10331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A690"
   },
   {
     "Department": "police_city",
@@ -9657,7 +10346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A691"
   },
   {
     "Department": "police_city",
@@ -9671,7 +10361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A692"
   },
   {
     "Department": "police_city",
@@ -9685,7 +10376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪರಪ್ಪನ ಅಗ್ರಹಾರ",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A693"
   },
   {
     "Department": "police_city",
@@ -9699,7 +10391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಟನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A694"
   },
   {
     "Department": "police_city",
@@ -9713,7 +10406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾತಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A695"
   },
   {
     "Department": "police_city",
@@ -9727,7 +10421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A696"
   },
   {
     "Department": "police_city",
@@ -9741,7 +10436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A697"
   },
   {
     "Department": "police_city",
@@ -9755,7 +10451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A698"
   },
   {
     "Department": "police_city",
@@ -9769,7 +10466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಟ್ಟೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A699"
   },
   {
     "Department": "police_city",
@@ -9783,7 +10481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A700"
   },
   {
     "Department": "police_city",
@@ -9797,7 +10496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A701"
   },
   {
     "Department": "police_city",
@@ -9811,7 +10511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾನುಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A702"
   },
   {
     "Department": "police_city",
@@ -9825,7 +10526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A703"
   },
   {
     "Department": "police_city",
@@ -9839,7 +10541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಗೋಪಾಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A704"
   },
   {
     "Department": "police_city",
@@ -9853,7 +10556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A705"
   },
   {
     "Department": "police_city",
@@ -9867,7 +10571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A706"
   },
   {
     "Department": "police_city",
@@ -9881,7 +10586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A707"
   },
   {
     "Department": "police_city",
@@ -9895,7 +10601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A708"
   },
   {
     "Department": "police_city",
@@ -9909,7 +10616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಲ್ಪಾಡ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A709"
   },
   {
     "Department": "police_city",
@@ -9923,7 +10631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಬರ್ಟ್‌ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A710"
   },
   {
     "Department": "police_city",
@@ -9937,7 +10646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್.ಜೆ. ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A711"
   },
   {
     "Department": "police_city",
@@ -9951,7 +10661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷದಶಿವನಗರ್ Pಷ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A712"
   },
   {
     "Department": "police_city",
@@ -9965,7 +10676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಂಗಿರಾಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A713"
   },
   {
     "Department": "police_city",
@@ -9979,7 +10691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಿಗೆಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A714"
   },
   {
     "Department": "police_city",
@@ -9993,7 +10706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ ನಗರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A715"
   },
   {
     "Department": "police_city",
@@ -10007,7 +10721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂತೆಮರಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A716"
   },
   {
     "Department": "police_city",
@@ -10021,7 +10736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A717"
   },
   {
     "Department": "police_city",
@@ -10035,7 +10751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾತನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A718"
   },
   {
     "Department": "police_city",
@@ -10049,7 +10766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A719"
   },
   {
     "Department": "police_city",
@@ -10063,7 +10781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A720"
   },
   {
     "Department": "police_city",
@@ -10077,7 +10796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A721"
   },
   {
     "Department": "police_city",
@@ -10091,7 +10811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A722"
   },
   {
     "Department": "police_city",
@@ -10105,7 +10826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A723"
   },
   {
     "Department": "police_city",
@@ -10119,7 +10841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A724"
   },
   {
     "Department": "police_city",
@@ -10133,7 +10856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A725"
   },
   {
     "Department": "police_city",
@@ -10147,7 +10871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A726"
   },
   {
     "Department": "police_city",
@@ -10161,7 +10886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A727"
   },
   {
     "Department": "police_city",
@@ -10175,7 +10901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A728"
   },
   {
     "Department": "police_city",
@@ -10189,7 +10916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A729"
   },
   {
     "Department": "police_city",
@@ -10203,7 +10931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A730"
   },
   {
     "Department": "police_city",
@@ -10217,7 +10946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುದ್ದಗುಂಟೆಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A731"
   },
   {
     "Department": "police_city",
@@ -10231,7 +10961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗಟೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A732"
   },
   {
     "Department": "police_city",
@@ -10245,7 +10976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A733"
   },
   {
     "Department": "police_city",
@@ -10259,7 +10991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೈಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A734"
   },
   {
     "Department": "police_city",
@@ -10273,7 +11006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಕಾಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A735"
   },
   {
     "Department": "police_city",
@@ -10287,7 +11021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A736"
   },
   {
     "Department": "police_city",
@@ -10301,7 +11036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A737"
   },
   {
     "Department": "police_city",
@@ -10315,7 +11051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A738"
   },
   {
     "Department": "police_city",
@@ -10329,7 +11066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A739"
   },
   {
     "Department": "police_city",
@@ -10343,7 +11081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A740"
   },
   {
     "Department": "police_city",
@@ -10357,7 +11096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A741"
   },
   {
     "Department": "police_city",
@@ -10371,7 +11111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A742"
   },
   {
     "Department": "police_city",
@@ -10385,7 +11126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A743"
   },
   {
     "Department": "police_city",
@@ -10399,7 +11141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A744"
   },
   {
     "Department": "police_city",
@@ -10413,7 +11156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A745"
   },
   {
     "Department": "police_city",
@@ -10427,7 +11171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A746"
   },
   {
     "Department": "police_city",
@@ -10441,7 +11186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A747"
   },
   {
     "Department": "police_city",
@@ -10455,7 +11201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನಸೌಧ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A748"
   },
   {
     "Department": "police_city",
@@ -10469,7 +11216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A749"
   },
   {
     "Department": "police_city",
@@ -10483,7 +11231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A750"
   },
   {
     "Department": "police_city",
@@ -10497,7 +11246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A751"
   },
   {
     "Department": "police_city",
@@ -10511,7 +11261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವನಾಥಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A752"
   },
   {
     "Department": "police_city",
@@ -10525,7 +11276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವೇಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A753"
   },
   {
     "Department": "police_city",
@@ -10539,7 +11291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಯಾಲಿಕಾವಲ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A754"
   },
   {
     "Department": "police_city",
@@ -10553,7 +11306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A755"
   },
   {
     "Department": "police_city",
@@ -10567,7 +11321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A756"
   },
   {
     "Department": "police_city",
@@ -10581,7 +11336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A757"
   },
   {
     "Department": "police_city",
@@ -10595,7 +11351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A758"
   },
   {
     "Department": "police_city",
@@ -10609,7 +11366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A759"
   },
   {
     "Department": "police_city",
@@ -10623,7 +11381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A760"
   },
   {
     "Department": "police_city",
@@ -10637,7 +11396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A761"
   },
   {
     "Department": "police_city",
@@ -10651,7 +11411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಆರ್‌ಎಂಸಿ ಯಾರ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A762"
   },
   {
     "Department": "election_ac",
@@ -10665,7 +11426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಶಿವಣ್ಣ"
+    "NameKN": "ಬಿ ಶಿವಣ್ಣ",
+    "cellRef": "A763"
   },
   {
     "Department": "election_ac",
@@ -10679,7 +11441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಟಿಎಂ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ"
+    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ",
+    "cellRef": "A764"
   },
   {
     "Department": "election_ac",
@@ -10693,7 +11456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A765"
   },
   {
     "Department": "election_ac",
@@ -10707,7 +11471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
+    "NameKN": "ಎಂ ಕೃಷ್ಣಪ್ಪ",
+    "cellRef": "A766"
   },
   {
     "Department": "election_ac",
@@ -10721,7 +11486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A767"
   },
   {
     "Department": "election_ac",
@@ -10735,7 +11501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ ಎಲ್.ಎ"
+    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ LA",
+    "cellRef": "A768"
   },
   {
     "Department": "election_ac",
@@ -10749,7 +11516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ"
+    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ",
+    "cellRef": "A769"
   },
   {
     "Department": "election_ac",
@@ -10763,7 +11531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ"
+    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ",
+    "cellRef": "A770"
   },
   {
     "Department": "election_ac",
@@ -10777,7 +11546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ. ರಾಮಣ್ಣನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ರಘು"
+    "NameKN": "ಎಸ್ ರಘು",
+    "cellRef": "A771"
   },
   {
     "Department": "election_ac",
@@ -10791,7 +11561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಜೆಡ್ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್"
+    "NameKN": "BZ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್",
+    "cellRef": "A772"
   },
   {
     "Department": "election_ac",
@@ -10805,7 +11576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "MLA",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A773"
   },
   {
     "Department": "election_ac",
@@ -10819,7 +11591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್"
+    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್",
+    "cellRef": "A774"
   },
   {
     "Department": "election_ac",
@@ -10833,7 +11606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್"
+    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್",
+    "cellRef": "A775"
   },
   {
     "Department": "election_ac",
@@ -10847,7 +11621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A776"
   },
   {
     "Department": "election_ac",
@@ -10861,7 +11636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಮುನಿರಾಜು"
+    "NameKN": "ಎಸ್ ಮುನಿರಾಜು",
+    "cellRef": "A777"
   },
   {
     "Department": "election_ac",
@@ -10875,7 +11651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ. ಎಚ್. ಮುನಿಯಪ್ಪ"
+    "NameKN": "ಕೆ ಎಚ್ ಮುನಿಯಪ್ಪ",
+    "cellRef": "A778"
   },
   {
     "Department": "election_ac",
@@ -10889,7 +11666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್"
+    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್",
+    "cellRef": "A779"
   },
   {
     "Department": "election_ac",
@@ -10903,7 +11681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್"
+    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್",
+    "cellRef": "A780"
   },
   {
     "Department": "election_ac",
@@ -10917,7 +11696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A781"
   },
   {
     "Department": "election_ac",
@@ -10931,7 +11711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ"
+    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ",
+    "cellRef": "A782"
   },
   {
     "Department": "election_ac",
@@ -10945,7 +11726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A783"
   },
   {
     "Department": "election_ac",
@@ -10959,7 +11741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A784"
   },
   {
     "Department": "election_ac",
@@ -10973,7 +11756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎಸ್. ಸುರೇಶ ಬೈರತಿ"
+    "NameKN": "ಬಿ.ಎಸ್.ಸುರೇಶ ಬೈರತಿ",
+    "cellRef": "A785"
   },
   {
     "Department": "election_ac",
@@ -10987,7 +11771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ"
+    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ",
+    "cellRef": "A786"
   },
   {
     "Department": "election_ac",
@@ -11001,7 +11786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸಿ.ಕೆ. ರಾಮ ಮೂರ್ತಿ"
+    "NameKN": "ಸಿ ಕೆ ರಾಮ ಮೂರ್ತಿ",
+    "cellRef": "A787"
   },
   {
     "Department": "election_ac",
@@ -11015,7 +11801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎ. ಬಸವರಾಜ"
+    "NameKN": "ಬಿಎ ಬಸವರಾಜ",
+    "cellRef": "A788"
   },
   {
     "Department": "election_ac",
@@ -11029,7 +11816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಡಿ.ಕೆ. ಶಿವಕುಮಾರ್"
+    "NameKN": "ಡಿಕೆ ಶಿವಕುಮಾರ್",
+    "cellRef": "A789"
   },
   {
     "Department": "election_ac",
@@ -11043,7 +11831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A790"
   },
   {
     "Department": "election_ac",
@@ -11057,7 +11846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಚಿನ್ನದ ಕ್ಷೇತ್ರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A791"
   },
   {
     "Department": "election_ac",
@@ -11071,7 +11861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A792"
   },
   {
     "Department": "election_ac",
@@ -11085,7 +11876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಜಿ. ಪರಮೇಶ್ವರ"
+    "NameKN": "ಜಿ ಪರಮೇಶ್ವರ",
+    "cellRef": "A793"
   },
   {
     "Department": "election_ac",
@@ -11099,7 +11891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A794"
   },
   {
     "Department": "election_ac",
@@ -11113,7 +11906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A795"
   },
   {
     "Department": "election_ac",
@@ -11127,7 +11921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A796"
   },
   {
     "Department": "election_ac",
@@ -11141,7 +11936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಚ್.ಸಿ ಬಾಲಕೃಷ್ಣ"
+    "NameKN": "ಎಚ್ ಸಿ ಬಾಲಕೃಷ್ಣ",
+    "cellRef": "A797"
   },
   {
     "Department": "election_ac",
@@ -11155,7 +11951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮಂಜುಳಾ ಎಸ್"
+    "NameKN": "ಮಂಜುಳಾ ಎಸ್",
+    "cellRef": "A798"
   },
   {
     "Department": "election_ac",
@@ -11169,7 +11966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ"
+    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ",
+    "cellRef": "A799"
   },
   {
     "Department": "election_ac",
@@ -11183,7 +11981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A800"
   },
   {
     "Department": "election_ac",
@@ -11197,7 +11996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "MLA",
-    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿ.ಎನ್"
+    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿಎನ್",
+    "cellRef": "A801"
   },
   {
     "Department": "election_ac",
@@ -11211,7 +12011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಎನ್. ನಂಜೇಗೌಡ"
+    "NameKN": "ಕೆ.ಎನ್.ನಂಜೇಗೌಡ",
+    "cellRef": "A802"
   },
   {
     "Department": "election_ac",
@@ -11225,7 +12026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A803"
   },
   {
     "Department": "election_ac",
@@ -11239,7 +12041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A804"
   },
   {
     "Department": "election_ac",
@@ -11253,7 +12056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A805"
   },
   {
     "Department": "election_ac",
@@ -11267,7 +12071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್"
+    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್",
+    "cellRef": "A806"
   },
   {
     "Department": "election_ac",
@@ -11281,7 +12086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪದ್ಮನಾಬನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಆರ್. ಅಶೋಕ"
+    "NameKN": "ಆರ್ ಅಶೋಕ",
+    "cellRef": "A807"
   },
   {
     "Department": "election_ac",
@@ -11295,7 +12101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A808"
   },
   {
     "Department": "election_ac",
@@ -11309,7 +12116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎ.ಸಿ. ಶ್ರೀನಿವಾಸ"
+    "NameKN": "ಎಸಿ ಶ್ರೀನಿವಾಸ",
+    "cellRef": "A809"
   },
   {
     "Department": "election_ac",
@@ -11323,7 +12131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಸುರೇಶ್ ಕುಮಾರ್"
+    "NameKN": "ಎಸ್ ಸುರೇಶ್ ಕುಮಾರ್",
+    "cellRef": "A810"
   },
   {
     "Department": "election_ac",
@@ -11337,7 +12146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮುನಿರತ್ನ"
+    "NameKN": "ಮುನಿರತ್ನ",
+    "cellRef": "A811"
   },
   {
     "Department": "election_ac",
@@ -11351,7 +12161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "H.A. ಇಕ್ಬಾಲ್ ಹುಸೇನ್"
+    "NameKN": "HA ಇಕ್ಬಾಲ್ ಹುಸೇನ್",
+    "cellRef": "A812"
   },
   {
     "Department": "election_ac",
@@ -11365,7 +12176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ವಜ್ಞನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಜೆ. ಜಾರ್ಜ್"
+    "NameKN": "ಕೆಜೆ ಜಾರ್ಜ್",
+    "cellRef": "A813"
   },
   {
     "Department": "election_ac",
@@ -11379,7 +12191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎನ್.ಎ. ಹರಿಸ್"
+    "NameKN": "ಎನ್ಎ ಹರಿಸ್",
+    "cellRef": "A814"
   },
   {
     "Department": "election_ac",
@@ -11393,7 +12206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್"
+    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್",
+    "cellRef": "A815"
   },
   {
     "Department": "election_ac",
@@ -11407,7 +12221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎನ್. ರವಿಕುಮಾರ್"
+    "NameKN": "ಬಿಎನ್ ರವಿಕುಮಾರ್",
+    "cellRef": "A816"
   },
   {
     "Department": "election_ac",
@@ -11421,7 +12236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A817"
   },
   {
     "Department": "election_ac",
@@ -11435,7 +12251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A818"
   },
   {
     "Department": "election_ac",
@@ -11449,7 +12266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A819"
   },
   {
     "Department": "election_ac",
@@ -11463,7 +12281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A820"
   },
   {
     "Department": "election_ac",
@@ -11477,7 +12296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಸುರೇಶ್ ಗೌಡ"
+    "NameKN": "ಬಿ ಸುರೇಶ್ ಗೌಡ",
+    "cellRef": "A821"
   },
   {
     "Department": "election_ac",
@@ -11491,7 +12311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
+    "NameKN": "ಎಂ ಕೃಷ್ಣಪ್ಪ",
+    "cellRef": "A822"
   },
   {
     "Department": "election_ac",
@@ -11505,7 +12326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಆರ್ ವಿಶ್ವನಾಥ್"
+    "NameKN": "ಎಸ್ ಆರ್ ವಿಶ್ವನಾಥ್",
+    "cellRef": "A823"
   },
   {
     "Department": "election_ac",
@@ -11519,7 +12341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಟಿ. ಸೋಮಶೇಖರ್"
+    "NameKN": "ಎಸ್ ಟಿ ಸೋಮಶೇಖರ್",
+    "cellRef": "A824"
   },
   {
     "Department": "election_pc",
@@ -11533,7 +12356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಕೇಂದ್ರ",
     "DesignationKN": "MP",
-    "NameKN": "ಪಿ.ಸಿ. ಮೋಹನ್"
+    "NameKN": "ಪಿಸಿ ಮೋಹನ್",
+    "cellRef": "A825"
   },
   {
     "Department": "election_pc",
@@ -11547,7 +12371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
+    "cellRef": "A826"
   },
   {
     "Department": "election_pc",
@@ -11561,7 +12386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಸಿ. ಎನ್. ಮಂಜುನಾಥ್"
+    "NameKN": "ಸಿ ಎನ್ ಮಂಜುನಾಥ್",
+    "cellRef": "A827"
   },
   {
     "Department": "election_pc",
@@ -11575,7 +12401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MP",
-    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ"
+    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ",
+    "cellRef": "A828"
   },
   {
     "Department": "election_pc",
@@ -11589,7 +12416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A829"
   },
   {
     "Department": "election_pc",
@@ -11603,7 +12431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MP",
-    "NameKN": "ಕೆ. ಸುಧಾಕರ್"
+    "NameKN": "ಕೆ ಸುಧಾಕರ್",
+    "cellRef": "A830"
   },
   {
     "Department": "election_pc",
@@ -11617,7 +12446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A831"
   },
   {
     "Department": "election_pc",
@@ -11631,7 +12461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "MP",
-    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ. ಬಾಬು"
+    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ ಬಾಬು",
+    "cellRef": "A832"
   },
   {
     "Department": "election_pc",
@@ -11645,7 +12476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A833"
   },
   {
     "Department": "election_pc",
@@ -11659,7 +12491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "MP",
-    "NameKN": "ವಿ. ಸೋಮಣ್ಣ"
+    "NameKN": "ವಿ ಸೋಮಣ್ಣ",
+    "cellRef": "A834"
   },
   {
     "Department": "Pin Code",
@@ -11673,7 +12506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಚಿತ್ನಗರ - 560107",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A835"
   },
   {
     "Department": "Pin Code",
@@ -11687,7 +12521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ - 560030",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A836"
   },
   {
     "Department": "Pin Code",
@@ -11701,7 +12536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಎಫ್ ಸ್ಟೇಷನ್ ಯಲಹಂಕ - 560063",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A837"
   },
   {
     "Department": "Pin Code",
@@ -11715,7 +12551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ರಾಮ್ - 560007",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A838"
   },
   {
     "Department": "Pin Code",
@@ -11729,7 +12566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ - 562106",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A839"
   },
   {
     "Department": "Pin Code",
@@ -11743,7 +12581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಂಜನಾಪುರ - 560108",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A840"
   },
   {
     "Department": "Pin Code",
@@ -11757,7 +12596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಪಿಎಂಸಿ ಯಾರ್ಡ್ ಬಂಗಾರಪೇಟೆ - 563114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A841"
   },
   {
     "Department": "Pin Code",
@@ -11771,7 +12611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ - 562107",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A842"
   },
   {
     "Department": "Pin Code",
@@ -11785,7 +12626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಸ್ಟಿನ್ ಟೌನ್ - 560047",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A843"
   },
   {
     "Department": "Pin Code",
@@ -11799,7 +12641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವತಿ ಅಂಚೆ ಕಛೇರಿ - 562164",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A844"
   },
   {
     "Department": "Pin Code",
@@ -11813,7 +12656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಬೆಂಗಳೂರು) - 562149",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A845"
   },
   {
     "Department": "Pin Code",
@@ -11827,7 +12671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಕೃಷ್ಣಗಿರಿ) - 635103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A846"
   },
   {
     "Department": "Pin Code",
@@ -11841,7 +12686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ - 560050",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A847"
   },
   {
     "Department": "Pin Code",
@@ -11855,7 +12701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು GPO - 560001",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A848"
   },
   {
     "Department": "Pin Code",
@@ -11869,7 +12716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ - 560300",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A849"
   },
   {
     "Department": "Pin Code",
@@ -11883,7 +12731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ವಿಶ್ವವಿದ್ಯಾಲಯ - 560056",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A850"
   },
   {
     "Department": "Pin Code",
@@ -11897,7 +12746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೇರುಘಟ್ಟ - 560083",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A851"
   },
   {
     "Department": "Pin Code",
@@ -11911,7 +12761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ - 560004",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A852"
   },
   {
     "Department": "Pin Code",
@@ -11925,7 +12776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಟ್ಲಹಳ್ಳಿ - 563123",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A853"
   },
   {
     "Department": "Pin Code",
@@ -11939,7 +12791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು - 560114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A854"
   },
   {
     "Department": "Pin Code",
@@ -11953,7 +12806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳತ್ತೂರು - 635124",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A855"
   },
   {
     "Department": "Pin Code",
@@ -11967,7 +12821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು - 560103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A856"
   },
   {
     "Department": "Pin Code",
@@ -11981,7 +12836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆನ್ಸನ್ ಟೌನ್ - 560046",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A857"
   },
   {
     "Department": "Pin Code",
@@ -11995,7 +12851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆರಿಗೈ - 635105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A858"
   },
   {
     "Department": "Pin Code",
@@ -12009,7 +12866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟಹಲಸೂರು - 562157",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A859"
   },
   {
     "Department": "Pin Code",
@@ -12023,7 +12881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇವೂರು (ರಾಮನಗರ) - 562108",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A860"
   },
   {
     "Department": "Pin Code",
@@ -12037,7 +12896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತನಗರ - 563115",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A861"
   },
   {
     "Department": "Pin Code",
@@ -12051,7 +12911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ - 562109",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A862"
   },
   {
     "Department": "Pin Code",
@@ -12065,7 +12926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೋಲಾರೆ - 560116",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A863"
   },
   {
     "Department": "Pin Code",
@@ -12079,7 +12941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ (ಬೆಂಗಳೂರು) - 560068",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A864"
   },
   {
     "Department": "Pin Code",
@@ -12093,7 +12956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮಸಂದ್ರ ಇಂಡಸ್ಟ್ರಿಯಲ್ ಎಸ್ಟೇಟ್ - 560099",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A865"
   },
   {
     "Department": "Pin Code",
@@ -12107,7 +12971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೂದಿಕೋಟೆ - 563147",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A866"
   },
   {
     "Department": "Pin Code",
@@ -12121,7 +12986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬುರುಡುಗುಂಟೆ - 563159",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A867"
   },
   {
     "Department": "Pin Code",
@@ -12135,7 +13001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಮೆಲರಾಮ್ - 560035",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A868"
   },
   {
     "Department": "Pin Code",
@@ -12149,7 +13016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ರೀಫ್ಸ್ - 563117",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A869"
   },
   {
     "Department": "Pin Code",
@@ -12163,7 +13031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ (ಬೆಂಗಳೂರು) - 560018",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A870"
   },
   {
     "Department": "Pin Code",
@@ -12177,7 +13046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ - 560081",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A871"
   },
   {
     "Department": "Pin Code",
@@ -12191,7 +13061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ - 562160",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A872"
   },
   {
     "Department": "Pin Code",
@@ -12205,7 +13076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ - 562101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A873"
   },
   {
     "Department": "Pin Code",
@@ -12219,7 +13091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ - 560053",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A874"
   },
   {
     "Department": "Pin Code",
@@ -12233,7 +13106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ - 560090",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A875"
   },
   {
     "Department": "Pin Code",
@@ -12247,7 +13121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಸಂದ್ರ - 560061",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A876"
   },
   {
     "Department": "Pin Code",
@@ -12261,7 +13136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಮಾರುಕಟ್ಟೆ - 563125",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A877"
   },
   {
     "Department": "Pin Code",
@@ -12275,7 +13151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "CPC ಆದಾಯ ತೆರಿಗೆ ಇಲಾಖೆ - 560500",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A878"
   },
   {
     "Department": "Pin Code",
@@ -12289,7 +13166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿವಿ ರಾಮನ್ ನಗರ - 560093",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A879"
   },
   {
     "Department": "Pin Code",
@@ -12303,7 +13181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಲಸನೂರು - 563126",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A880"
   },
   {
     "Department": "Pin Code",
@@ -12317,7 +13196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇಶಿಹಳ್ಳಿ ಬಂಗಾರಪೇಟೆ - 563162",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A881"
   },
   {
     "Department": "Pin Code",
@@ -12331,7 +13211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ - 562110",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A882"
   },
   {
     "Department": "Pin Code",
@@ -12345,7 +13226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸ್ಪೇಟ್ - 562111",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A883"
   },
   {
     "Department": "Pin Code",
@@ -12359,7 +13241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಬಜಾರ್ - 561203",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A884"
   },
   {
     "Department": "Pin Code",
@@ -12373,7 +13256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ - 561204",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A885"
   },
   {
     "Department": "Pin Code",
@@ -12387,7 +13271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡದುನ್ನಸಂದ್ರ - 560117",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A886"
   },
   {
     "Department": "Pin Code",
@@ -12401,7 +13286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A887"
   },
   {
     "Department": "Pin Code",
@@ -12415,7 +13301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A888"
   },
   {
     "Department": "Pin Code",
@@ -12429,7 +13316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು - 560071",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A889"
   },
   {
     "Department": "Pin Code",
@@ -12443,7 +13331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "EPIP - 560066",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A890"
   },
   {
     "Department": "Pin Code",
@@ -12457,7 +13346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಸರ್ ಟೌನ್ - 560005",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A891"
   },
   {
     "Department": "Pin Code",
@@ -12471,7 +13361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗವಿಪುರಂ ವಿಸ್ತರಣೆ - 560019",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A892"
   },
   {
     "Department": "Pin Code",
@@ -12485,7 +13376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಯತ್ರಿನಗರ - 560021",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A893"
   },
   {
     "Department": "Pin Code",
@@ -12499,7 +13391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "GCEC ರಾಮನಗರ - 562159",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A894"
   },
   {
     "Department": "Pin Code",
@@ -12513,7 +13406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ (ಬೆಂಗಳೂರು) - 560085",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A895"
   },
   {
     "Department": "Pin Code",
@@ -12527,7 +13421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "GKVK - 560065",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A896"
   },
   {
     "Department": "Pin Code",
@@ -12541,7 +13436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ಎಲೆಕ್ಟ್ರಿಕ್ ಫ್ಯಾಕ್ಟರಿ - 560026",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A897"
   },
   {
     "Department": "Pin Code",
@@ -12555,7 +13451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ರೇಷ್ಮೆ ಫಾರ್ಮ್ - 562161",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A898"
   },
   {
     "Department": "Pin Code",
@@ -12569,7 +13466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಿಪಲ್ಲಿ - 563161",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A899"
   },
   {
     "Department": "Pin Code",
@@ -12583,7 +13481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೂಳೂರು - 572118",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A900"
   },
   {
     "Department": "Pin Code",
@@ -12597,7 +13496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HA ಫಾರ್ಮ್ - 560024",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A901"
   },
   {
     "Department": "Pin Code",
@@ -12611,7 +13511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL II ಹಂತ - 560008",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A902"
   },
   {
     "Department": "Pin Code",
@@ -12625,7 +13526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಂಪಿನಗರ - 560104",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A903"
   },
   {
     "Department": "Pin Code",
@@ -12639,7 +13541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ - 562112",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A904"
   },
   {
     "Department": "Pin Code",
@@ -12653,7 +13556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು - 572120",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A905"
   },
   {
     "Department": "Pin Code",
@@ -12667,7 +13571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೇರೋಹಳ್ಳಿ - 560091",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A906"
   },
   {
     "Department": "Pin Code",
@@ -12681,7 +13586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ - 560088",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A907"
   },
   {
     "Department": "Pin Code",
@@ -12695,7 +13601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸ್ಸರಘಟ್ಟ ಕೆರೆ - 560089",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A908"
   },
   {
     "Department": "Pin Code",
@@ -12709,7 +13616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಹಳ್ಳಿ SO - 572168",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A909"
   },
   {
     "Department": "Pin Code",
@@ -12723,7 +13631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HKP ರಸ್ತೆ - 560051",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A910"
   },
   {
     "Department": "Pin Code",
@@ -12737,7 +13646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳವನಹಳ್ಳಿ - 572121",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A911"
   },
   {
     "Department": "Pin Code",
@@ -12751,7 +13661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಗನೂರು - 562138",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A912"
   },
   {
     "Department": "Pin Code",
@@ -12765,7 +13676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನುಡಿಕೆ - 572122",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A913"
   },
   {
     "Department": "Pin Code",
@@ -12779,7 +13691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊರಮಾವು - 560113",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A914"
   },
   {
     "Department": "Pin Code",
@@ -12793,7 +13706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ - 562114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A915"
   },
   {
     "Department": "Pin Code",
@@ -12807,7 +13721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು - 561210",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A916"
   },
   {
     "Department": "Pin Code",
@@ -12821,7 +13736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಗೋಶಾಲೆ - 635110",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A917"
   },
   {
     "Department": "Pin Code",
@@ -12835,7 +13751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಇಂಡಲ್. ಸಂಕೀರ್ಣ - 635126",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A918"
   },
   {
     "Department": "Pin Code",
@@ -12849,7 +13766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್ - 560102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A919"
   },
   {
     "Department": "Pin Code",
@@ -12863,7 +13781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರು ದುರ್ಗ - 572123",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A920"
   },
   {
     "Department": "Pin Code",
@@ -12877,7 +13796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ (ಬೆಂಗಳೂರು) - 560038",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A921"
   },
   {
     "Department": "Pin Code",
@@ -12891,7 +13811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ - 560013",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A922"
   },
   {
     "Department": "Pin Code",
@@ -12905,7 +13826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪೂರ್ವ - 560014",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A923"
   },
   {
     "Department": "Pin Code",
@@ -12919,7 +13841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಶ್ಚಿಮ - 560015",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A924"
   },
   {
     "Department": "Pin Code",
@@ -12933,7 +13856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ - 560041",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A925"
   },
   {
     "Department": "Pin Code",
@@ -12947,7 +13871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪೂರ್ವ - 560069",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A926"
   },
   {
     "Department": "Pin Code",
@@ -12961,7 +13886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಎಕ್ಸ್ಟೆನ್ ತುಮಕೂರು - 572102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A927"
   },
   {
     "Department": "Pin Code",
@@ -12975,7 +13901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಶ್ಚಿಮ - 560070",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A928"
   },
   {
     "Department": "Pin Code",
@@ -12989,7 +13916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಂಗಾರ್ III ಬ್ಲಾಕ್ - 560011",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A929"
   },
   {
     "Department": "Pin Code",
@@ -13003,7 +13931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ - 560105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A930"
   },
   {
     "Department": "Pin Code",
@@ -13017,7 +13946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ - 560078",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A931"
   },
   {
     "Department": "Pin Code",
@@ -13031,7 +13961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ವಿಸ್ತರಣೆ ಸೋ - 560067",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A932"
   },
   {
     "Department": "Pin Code",
@@ -13045,7 +13976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೈವಾರ - 563128",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A933"
   },
   {
     "Department": "Pin Code",
@@ -13059,7 +13991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಯಾಣನಗರ - 560043",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A934"
   },
   {
     "Department": "Pin Code",
@@ -13073,7 +14006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ - 563129",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A935"
   },
   {
     "Department": "Pin Code",
@@ -13087,7 +14021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ - 562117",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A936"
   },
   {
     "Department": "Pin Code",
@@ -13101,7 +14036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ನಮಂಗಲ - 560115",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A937"
   },
   {
     "Department": "Pin Code",
@@ -13115,7 +14051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪನಹಳ್ಳಿ - 572126",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A938"
   },
   {
     "Department": "Pin Code",
@@ -13129,7 +14066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ - 560060",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A939"
   },
   {
     "Department": "Pin Code",
@@ -13143,7 +14081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ರಸ್ತೆ - 560009",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A940"
   },
   {
     "Department": "Pin Code",
@@ -13157,7 +14096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "KHB ಕಾಲೋನಿ - 560079",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A941"
   },
   {
     "Department": "Pin Code",
@@ -13171,7 +14111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡೇಹಳ್ಳಿ - 560112",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A942"
   },
   {
     "Department": "Pin Code",
@@ -13185,7 +14126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ - 562119",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A943"
   },
   {
     "Department": "Pin Code",
@@ -13199,7 +14141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ - 563101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A944"
   },
   {
     "Department": "Pin Code",
@@ -13213,7 +14156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ವಿಸ್ತರಣೆ - 563102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A945"
   },
   {
     "Department": "Pin Code",
@@ -13227,7 +14171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರ (ತುಮಕೂರು) - 572128",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A946"
   },
   {
     "Department": "Pin Code",
@@ -13241,7 +14186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ I ಬ್ಲಾಕ್ - 560034",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A947"
   },
   {
     "Department": "Pin Code",
@@ -13255,7 +14201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ VI ಬ್ಲಾಕ್ - 560095",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A948"
   },
   {
     "Department": "Pin Code",
@@ -13269,7 +14216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ - 572129",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A949"
   },
   {
     "Department": "Pin Code",
@@ -13283,7 +14231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು - 560077",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A950"
   },
   {
     "Department": "Pin Code",
@@ -13297,7 +14246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ - 560036",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A951"
   },
   {
     "Department": "Pin Code",
@@ -13311,7 +14261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ ಆರ್ ಎಸ್ - 560016",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A952"
   },
   {
     "Department": "Pin Code",
@@ -13325,7 +14276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು - 561101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A953"
   },
   {
     "Department": "Pin Code",
@@ -13339,7 +14291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ - 560111",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A954"
   },
   {
     "Department": "Pin Code",
@@ -13353,7 +14306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೋಡು - 560074",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A955"
   },
   {
     "Department": "Pin Code",
@@ -13367,7 +14321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಪ್ಪಂ - 517425",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A956"
   },
   {
     "Department": "Pin Code",
@@ -13381,7 +14336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುವೆಂಪುನಗರ - 572103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A957"
   },
   {
     "Department": "Pin Code",
@@ -13395,7 +14351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸಂದ್ರ - 572104",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A958"
   },
   {
     "Department": "Pin Code",
@@ -13409,7 +14366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ - 562162",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A959"
   },
   {
     "Department": "Pin Code",
@@ -13423,7 +14381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ - 562120",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A960"
   },
   {
     "Department": "Pin Code",
@@ -13437,7 +14396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ - 560023",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A961"
   },
   {
     "Department": "Pin Code",
@@ -13451,7 +14411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ - 560048",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A962"
   },
   {
     "Department": "Pin Code",
@@ -13465,7 +14426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ - 560003",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A963"
   },
   {
     "Department": "Pin Code",
@@ -13479,7 +14441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು - 563130",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A964"
   },
   {
     "Department": "Pin Code",
@@ -13493,7 +14456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ರೈಲು ನಿಲ್ದಾಣ - 563160",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A965"
   },
   {
     "Department": "Pin Code",
@@ -13507,7 +14471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೆನಹಳ್ಳಿ - 561211",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A966"
   },
   {
     "Department": "Pin Code",
@@ -13521,7 +14486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳವಾಡಿ - 562121",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A967"
   },
   {
     "Department": "Pin Code",
@@ -13535,7 +14501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳೂರು ಎಸ್‌ಒ - 572105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A968"
   },
   {
     "Department": "Pin Code",
@@ -13549,7 +14516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಸೇವಾನಗರ - 560033",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A969"
   },
   {
     "Department": "Pin Code",
@@ -13563,7 +14531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ - 563139",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A970"
   },
   {
     "Department": "Pin Code",
@@ -13577,7 +14546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಠಗೊಂಡಪಲ್ಲಿ - 635114",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A971"
   },
   {
     "Department": "Pin Code",
@@ -13591,7 +14561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಳೆಕೋಟೆ - 561205",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A972"
   },
   {
     "Department": "Pin Code",
@@ -13605,7 +14576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೇಲೂರು (ಕೋಲಾರ) - 562102",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A973"
   },
   {
     "Department": "Pin Code",
@@ -13619,7 +14591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ - 560076",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A974"
   },
   {
     "Department": "Pin Code",
@@ -13633,7 +14606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿಲ್ಕ್ ಕಾಲೋನಿ - 560055",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A975"
   },
   {
     "Department": "Pin Code",
@@ -13647,7 +14621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MSRIT - 560054",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A976"
   },
   {
     "Department": "Pin Code",
@@ -13661,7 +14636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರುಗಮಲೆ - 563146",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A977"
   },
   {
     "Department": "Pin Code",
@@ -13675,7 +14651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮ್ಯೂಸಿಯಂ ರಸ್ತೆ - 560025",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A978"
   },
   {
     "Department": "Pin Code",
@@ -13689,7 +14666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇನಹಳ್ಳಿ - 562163",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A979"
   },
   {
     "Department": "Pin Code",
@@ -13703,7 +14681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ - 560072",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A980"
   },
   {
     "Department": "Pin Code",
@@ -13717,7 +14696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಸಂದ್ರ (ಬೆಂಗಳೂರು) - 560073",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A981"
   },
   {
     "Department": "Pin Code",
@@ -13731,7 +14711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "NAL - 560017",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A982"
   },
   {
     "Department": "Pin Code",
@@ -13745,7 +14726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ - 562122",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A983"
   },
   {
     "Department": "Pin Code",
@@ -13759,7 +14741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ (ಕೋಲಾರ) - 562103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A984"
   },
   {
     "Department": "Pin Code",
@@ -13773,7 +14756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಣನ್ದಿನಿ ಳಯೋಉತ್ - ೫೬೦೦೯೬",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A985"
   },
   {
     "Department": "Pin Code",
@@ -13787,7 +14771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ - 563133",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A986"
   },
   {
     "Department": "Pin Code",
@@ -13801,7 +14786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಯಂಡಹಳ್ಳಿ - 560039",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A987"
   },
   {
     "Department": "Pin Code",
@@ -13815,7 +14801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ - 562123",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A988"
   },
   {
     "Department": "Pin Code",
@@ -13829,7 +14816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ತಿಪ್ಪಸಂದ್ರ - 560075",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A989"
   },
   {
     "Department": "Pin Code",
@@ -13843,7 +14831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಡಘಟ್ಟ - 571433",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A990"
   },
   {
     "Department": "Pin Code",
@@ -13857,7 +14846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ ವಿಸ್ತರಣೆ - 572106",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A991"
   },
   {
     "Department": "Pin Code",
@@ -13871,7 +14861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಮ್ - 563120",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A992"
   },
   {
     "Department": "Pin Code",
@@ -13885,7 +14876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ - 560057",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A993"
   },
   {
     "Department": "Pin Code",
@@ -13899,7 +14891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಸಣ್ಣ ಕೈಗಾರಿಕೆಗಳು - 560058",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A994"
   },
   {
     "Department": "Pin Code",
@@ -13913,7 +14906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೆರೇಸಂದ್ರ - 562104",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A995"
   },
   {
     "Department": "Pin Code",
@@ -13927,7 +14921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ - 560010",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A996"
   },
   {
     "Department": "Pin Code",
@@ -13941,7 +14936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ - 560098",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A997"
   },
   {
     "Department": "Pin Code",
@@ -13955,7 +14951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಮೇಶ್‌ನಗರ - 560037",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A998"
   },
   {
     "Department": "Pin Code",
@@ -13969,7 +14966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "RMV ವಿಸ್ತರಣೆ II ಹಂತ - 560094",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A999"
   },
   {
     "Department": "Pin Code",
@@ -13983,7 +14981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ - 560032",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1000"
   },
   {
     "Department": "Pin Code",
@@ -13997,7 +14996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "RV ನಿಕೇತನ್ - 560059",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1001"
   },
   {
     "Department": "Pin Code",
@@ -14011,7 +15011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ - 560080",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1002"
   },
   {
     "Department": "Pin Code",
@@ -14025,7 +15026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರನಗರ PO - 560092",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1003"
   },
   {
     "Department": "Pin Code",
@@ -14039,7 +15041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ - 562125",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1004"
   },
   {
     "Department": "Pin Code",
@@ -14053,7 +15056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ಸಂಸ್ಥೆ - 560012",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1005"
   },
   {
     "Department": "Pin Code",
@@ -14067,7 +15071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ - 560020",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1006"
   },
   {
     "Department": "Pin Code",
@@ -14081,7 +15086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ - 560027",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1007"
   },
   {
     "Department": "Pin Code",
@@ -14095,7 +15101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಗಟ್ಟಾ ಬಜಾರ್ - 562105",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1008"
   },
   {
     "Department": "Pin Code",
@@ -14109,7 +15116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವನ್ ಚೆಟ್ಟಿ ಗಾರ್ಡನ್ಸ್ - 560042",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1009"
   },
   {
     "Department": "Pin Code",
@@ -14123,7 +15131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲೂರು - 562127",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1010"
   },
   {
     "Department": "Pin Code",
@@ -14137,7 +15146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀ ಜಯಚಾಮರಾಜೇಂದ್ರ ರಸ್ತೆ - 560002",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1011"
   },
   {
     "Department": "Pin Code",
@@ -14151,7 +15161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ - 563135",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1012"
   },
   {
     "Department": "Pin Code",
@@ -14165,7 +15176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಂಟ್ ಥಾಮಸ್ ಟೌನ್ - 560084",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1013"
   },
   {
     "Department": "Pin Code",
@@ -14179,7 +15191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗ್ಗನಹಳ್ಳಿ - 562128",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1014"
   },
   {
     "Department": "Pin Code",
@@ -14193,7 +15206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲೇಬೆಲೆ - 562129",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1015"
   },
   {
     "Department": "Pin Code",
@@ -14207,7 +15221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಮಾಕಾ - 563103",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1016"
   },
   {
     "Department": "Pin Code",
@@ -14221,7 +15236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ - 560029",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1017"
   },
   {
     "Department": "Pin Code",
@@ -14235,7 +15251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ (ಬೆಂಗಳೂರು) - 562130",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1018"
   },
   {
     "Department": "Pin Code",
@@ -14249,7 +15266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ - 563137",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1019"
   },
   {
     "Department": "Pin Code",
@@ -14263,7 +15281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ - 560109",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1020"
   },
   {
     "Department": "Pin Code",
@@ -14277,7 +15296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಥಾಲಿ - 635118",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1021"
   },
   {
     "Department": "Pin Code",
@@ -14291,7 +15311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪ್ಪಸಂದ್ರ - 562131",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1022"
   },
   {
     "Department": "Pin Code",
@@ -14305,7 +15326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೊಂಡೇಭಾವಿ - 561213",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1023"
   },
   {
     "Department": "Pin Code",
@@ -14319,7 +15341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೋವಿನಕೆರೆ - 572138",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1024"
   },
   {
     "Department": "Pin Code",
@@ -14333,7 +15356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರಬೇತಿ ಕಮಾಂಡ್ IAF - 560006",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1025"
   },
   {
     "Department": "Pin Code",
@@ -14347,7 +15371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು - 572101",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1026"
   },
   {
     "Department": "Pin Code",
@@ -14361,7 +15386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು - 562132",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1027"
   },
   {
     "Department": "Pin Code",
@@ -14375,7 +15401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉದಯಪುರ - 560082",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1028"
   },
   {
     "Department": "Pin Code",
@@ -14389,7 +15416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಲ್ಲಾಳು ಉಪನಗರ - 560110",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1029"
   },
   {
     "Department": "Pin Code",
@@ -14403,7 +15431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಡಿಗೆರೆ - 572140",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1030"
   },
   {
     "Department": "Pin Code",
@@ -14417,7 +15446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು - 560087",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1031"
   },
   {
     "Department": "Pin Code",
@@ -14431,7 +15461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತ ನಗರ - 560052",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1032"
   },
   {
     "Department": "Pin Code",
@@ -14445,7 +15476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರೇಗೌಡನದೊಡ್ಡಿ - 561201",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1033"
   },
   {
     "Department": "Pin Code",
@@ -14459,7 +15491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ - 563157",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1034"
   },
   {
     "Department": "Pin Code",
@@ -14473,7 +15506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಂಕಟೇಶಪುರ - 560045",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1035"
   },
   {
     "Department": "Pin Code",
@@ -14487,7 +15521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಪ್ಪನಪಲ್ಲಿ - 635121",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1036"
   },
   {
     "Department": "Pin Code",
@@ -14501,7 +15536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ - 560097",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1037"
   },
   {
     "Department": "Pin Code",
@@ -14515,7 +15551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ (ಬೆಂಗಳೂರು) - 560040",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1038"
   },
   {
     "Department": "Pin Code",
@@ -14529,7 +15566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ - 562135",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1039"
   },
   {
     "Department": "Pin Code",
@@ -14543,7 +15581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ಯಾನಗರ - 560049",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1040"
   },
   {
     "Department": "Pin Code",
@@ -14557,7 +15596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಸ್ಟ್ ಆಫ್ ಕಾರ್ಡ್ ರೋಡ್ II ಹಂತ - 560086",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1041"
   },
   {
     "Department": "Pin Code",
@@ -14571,7 +15611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಪ್ರೋ ಲಿಮಿಟೆಡ್ - 560100",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1042"
   },
   {
     "Department": "Pin Code",
@@ -14585,7 +15626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್ - 560064",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1043"
   },
   {
     "Department": "Pin Code",
@@ -14599,7 +15641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಬಜಾರ್ - 560022",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1044"
   },
   {
     "Department": "stamps_dro",
@@ -14613,7 +15656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1045"
   },
   {
     "Department": "stamps_dro",
@@ -14627,7 +15671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ."
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ",
+    "cellRef": "A1046"
   },
   {
     "Department": "stamps_dro",
@@ -14641,7 +15686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ. ಬೆಳಗಲಿ"
+    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ ಬೆಳಗಲಿ",
+    "cellRef": "A1047"
   },
   {
     "Department": "stamps_dro",
@@ -14655,7 +15701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1048"
   },
   {
     "Department": "stamps_dro",
@@ -14669,7 +15716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1049"
   },
   {
     "Department": "stamps_dro",
@@ -14683,7 +15731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1050"
   },
   {
     "Department": "stamps_dro",
@@ -14697,7 +15746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1051"
   },
   {
     "Department": "stamps_dro",
@@ -14711,7 +15761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1052"
   },
   {
     "Department": "stamps_dro",
@@ -14725,7 +15776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ",
+    "cellRef": "A1053"
   },
   {
     "Department": "stamps_dro",
@@ -14739,7 +15791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1054"
   },
   {
     "Department": "stamps_dro",
@@ -14753,7 +15806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1055"
   },
   {
     "Department": "stamps_dro",
@@ -14767,7 +15821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1056"
   },
   {
     "Department": "stamps_dro",
@@ -14781,7 +15836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1057"
   },
   {
     "Department": "stamps_dro",
@@ -14795,7 +15851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1058"
   },
   {
     "Department": "stamps_dro",
@@ -14809,7 +15866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎ.ಎನ್. ಭಾರತಿ"
+    "NameKN": "ಎಎನ್ ಭಾರತಿ",
+    "cellRef": "A1059"
   },
   {
     "Department": "stamps_dro",
@@ -14823,7 +15881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1060"
   },
   {
     "Department": "stamps_dro",
@@ -14837,7 +15896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1061"
   },
   {
     "Department": "stamps_dro",
@@ -14851,7 +15911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ.ಎಚ್. ಶಂಕರೇಗೌಡ"
+    "NameKN": "ಬಿ.ಎಚ್.ಶಂಕರೇಗೌಡ",
+    "cellRef": "A1062"
   },
   {
     "Department": "stamps_dro",
@@ -14865,7 +15926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಬುರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1063"
   },
   {
     "Department": "stamps_dro",
@@ -14879,7 +15941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1064"
   },
   {
     "Department": "stamps_dro",
@@ -14893,7 +15956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಗು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1065"
   },
   {
     "Department": "stamps_dro",
@@ -14907,7 +15971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎನ್. ಶ್ರೀನಿಧಿ"
+    "NameKN": "ಎನ್ ಶ್ರೀನಿಧಿ",
+    "cellRef": "A1066"
   },
   {
     "Department": "stamps_dro",
@@ -14921,7 +15986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1067"
   },
   {
     "Department": "stamps_dro",
@@ -14935,7 +16001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1068"
   },
   {
     "Department": "stamps_dro",
@@ -14949,7 +16016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1069"
   },
   {
     "Department": "stamps_dro",
@@ -14963,7 +16031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1070"
   },
   {
     "Department": "stamps_dro",
@@ -14977,7 +16046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1071"
   },
   {
     "Department": "stamps_dro",
@@ -14991,7 +16061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್"
+    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್",
+    "cellRef": "A1072"
   },
   {
     "Department": "stamps_dro",
@@ -15005,7 +16076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಂ. ಶ್ರೀದೇವಿ"
+    "NameKN": "ಎಂ ಶ್ರೀದೇವಿ",
+    "cellRef": "A1073"
   },
   {
     "Department": "stamps_dro",
@@ -15019,7 +16091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1074"
   },
   {
     "Department": "stamps_dro",
@@ -15033,7 +16106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಸ್.ಬಿ. ದವಳೇಶ್ವರ"
+    "NameKN": "ಎಸ್.ಬಿ.ದವಳೇಶ್ವರ",
+    "cellRef": "A1075"
   },
   {
     "Department": "stamps_dro",
@@ -15047,7 +16121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ. ಶ್ರೀಕಾಂತ್"
+    "NameKN": "ಬಿ ಶ್ರೀಕಾಂತ್",
+    "cellRef": "A1076"
   },
   {
     "Department": "stamps_dro",
@@ -15061,7 +16136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1077"
   },
   {
     "Department": "stamps_dro",
@@ -15075,7 +16151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1078"
   },
   {
     "Department": "stamps_sro",
@@ -15089,7 +16166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಫಜಲಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1079"
   },
   {
     "Department": "stamps_sro",
@@ -15103,7 +16181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಳಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1080"
   },
   {
     "Department": "stamps_sro",
@@ -15117,7 +16196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1081"
   },
   {
     "Department": "stamps_sro",
@@ -15131,7 +16211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ"
+    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ",
+    "cellRef": "A1082"
   },
   {
     "Department": "stamps_sro",
@@ -15145,7 +16226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಣ್ಣಿಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1083"
   },
   {
     "Department": "stamps_sro",
@@ -15159,7 +16241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಕಲಗೂಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1084"
   },
   {
     "Department": "stamps_sro",
@@ -15173,7 +16256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಸೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1085"
   },
   {
     "Department": "stamps_sro",
@@ -15187,7 +16271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಥಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1086"
   },
   {
     "Department": "stamps_sro",
@@ -15201,7 +16286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ"
+    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ",
+    "cellRef": "A1087"
   },
   {
     "Department": "stamps_sro",
@@ -15215,7 +16301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಔರಾದ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1088"
   },
   {
     "Department": "stamps_sro",
@@ -15229,7 +16316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾದಾಮಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1089"
   },
   {
     "Department": "stamps_sro",
@@ -15243,7 +16331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1090"
   },
   {
     "Department": "stamps_sro",
@@ -15257,7 +16346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1091"
   },
   {
     "Department": "stamps_sro",
@@ -15271,7 +16361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಲಹೊಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1092"
   },
   {
     "Department": "stamps_sro",
@@ -15285,7 +16376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1093"
   },
   {
     "Department": "stamps_sro",
@@ -15299,7 +16391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್",
+    "cellRef": "A1094"
   },
   {
     "Department": "stamps_sro",
@@ -15313,7 +16406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ"
+    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ",
+    "cellRef": "A1095"
   },
   {
     "Department": "stamps_sro",
@@ -15327,7 +16421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1096"
   },
   {
     "Department": "stamps_sro",
@@ -15341,7 +16436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1097"
   },
   {
     "Department": "stamps_sro",
@@ -15355,7 +16451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಾವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1098"
   },
   {
     "Department": "stamps_sro",
@@ -15369,7 +16466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1099"
   },
   {
     "Department": "stamps_sro",
@@ -15383,7 +16481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1100"
   },
   {
     "Department": "stamps_sro",
@@ -15397,7 +16496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಟವಾಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1101"
   },
   {
     "Department": "stamps_sro",
@@ -15411,7 +16511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವಕಲ್ಯಾಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1102"
   },
   {
     "Department": "stamps_sro",
@@ -15425,7 +16526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಬಾಗೇವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1103"
   },
   {
     "Department": "stamps_sro",
@@ -15439,7 +16541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎ. ರಾಘವೇಂದ್ರ"
+    "NameKN": "ಎ ರಾಘವೇಂದ್ರ",
+    "cellRef": "A1104"
   },
   {
     "Department": "stamps_sro",
@@ -15453,7 +16556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್. ಕಟ್ಟಿಮನಿ"
+    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್ ಕಟ್ಟಿಮನಿ",
+    "cellRef": "A1105"
   },
   {
     "Department": "stamps_sro",
@@ -15467,7 +16571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1106"
   },
   {
     "Department": "stamps_sro",
@@ -15481,7 +16586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1107"
   },
   {
     "Department": "stamps_sro",
@@ -15495,7 +16601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1108"
   },
   {
     "Department": "stamps_sro",
@@ -15509,7 +16616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ತಂಗಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1109"
   },
   {
     "Department": "stamps_sro",
@@ -15523,7 +16631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಲೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1110"
   },
   {
     "Department": "stamps_sro",
@@ -15537,7 +16646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟದಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1111"
   },
   {
     "Department": "stamps_sro",
@@ -15551,7 +16661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭದ್ರಾವತಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1112"
   },
   {
     "Department": "stamps_sro",
@@ -15565,7 +16676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1113"
   },
   {
     "Department": "stamps_sro",
@@ -15579,7 +16691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಟ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1114"
   },
   {
     "Department": "stamps_sro",
@@ -15593,7 +16706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1115"
   },
   {
     "Department": "stamps_sro",
@@ -15607,7 +16721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿದರಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್"
+    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್",
+    "cellRef": "A1116"
   },
   {
     "Department": "stamps_sro",
@@ -15621,7 +16736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1117"
   },
   {
     "Department": "stamps_sro",
@@ -15635,7 +16751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಳಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1118"
   },
   {
     "Department": "stamps_sro",
@@ -15649,7 +16766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಸನ್ನ ಜಿ"
+    "NameKN": "ಪ್ರಸನ್ನ ಜಿ",
+    "cellRef": "A1119"
   },
   {
     "Department": "stamps_sro",
@@ -15663,7 +16781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ರಹ್ಮಾವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1120"
   },
   {
     "Department": "stamps_sro",
@@ -15677,7 +16796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM ಲೇಔಟ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಾವ್ಯ ಕೆ. ಕೋರ"
+    "NameKN": "ಕಾವ್ಯ ಕೆ ಕೋರ",
+    "cellRef": "A1121"
   },
   {
     "Department": "stamps_sro",
@@ -15691,7 +16811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1122"
   },
   {
     "Department": "stamps_sro",
@@ -15705,7 +16826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ.ವಿ. ರವಿಕುಮಾರ್"
+    "NameKN": "ಕೆ ವಿ ರವಿಕುಮಾರ್",
+    "cellRef": "A1123"
   },
   {
     "Department": "stamps_sro",
@@ -15719,7 +16841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1124"
   },
   {
     "Department": "stamps_sro",
@@ -15733,7 +16856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1125"
   },
   {
     "Department": "stamps_sro",
@@ -15747,7 +16871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಉಮಾದೇವಿ ಎ.ಎಸ್"
+    "NameKN": "ಉಮಾದೇವಿ ಎಎಸ್",
+    "cellRef": "A1126"
   },
   {
     "Department": "stamps_sro",
@@ -15761,7 +16886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1127"
   },
   {
     "Department": "stamps_sro",
@@ -15775,7 +16901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1128"
   },
   {
     "Department": "stamps_sro",
@@ -15789,7 +16916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1129"
   },
   {
     "Department": "stamps_sro",
@@ -15803,7 +16931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1130"
   },
   {
     "Department": "stamps_sro",
@@ -15817,7 +16946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1131"
   },
   {
     "Department": "stamps_sro",
@@ -15831,7 +16961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1132"
   },
   {
     "Department": "stamps_sro",
@@ -15845,7 +16976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕೋಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1133"
   },
   {
     "Department": "stamps_sro",
@@ -15859,7 +16991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂಚೋಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1134"
   },
   {
     "Department": "stamps_sro",
@@ -15873,7 +17006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1135"
   },
   {
     "Department": "stamps_sro",
@@ -15887,7 +17021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1136"
   },
   {
     "Department": "stamps_sro",
@@ -15901,7 +17036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ತಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1137"
   },
   {
     "Department": "stamps_sro",
@@ -15915,7 +17051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸನಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ"
+    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ",
+    "cellRef": "A1138"
   },
   {
     "Department": "stamps_sro",
@@ -15929,7 +17066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1139"
   },
   {
     "Department": "stamps_sro",
@@ -15943,7 +17081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1140"
   },
   {
     "Department": "stamps_sro",
@@ -15957,7 +17096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್"
+    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್",
+    "cellRef": "A1141"
   },
   {
     "Department": "stamps_sro",
@@ -15971,7 +17111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1142"
   },
   {
     "Department": "stamps_sro",
@@ -15985,7 +17126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಎಚ್.ಎಸ್"
+    "NameKN": "ಸತೀಶ್ ಎಚ್ ಎಸ್",
+    "cellRef": "A1143"
   },
   {
     "Department": "stamps_sro",
@@ -15999,7 +17141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1144"
   },
   {
     "Department": "stamps_sro",
@@ -16013,7 +17156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಜೇಂದ್ರಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1145"
   },
   {
     "Department": "stamps_sro",
@@ -16027,7 +17171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ"
+    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ",
+    "cellRef": "A1146"
   },
   {
     "Department": "stamps_sro",
@@ -16041,7 +17186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ಕೆ. ಶಾಂತಮೂರ್ತಿ"
+    "NameKN": "ಎಂ.ಕೆ.ಶಾಂತಮೂರ್ತಿ",
+    "cellRef": "A1147"
   },
   {
     "Department": "stamps_sro",
@@ -16055,7 +17201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾವತಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1148"
   },
   {
     "Department": "stamps_sro",
@@ -16069,7 +17216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1149"
   },
   {
     "Department": "stamps_sro",
@@ -16083,7 +17231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋಕಾಕ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1150"
   },
   {
     "Department": "stamps_sro",
@@ -16097,7 +17246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1151"
   },
   {
     "Department": "stamps_sro",
@@ -16111,7 +17261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1152"
   },
   {
     "Department": "stamps_sro",
@@ -16125,7 +17276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಬರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1153"
   },
   {
     "Department": "stamps_sro",
@@ -16139,7 +17291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಳೇದಗುಡ್ಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1154"
   },
   {
     "Department": "stamps_sro",
@@ -16153,7 +17306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಂಡ್ಲುಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1155"
   },
   {
     "Department": "stamps_sro",
@@ -16167,7 +17321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಗರಿಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1156"
   },
   {
     "Department": "stamps_sro",
@@ -16181,7 +17336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಳಿಯಾಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1157"
   },
   {
     "Department": "stamps_sro",
@@ -16195,7 +17351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್"
+    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್",
+    "cellRef": "A1158"
   },
   {
     "Department": "stamps_sro",
@@ -16209,7 +17366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾನಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1159"
   },
   {
     "Department": "stamps_sro",
@@ -16223,7 +17381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1160"
   },
   {
     "Department": "stamps_sro",
@@ -16237,7 +17396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1161"
   },
   {
     "Department": "stamps_sro",
@@ -16251,7 +17411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಿಹರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1162"
   },
   {
     "Department": "stamps_sro",
@@ -16265,7 +17426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1163"
   },
   {
     "Department": "stamps_sro",
@@ -16279,7 +17441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1164"
   },
   {
     "Department": "stamps_sro",
@@ -16293,7 +17456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚೈತ್ರಾ ಬಿ.ಎ"
+    "NameKN": "ಚೈತ್ರಾ ಬಿಎ",
+    "cellRef": "A1165"
   },
   {
     "Department": "stamps_sro",
@@ -16307,7 +17471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗಡದೇವನ ಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1166"
   },
   {
     "Department": "stamps_sro",
@@ -16321,7 +17486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್"
+    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್",
+    "cellRef": "A1167"
   },
   {
     "Department": "stamps_sro",
@@ -16335,7 +17501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1168"
   },
   {
     "Department": "stamps_sro",
@@ -16349,7 +17516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರಿಯೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1169"
   },
   {
     "Department": "stamps_sro",
@@ -16363,7 +17531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳಲ್ಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1170"
   },
   {
     "Department": "stamps_sro",
@@ -16377,7 +17546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳೆನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1171"
   },
   {
     "Department": "stamps_sro",
@@ -16391,7 +17561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1172"
   },
   {
     "Department": "stamps_sro",
@@ -16405,7 +17576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1173"
   },
   {
     "Department": "stamps_sro",
@@ -16419,7 +17591,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1174"
   },
   {
     "Department": "stamps_sro",
@@ -16433,7 +17606,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿ. ಗೀತಾ"
+    "NameKN": "ವಿ ಗೀತಾ",
+    "cellRef": "A1175"
   },
   {
     "Department": "stamps_sro",
@@ -16447,7 +17621,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1176"
   },
   {
     "Department": "stamps_sro",
@@ -16461,7 +17636,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1177"
   },
   {
     "Department": "stamps_sro",
@@ -16475,7 +17651,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ ಉತ್ತರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1178"
   },
   {
     "Department": "stamps_sro",
@@ -16489,7 +17666,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ (ದಕ್ಷಿಣ)",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1179"
   },
   {
     "Department": "stamps_sro",
@@ -16503,7 +17681,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಕ್ಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1180"
   },
   {
     "Department": "stamps_sro",
@@ -16517,7 +17696,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1181"
   },
   {
     "Department": "stamps_sro",
@@ -16531,7 +17711,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಮ್ನಾಬಾದ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1182"
   },
   {
     "Department": "stamps_sro",
@@ -16545,7 +17726,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುನಗುಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1183"
   },
   {
     "Department": "stamps_sro",
@@ -16559,7 +17741,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1184"
   },
   {
     "Department": "stamps_sro",
@@ -16573,7 +17756,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1185"
   },
   {
     "Department": "stamps_sro",
@@ -16587,7 +17771,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂವಿನ ಹಡಗಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1186"
   },
   {
     "Department": "stamps_sro",
@@ -16601,7 +17786,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಳಕಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1187"
   },
   {
     "Department": "stamps_sro",
@@ -16615,7 +17801,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1188"
   },
   {
     "Department": "stamps_sro",
@@ -16629,7 +17816,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಿ.ಜೆ. ಪ್ರಭಾಕರ್"
+    "NameKN": "ಸಿಜೆ ಪ್ರಭಾಕರ್",
+    "cellRef": "A1189"
   },
   {
     "Department": "stamps_sro",
@@ -16643,7 +17831,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1190"
   },
   {
     "Department": "stamps_sro",
@@ -16657,7 +17846,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಸ್. ಎಸ್. ಸ್ವರ್ಣಲತಾ"
+    "NameKN": "ಎಸ್ ಎಸ್ ಸ್ವರ್ಣಲತಾ",
+    "cellRef": "A1191"
   },
   {
     "Department": "stamps_sro",
@@ -16671,7 +17861,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಮಖಂಡಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1192"
   },
   {
     "Department": "stamps_sro",
@@ -16685,7 +17876,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಬಿ. ಗುರು ರಾಘವೇಂದ್ರ"
+    "NameKN": "ಬಿ ಗುರು ರಾಘವೇಂದ್ರ",
+    "cellRef": "A1193"
   },
   {
     "Department": "stamps_sro",
@@ -16699,7 +17891,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೇವರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1194"
   },
   {
     "Department": "stamps_sro",
@@ -16713,7 +17906,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಜಲಿ ಸಿ"
+    "NameKN": "ಅಂಜಲಿ ಸಿ",
+    "cellRef": "A1195"
   },
   {
     "Department": "stamps_sro",
@@ -16727,7 +17921,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ. ಆರ್. ದೇವರಾಜು"
+    "NameKN": "ಕೆ ಆರ್ ದೇವರಾಜು",
+    "cellRef": "A1196"
   },
   {
     "Department": "stamps_sro",
@@ -16741,7 +17936,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1197"
   },
   {
     "Department": "stamps_sro",
@@ -16755,7 +17951,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1198"
   },
   {
     "Department": "stamps_sro",
@@ -16769,7 +17966,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ"
+    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ",
+    "cellRef": "A1199"
   },
   {
     "Department": "stamps_sro",
@@ -16783,7 +17981,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಡೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1200"
   },
   {
     "Department": "stamps_sro",
@@ -16797,7 +17996,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲಘಟಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1201"
   },
   {
     "Department": "stamps_sro",
@@ -16811,7 +18011,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಂಪ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1202"
   },
   {
     "Department": "stamps_sro",
@@ -16825,7 +18026,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1203"
   },
   {
     "Department": "stamps_sro",
@@ -16839,7 +18041,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರಟಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1204"
   },
   {
     "Department": "stamps_sro",
@@ -16853,7 +18056,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1205"
   },
   {
     "Department": "stamps_sro",
@@ -16867,7 +18071,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1206"
   },
   {
     "Department": "stamps_sro",
@@ -16881,7 +18086,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವೈ.ಎಚ್. ವೆಂಕಟೇಶ್"
+    "NameKN": "ವೈ.ಎಚ್.ವೆಂಕಟೇಶ್",
+    "cellRef": "A1207"
   },
   {
     "Department": "stamps_sro",
@@ -16895,7 +18101,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1208"
   },
   {
     "Department": "stamps_sro",
@@ -16909,7 +18116,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಖಾನಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1209"
   },
   {
     "Department": "stamps_sro",
@@ -16923,7 +18131,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1210"
   },
   {
     "Department": "stamps_sro",
@@ -16937,7 +18146,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1211"
   },
   {
     "Department": "stamps_sro",
@@ -16951,7 +18161,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1212"
   },
   {
     "Department": "stamps_sro",
@@ -16965,7 +18176,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1213"
   },
   {
     "Department": "stamps_sro",
@@ -16979,7 +18191,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1214"
   },
   {
     "Department": "stamps_sro",
@@ -16993,7 +18206,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1215"
   },
   {
     "Department": "stamps_sro",
@@ -17007,7 +18221,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಆರ್. ರಾಮಪ್ರಸಾದ್"
+    "NameKN": "ಆರ್ ರಾಮಪ್ರಸಾದ್",
+    "cellRef": "A1216"
   },
   {
     "Department": "stamps_sro",
@@ -17021,7 +18236,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೇರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1217"
   },
   {
     "Department": "stamps_sro",
@@ -17035,7 +18251,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೂಡ್ಲಿಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1218"
   },
   {
     "Department": "stamps_sro",
@@ -17049,7 +18266,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಟಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1219"
   },
   {
     "Department": "stamps_sro",
@@ -17063,7 +18281,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಗೋಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1220"
   },
   {
     "Department": "stamps_sro",
@@ -17077,7 +18296,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1221"
   },
   {
     "Department": "stamps_sro",
@@ -17091,7 +18311,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1222"
   },
   {
     "Department": "stamps_sro",
@@ -17105,7 +18326,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುರುಗೋಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1223"
   },
   {
     "Department": "stamps_sro",
@@ -17119,7 +18341,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಷ್ಟಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1224"
   },
   {
     "Department": "stamps_sro",
@@ -17133,7 +18356,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್"
+    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್",
+    "cellRef": "A1225"
   },
   {
     "Department": "stamps_sro",
@@ -17147,7 +18371,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1226"
   },
   {
     "Department": "stamps_sro",
@@ -17161,7 +18386,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಷ್ಮೇಶ್ವರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1227"
   },
   {
     "Department": "stamps_sro",
@@ -17175,7 +18401,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗಶುಗರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1228"
   },
   {
     "Department": "stamps_sro",
@@ -17189,7 +18416,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ವಿ. ಸತೀಶ್"
+    "NameKN": "ಎಂವಿ ಸತೀಶ್",
+    "cellRef": "A1229"
   },
   {
     "Department": "stamps_sro",
@@ -17203,7 +18431,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1230"
   },
   {
     "Department": "stamps_sro",
@@ -17217,7 +18446,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1231"
   },
   {
     "Department": "stamps_sro",
@@ -17231,7 +18461,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1232"
   },
   {
     "Department": "stamps_sro",
@@ -17245,7 +18476,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1233"
   },
   {
     "Department": "stamps_sro",
@@ -17259,7 +18491,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಮ್ಯಾ ಎನ್"
+    "NameKN": "ರಮ್ಯಾ ಎನ್",
+    "cellRef": "A1234"
   },
   {
     "Department": "stamps_sro",
@@ -17273,7 +18506,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1235"
   },
   {
     "Department": "stamps_sro",
@@ -17287,7 +18521,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿಕ್ರಮ್ ಕೆ. ಮಗರ್"
+    "NameKN": "ವಿಕ್ರಮ್ ಕೆ ಮಗರ್",
+    "cellRef": "A1236"
   },
   {
     "Department": "stamps_sro",
@@ -17301,7 +18536,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1237"
   },
   {
     "Department": "stamps_sro",
@@ -17315,7 +18551,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1238"
   },
   {
     "Department": "stamps_sro",
@@ -17329,7 +18566,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1239"
   },
   {
     "Department": "stamps_sro",
@@ -17343,7 +18581,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ತಾಲೂಕು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1240"
   },
   {
     "Department": "stamps_sro",
@@ -17357,7 +18596,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾನ್ವಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1241"
   },
   {
     "Department": "stamps_sro",
@@ -17371,7 +18611,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿರ್ಲೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1242"
   },
   {
     "Department": "stamps_sro",
@@ -17385,7 +18626,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೊಳಕಾಲ್ಮೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1243"
   },
   {
     "Department": "stamps_sro",
@@ -17399,7 +18641,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಬಿದ್ರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1244"
   },
   {
     "Department": "stamps_sro",
@@ -17413,7 +18656,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುದ್ದೇಬಿಹಾಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1245"
   },
   {
     "Department": "stamps_sro",
@@ -17427,7 +18671,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಧೋಳ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1246"
   },
   {
     "Department": "stamps_sro",
@@ -17441,7 +18686,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಿಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1247"
   },
   {
     "Department": "stamps_sro",
@@ -17455,7 +18701,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1248"
   },
   {
     "Department": "stamps_sro",
@@ -17469,7 +18716,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1249"
   },
   {
     "Department": "stamps_sro",
@@ -17483,7 +18731,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡಗೋಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1250"
   },
   {
     "Department": "stamps_sro",
@@ -17497,7 +18746,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡರಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1251"
   },
   {
     "Department": "stamps_sro",
@@ -17511,7 +18761,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರಗೋಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1252"
   },
   {
     "Department": "stamps_sro",
@@ -17525,7 +18776,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪೂರ್ವ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1253"
   },
   {
     "Department": "stamps_sro",
@@ -17539,7 +18791,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1254"
   },
   {
     "Department": "stamps_sro",
@@ -17553,7 +18806,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪಶ್ಚಿಮ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1255"
   },
   {
     "Department": "stamps_sro",
@@ -17567,7 +18821,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು (ಉತ್ತರ)",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1256"
   },
   {
     "Department": "stamps_sro",
@@ -17581,7 +18836,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1257"
   },
   {
     "Department": "stamps_sro",
@@ -17595,7 +18851,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚಂಪಾ ಎಲ್"
+    "NameKN": "ಚಂಪಾ ಎಲ್",
+    "cellRef": "A1258"
   },
   {
     "Department": "stamps_sro",
@@ -17609,7 +18866,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಜನಗೂಡು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1259"
   },
   {
     "Department": "stamps_sro",
@@ -17623,7 +18881,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಗುಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1260"
   },
   {
     "Department": "stamps_sro",
@@ -17637,7 +18896,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಿಂಹರಾಜಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1261"
   },
   {
     "Department": "stamps_sro",
@@ -17651,7 +18911,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನವಲಗುಂದ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1262"
   },
   {
     "Department": "stamps_sro",
@@ -17665,7 +18926,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆ.ಪಿ"
+    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆಪಿ",
+    "cellRef": "A1263"
   },
   {
     "Department": "stamps_sro",
@@ -17679,7 +18941,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಪ್ಪಾಣಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1264"
   },
   {
     "Department": "stamps_sro",
@@ -17693,7 +18956,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ನುಗ್ಗೇಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1265"
   },
   {
     "Department": "stamps_sro",
@@ -17707,7 +18971,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾಂಡವಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1266"
   },
   {
     "Department": "stamps_sro",
@@ -17721,7 +18986,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1267"
   },
   {
     "Department": "stamps_sro",
@@ -17735,7 +19001,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕರಿಬಸವ ಗೌಡ"
+    "NameKN": "ಕರಿಬಸವ ಗೌಡ",
+    "cellRef": "A1268"
   },
   {
     "Department": "stamps_sro",
@@ -17749,7 +19016,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿರಿಯಾಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1269"
   },
   {
     "Department": "stamps_sro",
@@ -17763,7 +19031,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೊನ್ನಂಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1270"
   },
   {
     "Department": "stamps_sro",
@@ -17777,7 +19046,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1271"
   },
   {
     "Department": "stamps_sro",
@@ -17791,7 +19061,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಬಾಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1272"
   },
   {
     "Department": "stamps_sro",
@@ -17805,7 +19076,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1273"
   },
   {
     "Department": "stamps_sro",
@@ -17819,7 +19091,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ."
+    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ",
+    "cellRef": "A1274"
   },
   {
     "Department": "stamps_sro",
@@ -17833,7 +19106,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1275"
   },
   {
     "Department": "stamps_sro",
@@ -17847,7 +19121,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1276"
   },
   {
     "Department": "stamps_sro",
@@ -17861,7 +19136,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಣಿಬೆನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1277"
   },
   {
     "Department": "stamps_sro",
@@ -17875,7 +19151,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರೋಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1278"
   },
   {
     "Department": "stamps_sro",
@@ -17889,7 +19166,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ. ಗಿರೀಶ್"
+    "NameKN": "ಎಂ ಗಿರೀಶ್",
+    "cellRef": "A1279"
   },
   {
     "Department": "stamps_sro",
@@ -17903,7 +19181,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಲಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1280"
   },
   {
     "Department": "stamps_sro",
@@ -17917,7 +19196,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾಗರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1281"
   },
   {
     "Department": "stamps_sro",
@@ -17931,7 +19211,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಕಲೇಶಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1282"
   },
   {
     "Department": "stamps_sro",
@@ -17945,7 +19226,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಡೂರ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1283"
   },
   {
     "Department": "stamps_sro",
@@ -17959,7 +19241,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ"
+    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ",
+    "cellRef": "A1284"
   },
   {
     "Department": "stamps_sro",
@@ -17973,7 +19256,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸವಣೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1285"
   },
   {
     "Department": "stamps_sro",
@@ -17987,7 +19271,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಡಮ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1286"
   },
   {
     "Department": "stamps_sro",
@@ -18001,7 +19286,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಹಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1287"
   },
   {
     "Department": "stamps_sro",
@@ -18015,7 +19301,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರನಾರಾಯಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1288"
   },
   {
     "Department": "stamps_sro",
@@ -18029,7 +19316,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಘವೇಂದ್ರ"
+    "NameKN": "ರಾಘವೇಂದ್ರ",
+    "cellRef": "A1289"
   },
   {
     "Department": "stamps_sro",
@@ -18043,7 +19331,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1290"
   },
   {
     "Department": "stamps_sro",
@@ -18057,7 +19346,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಗ್ಗೋನ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1291"
   },
   {
     "Department": "stamps_sro",
@@ -18071,7 +19361,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಕಾರಿಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1292"
   },
   {
     "Department": "stamps_sro",
@@ -18085,7 +19376,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1293"
   },
   {
     "Department": "stamps_sro",
@@ -18099,7 +19391,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಗುಪ್ಪಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1294"
   },
   {
     "Department": "stamps_sro",
@@ -18113,7 +19406,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಹಟ್ಟಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1295"
   },
   {
     "Department": "stamps_sro",
@@ -18127,7 +19421,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅನಿತಾ ಜಿ. ಬಡಿಗೇರ್"
+    "NameKN": "ಅನಿತಾ ಜಿ ಬಡಿಗೇರ್",
+    "cellRef": "A1296"
   },
   {
     "Department": "stamps_sro",
@@ -18141,7 +19436,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೋರಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1297"
   },
   {
     "Department": "stamps_sro",
@@ -18155,7 +19451,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೃಂಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1298"
   },
   {
     "Department": "stamps_sro",
@@ -18169,7 +19466,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1299"
   },
   {
     "Department": "stamps_sro",
@@ -18183,7 +19481,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂದಗಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1300"
   },
   {
     "Department": "stamps_sro",
@@ -18197,7 +19496,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂಧನೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1301"
   },
   {
     "Department": "stamps_sro",
@@ -18211,7 +19511,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1302"
   },
   {
     "Department": "stamps_sro",
@@ -18225,7 +19526,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರ್ಸಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1303"
   },
   {
     "Department": "stamps_sro",
@@ -18239,7 +19541,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಮವಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1304"
   },
   {
     "Department": "stamps_sro",
@@ -18253,7 +19556,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೊರಬ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1305"
   },
   {
     "Department": "stamps_sro",
@@ -18267,7 +19571,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೌದತ್ತಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1306"
   },
   {
     "Department": "stamps_sro",
@@ -18281,7 +19586,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1307"
   },
   {
     "Department": "stamps_sro",
@@ -18295,7 +19601,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಮಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಚ್. ಎಸ್. ಅರವಿಂದ್"
+    "NameKN": "ಎಚ್ ಎಸ್ ಅರವಿಂದ್",
+    "cellRef": "A1308"
   },
   {
     "Department": "stamps_sro",
@@ -18309,7 +19616,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಂಗಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1309"
   },
   {
     "Department": "stamps_sro",
@@ -18323,7 +19631,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1310"
   },
   {
     "Department": "stamps_sro",
@@ -18337,7 +19646,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1311"
   },
   {
     "Department": "stamps_sro",
@@ -18351,7 +19661,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1312"
   },
   {
     "Department": "stamps_sro",
@@ -18365,7 +19676,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್"
+    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್",
+    "cellRef": "A1313"
   },
   {
     "Department": "stamps_sro",
@@ -18379,7 +19691,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೇರಾಡಲ್\\r\\n",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1314"
   },
   {
     "Department": "stamps_sro",
@@ -18393,7 +19706,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೀರ್ಥಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1315"
   },
   {
     "Department": "stamps_sro",
@@ -18407,7 +19721,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪಟೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1316"
   },
   {
     "Department": "stamps_sro",
@@ -18421,7 +19736,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1317"
   },
   {
     "Department": "stamps_sro",
@@ -18435,7 +19751,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುರುವೇಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1318"
   },
   {
     "Department": "stamps_sro",
@@ -18449,7 +19766,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1319"
   },
   {
     "Department": "stamps_sro",
@@ -18463,7 +19781,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ"
+    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ",
+    "cellRef": "A1320"
   },
   {
     "Department": "stamps_sro",
@@ -18477,7 +19796,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರಾಜಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1321"
   },
   {
     "Department": "stamps_sro",
@@ -18491,7 +19811,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಮೀಳಾ ಜಿ.ಜೆ"
+    "NameKN": "ಪ್ರಮೀಳಾ ಜಿಜೆ",
+    "cellRef": "A1322"
   },
   {
     "Department": "stamps_sro",
@@ -18505,7 +19826,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಟ್ಲ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1323"
   },
   {
     "Department": "stamps_sro",
@@ -18519,7 +19841,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1324"
   },
   {
     "Department": "stamps_sro",
@@ -18533,7 +19856,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್"
+    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್",
+    "cellRef": "A1325"
   },
   {
     "Department": "stamps_sro",
@@ -18547,7 +19871,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1326"
   },
   {
     "Department": "stamps_sro",
@@ -18561,7 +19886,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯೆಲ್ಬುರ್ಗಾ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1327"
   },
   {
     "Department": "stamps_sro",
@@ -18575,7 +19901,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲ್ಲಾಪುರ",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1328"
   },
   {
     "Department": "stamps_sro",
@@ -18589,7 +19916,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವತಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸುರೇಶ್ ಜಿ"
+    "NameKN": "ಸುರೇಶ್ ಜಿ",
+    "cellRef": "A1329"
   },
   {
     "Department": "police_traffic",
@@ -18603,7 +19931,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1330"
   },
   {
     "Department": "police_traffic",
@@ -18617,7 +19946,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1331"
   },
   {
     "Department": "police_traffic",
@@ -18631,7 +19961,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1332"
   },
   {
     "Department": "police_traffic",
@@ -18645,7 +19976,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1333"
   },
   {
     "Department": "police_traffic",
@@ -18659,7 +19991,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1334"
   },
   {
     "Department": "police_traffic",
@@ -18673,7 +20006,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1335"
   },
   {
     "Department": "police_traffic",
@@ -18687,7 +20021,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1336"
   },
   {
     "Department": "police_traffic",
@@ -18701,7 +20036,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1337"
   },
   {
     "Department": "police_traffic",
@@ -18715,7 +20051,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1338"
   },
   {
     "Department": "police_traffic",
@@ -18729,7 +20066,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1339"
   },
   {
     "Department": "police_traffic",
@@ -18743,7 +20081,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1340"
   },
   {
     "Department": "police_traffic",
@@ -18757,7 +20096,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1341"
   },
   {
     "Department": "police_traffic",
@@ -18771,7 +20111,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1342"
   },
   {
     "Department": "police_traffic",
@@ -18785,7 +20126,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1343"
   },
   {
     "Department": "police_traffic",
@@ -18799,7 +20141,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1344"
   },
   {
     "Department": "police_traffic",
@@ -18813,7 +20156,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1345"
   },
   {
     "Department": "police_traffic",
@@ -18827,7 +20171,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1346"
   },
   {
     "Department": "police_traffic",
@@ -18841,7 +20186,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1347"
   },
   {
     "Department": "police_traffic",
@@ -18855,7 +20201,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": ""
+    "NameKN": "",
+    "cellRef": "A1348"
   },
   {
     "Department": "police_traffic",
@@ -18869,7 +20216,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1349"
   },
   {
     "Department": "police_traffic",
@@ -18883,7 +20231,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1350"
   },
   {
     "Department": "police_traffic",
@@ -18897,7 +20246,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1351"
   },
   {
     "Department": "police_traffic",
@@ -18911,7 +20261,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1352"
   },
   {
     "Department": "police_traffic",
@@ -18925,7 +20276,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1353"
   },
   {
     "Department": "police_traffic",
@@ -18939,7 +20291,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1354"
   },
   {
     "Department": "police_traffic",
@@ -18953,7 +20306,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1355"
   },
   {
     "Department": "police_traffic",
@@ -18967,7 +20321,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1356"
   },
   {
     "Department": "police_traffic",
@@ -18981,7 +20336,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1357"
   },
   {
     "Department": "police_traffic",
@@ -18995,7 +20351,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1358"
   },
   {
     "Department": "police_traffic",
@@ -19009,7 +20366,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1359"
   },
   {
     "Department": "police_traffic",
@@ -19023,7 +20381,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1360"
   },
   {
     "Department": "police_traffic",
@@ -19037,7 +20396,8 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ ಬೆಂಗಳೂರು PS",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1361"
   },
   {
     "Department": "police_traffic",
@@ -19051,7 +20411,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1362"
   },
   {
     "Department": "police_traffic",
@@ -19065,7 +20426,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1363"
   },
   {
     "Department": "police_traffic",
@@ -19079,7 +20441,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1364"
   },
   {
     "Department": "police_traffic",
@@ -19093,7 +20456,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1365"
   },
   {
     "Department": "police_traffic",
@@ -19107,7 +20471,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1366"
   },
   {
     "Department": "police_traffic",
@@ -19121,7 +20486,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1367"
   },
   {
     "Department": "police_traffic",
@@ -19135,7 +20501,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1368"
   },
   {
     "Department": "police_traffic",
@@ -19149,7 +20516,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1369"
   },
   {
     "Department": "police_traffic",
@@ -19163,7 +20531,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1370"
   },
   {
     "Department": "police_traffic",
@@ -19177,7 +20546,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1371"
   },
   {
     "Department": "police_traffic",
@@ -19191,7 +20561,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1372"
   },
   {
     "Department": "police_traffic",
@@ -19205,7 +20576,8 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1373"
   },
   {
     "Department": "police_traffic",
@@ -19219,6 +20591,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-"
+    "NameKN": "-",
+    "cellRef": "A1374"
   }
 ]


### PR DESCRIPTION
# Add Google Sheets Edit Links for Officials

Once merged, will close #55 

## Changes
- Added `cellRef` field to officials.json to track Google Sheets cell references
- Updated xls2json.py script to include cell references during data conversion
- Implemented direct linking to specific cells in Google Sheets for easier community edits
- Added new translation keys for edit suggestion functionality
  - Added "details_suggest_edit" in en.json
  - Added corresponding Kannada translation
- Added edit suggestion CTA in the district details sidebar

Also: 

- **Moved Google Sheet ID and GID from hardcoded values in DistrictDetails.svelte to package.json configuration**
- Updated DistrictDetails.svelte to reference these values from package.json

Regarding the last two changes, I recommend having configuration values such as those IDs in a single, centralized location which makes it easier to update when needed. 

## Testing
- Verify that cell references are correctly mapped for randomly selected officials
- Confirm that clicking the edit link opens the correct cell in Google Sheets
- Validate translations for both English and Kannada interfaces

## Screenshots
![image](https://github.com/user-attachments/assets/0c02afa3-4640-4413-b00b-8f65f4e31007)
