### PR TITLE
Remove redundant cellRef attribute in officials.json

### DIFF
--- a/scripts/officials.json
+++ b/scripts/officials.json
@@ -11,8 +11,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ ಎನ್",
-    "cellRef": "A2"
+    "NameKN": "ಶಿವಶಂಕರ ಎನ್"
   },
   {
     "Department": "admin_district",
@@ -26,8 +25,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ನಗರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಜಗದೀಶ ಜಿ",
-    "cellRef": "A3"
+    "NameKN": "ಜಗದೀಶ ಜಿ"
   },
   {
     "Department": "admin_district",
@@ -41,8 +39,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A4"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -56,8 +53,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A5"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -71,8 +67,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A6"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -86,8 +81,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A7"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -101,8 +95,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A8"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -116,8 +109,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A9"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -131,8 +123,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A10"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -146,8 +137,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಪಿ ದಿನೇಶ್",
-    "cellRef": "A11"
+    "NameKN": "ಪಿ ದಿನೇಶ್"
   },
   {
     "Department": "admin_taluk",
@@ -161,8 +151,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A12"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -176,8 +165,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಪೂರ್ವ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ರಾಜೀವ್",
-    "cellRef": "A13"
+    "NameKN": "ರಾಜೀವ್"
   },
   {
     "Department": "admin_taluk",
@@ -191,8 +179,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಬಾಲಕೃಷ್ಣ",
-    "cellRef": "A14"
+    "NameKN": "ಬಾಲಕೃಷ್ಣ"
   },
   {
     "Department": "admin_taluk",
@@ -206,8 +193,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ",
-    "cellRef": "A15"
+    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ"
   },
   {
     "Department": "admin_taluk",
@@ -221,8 +207,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A16"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -236,8 +221,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A17"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -251,8 +235,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A18"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -266,8 +249,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A19"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -281,8 +263,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A20"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -296,8 +277,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A21"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -311,8 +291,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A22"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -326,8 +305,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A23"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -341,8 +319,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A24"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -356,8 +333,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A25"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -371,8 +347,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A26"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -386,8 +361,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A27"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -401,8 +375,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A28"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -416,8 +389,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A29"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -431,8 +403,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A30"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -446,8 +417,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ಎಫ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A31"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -461,8 +431,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A32"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -476,8 +445,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A33"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -491,8 +459,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A34"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -506,8 +473,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A35"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -521,8 +487,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A36"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -536,8 +501,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A37"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -551,8 +515,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A38"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -566,8 +529,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A39"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -581,8 +543,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A40"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -596,8 +557,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A41"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -611,8 +571,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A42"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -626,8 +585,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A43"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -641,8 +599,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A44"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -656,8 +613,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A45"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -671,8 +627,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A46"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -686,8 +641,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A47"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -701,8 +655,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A48"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -716,8 +669,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A49"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -731,8 +683,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A50"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -746,8 +697,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A51"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -761,8 +711,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A52"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -776,8 +725,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ",
-    "cellRef": "A53"
+    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -791,8 +739,7 @@
     "Unnamed: 3": "",
     "AreaKN": "94: ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ",
-    "cellRef": "A54"
+    "NameKN": "ಅಕ್ಷತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -806,8 +753,7 @@
     "Unnamed: 3": "",
     "AreaKN": "176: ಆಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್",
-    "cellRef": "A55"
+    "NameKN": "ರವಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -821,8 +767,7 @@
     "Unnamed: 3": "",
     "AreaKN": "102: ಎ.ಇ.ಸಿ.ಎಸ್. ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಿ. ಶ್ರೀನಿವಾಸ ಮೂರ್ತಿ",
-    "cellRef": "A56"
+    "NameKN": "ಜಿ. ಶ್ರೀನಿವಾಸ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -836,8 +781,7 @@
     "Unnamed: 3": "",
     "AreaKN": "172: ಅಗರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ",
-    "cellRef": "A57"
+    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -851,8 +795,7 @@
     "Unnamed: 3": "",
     "AreaKN": "8: ಅಮೃತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್",
-    "cellRef": "A58"
+    "NameKN": "ಸೋಮಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -866,8 +809,7 @@
     "Unnamed: 3": "",
     "AreaKN": "208: ಅಂಜನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು",
-    "cellRef": "A59"
+    "NameKN": "ರಘು"
   },
   {
     "Department": "bbmp_wards",
@@ -881,8 +823,7 @@
     "Unnamed: 3": "",
     "AreaKN": "56: ಅರಮನೆ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜ್ ಕುಮಾರ್",
-    "cellRef": "A60"
+    "NameKN": "ರಾಜ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -896,8 +837,7 @@
     "Unnamed: 3": "",
     "AreaKN": "167: ಅಶೋಕ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೇಖ್ ಅಹಮದ್",
-    "cellRef": "A61"
+    "NameKN": "ಶೇಖ್ ಅಹಮದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -911,8 +851,7 @@
     "Unnamed: 3": "",
     "AreaKN": "150: ಅತ್ತಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜ್ಯೋತಿ",
-    "cellRef": "A62"
+    "NameKN": "ಜ್ಯೋತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -926,8 +865,7 @@
     "Unnamed: 3": "",
     "AreaKN": "3: ಅಟ್ಟೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ",
-    "cellRef": "A63"
+    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -941,8 +879,7 @@
     "Unnamed: 3": "",
     "AreaKN": "152: ಆವಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್",
-    "cellRef": "A64"
+    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -956,8 +893,7 @@
     "Unnamed: 3": "",
     "AreaKN": "159: ಆಜಾದ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್",
-    "cellRef": "A65"
+    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -971,8 +907,7 @@
     "Unnamed: 3": "",
     "AreaKN": "165: ಬಿ ವೆಂಕಟ ರೆಡ್ಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ",
-    "cellRef": "A66"
+    "NameKN": "ಮಮತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -986,8 +921,7 @@
     "Unnamed: 3": "",
     "AreaKN": "18: ಬಾಗಲಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
-    "cellRef": "A67"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1001,8 +935,7 @@
     "Unnamed: 3": "",
     "AreaKN": "82: ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ",
-    "cellRef": "A68"
+    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -1016,8 +949,7 @@
     "Unnamed: 3": "",
     "AreaKN": "191: ಬನಶಂಕರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಮಾ",
-    "cellRef": "A69"
+    "NameKN": "ಸುಮಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1031,8 +963,7 @@
     "Unnamed: 3": "",
     "AreaKN": "31: ಬಂಡೆ ಮಠ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪೂರ್ಣಿಮಾ",
-    "cellRef": "A70"
+    "NameKN": "ಪೂರ್ಣಿಮಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1046,8 +977,7 @@
     "Unnamed: 3": "",
     "AreaKN": "92: ಬಸವನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ.",
-    "cellRef": "A71"
+    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ."
   },
   {
     "Department": "bbmp_wards",
@@ -1061,8 +991,7 @@
     "Unnamed: 3": "",
     "AreaKN": "133: ಬಸವೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್",
-    "cellRef": "A72"
+    "NameKN": "ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1076,8 +1005,7 @@
     "Unnamed: 3": "",
     "AreaKN": "211: ಬೇಗೂರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನೀಲಕಂಠಯ್ಯ",
-    "cellRef": "A73"
+    "NameKN": "ನೀಲಕಂಠಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -1091,8 +1019,7 @@
     "Unnamed: 3": "",
     "AreaKN": "107: ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A74"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -1106,8 +1033,7 @@
     "Unnamed: 3": "",
     "AreaKN": "109: ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ",
-    "cellRef": "A75"
+    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1121,8 +1047,7 @@
     "Unnamed: 3": "",
     "AreaKN": "120: ಭಾರತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಾವಿತ್ರಿ",
-    "cellRef": "A76"
+    "NameKN": "ಸಾವಿತ್ರಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1136,8 +1061,7 @@
     "Unnamed: 3": "",
     "AreaKN": "215: ಬಿಳೇಕಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A77"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1151,8 +1075,7 @@
     "Unnamed: 3": "",
     "AreaKN": "126: ಬಿನ್ನಿಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್",
-    "cellRef": "A78"
+    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1166,8 +1089,7 @@
     "Unnamed: 3": "",
     "AreaKN": "218: ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್ ದೇವಾ",
-    "cellRef": "A79"
+    "NameKN": "ರಮೇಶ್ ದೇವಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1181,8 +1103,7 @@
     "Unnamed: 3": "",
     "AreaKN": "181: ಬಿ ಟಿ ಎಂ ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕಲಾ",
-    "cellRef": "A80"
+    "NameKN": "ಶಶಿಕಲಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1196,8 +1117,7 @@
     "Unnamed: 3": "",
     "AreaKN": "10: ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಕುಮಾರ್",
-    "cellRef": "A81"
+    "NameKN": "ಶಿವಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1211,8 +1131,7 @@
     "Unnamed: 3": "",
     "AreaKN": "182: ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅನುಷಾ",
-    "cellRef": "A82"
+    "NameKN": "ಅನುಷಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1226,8 +1145,7 @@
     "Unnamed: 3": "",
     "AreaKN": "99: ಬೈರತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಿ.ಎನ್. ರಾಘವೇಂದ್ರ",
-    "cellRef": "A83"
+    "NameKN": "ಬಿ.ಎನ್. ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "bbmp_wards",
@@ -1241,8 +1159,7 @@
     "Unnamed: 3": "",
     "AreaKN": "110: ಸಿ ವಿ ರಾಮನ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ",
-    "cellRef": "A84"
+    "NameKN": "ರವಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1256,8 +1173,7 @@
     "Unnamed: 3": "",
     "AreaKN": "156: ಚಲವಾದಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಸಂತ್",
-    "cellRef": "A85"
+    "NameKN": "ವಸಂತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1271,8 +1187,7 @@
     "Unnamed: 3": "",
     "AreaKN": "86: ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ",
-    "cellRef": "A86"
+    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ"
   },
   {
     "Department": "bbmp_wards",
@@ -1286,8 +1201,7 @@
     "Unnamed: 3": "",
     "AreaKN": "158: ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೌಮ್ಯಾ",
-    "cellRef": "A87"
+    "NameKN": "ಸೌಮ್ಯಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1301,8 +1215,7 @@
     "Unnamed: 3": "",
     "AreaKN": "66: ಚಾಮುಂಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಯನತಾರಾ ಡಾ.",
-    "cellRef": "A88"
+    "NameKN": "ನಯನತಾರಾ ಡಾ."
   },
   {
     "Department": "bbmp_wards",
@@ -1316,8 +1229,7 @@
     "Unnamed: 3": "",
     "AreaKN": "142: ಚಂದ್ರಾಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾರತಿ",
-    "cellRef": "A89"
+    "NameKN": "ಭಾರತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1331,8 +1243,7 @@
     "Unnamed: 3": "",
     "AreaKN": "128: ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ",
-    "cellRef": "A90"
+    "NameKN": "ಶಂಕರಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -1346,8 +1257,7 @@
     "Unnamed: 3": "",
     "AreaKN": "194: ಚಿಕ್ಕಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್",
-    "cellRef": "A91"
+    "NameKN": "ಶರತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1361,8 +1271,7 @@
     "Unnamed: 3": "",
     "AreaKN": "17: ಚಿಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯದುಕೃಷ್ಣ",
-    "cellRef": "A92"
+    "NameKN": "ಯದುಕೃಷ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -1376,8 +1285,7 @@
     "Unnamed: 3": "",
     "AreaKN": "21: ಚೊಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ",
-    "cellRef": "A93"
+    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1391,8 +1299,7 @@
     "Unnamed: 3": "",
     "AreaKN": "40: ಚೌಡೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪಾಪರೆಡ್ಡಿ",
-    "cellRef": "A94"
+    "NameKN": "ಪಾಪರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1406,8 +1313,7 @@
     "Unnamed: 3": "",
     "AreaKN": "2: ಚೌಡೇಶ್ವರಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೆ.ಜಿ. ಸುಂದರೇಶ್",
-    "cellRef": "A95"
+    "NameKN": "ಕೆ.ಜಿ. ಸುಂದರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1421,8 +1327,7 @@
     "Unnamed: 3": "",
     "AreaKN": "127: ಕಾಟನ್ ಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು",
-    "cellRef": "A96"
+    "NameKN": "ರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -1436,8 +1341,7 @@
     "Unnamed: 3": "",
     "AreaKN": "108: ಕಾಕ್ಸ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ",
-    "cellRef": "A97"
+    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1451,8 +1355,7 @@
     "Unnamed: 3": "",
     "AreaKN": "122: ದತ್ತಾತ್ರೇಯ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್",
-    "cellRef": "A98"
+    "NameKN": "ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1466,8 +1369,7 @@
     "Unnamed: 3": "",
     "AreaKN": "129: ದಯಾನಂದ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮು",
-    "cellRef": "A99"
+    "NameKN": "ರಾಮು"
   },
   {
     "Department": "bbmp_wards",
@@ -1481,8 +1383,7 @@
     "Unnamed: 3": "",
     "AreaKN": "151: ದೀಪಾಂಜಲಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು",
-    "cellRef": "A100"
+    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -1496,8 +1397,7 @@
     "Unnamed: 3": "",
     "AreaKN": "190: ದೇವಗಿರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್",
-    "cellRef": "A101"
+    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1511,8 +1411,7 @@
     "Unnamed: 3": "",
     "AreaKN": "72: ದೇವರ ಜೀವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್",
-    "cellRef": "A102"
+    "NameKN": "ಉಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1526,8 +1425,7 @@
     "Unnamed: 3": "",
     "AreaKN": "155: ದೇವರಾಜ್ ಅರಸ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ",
-    "cellRef": "A103"
+    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1541,8 +1439,7 @@
     "Unnamed: 3": "",
     "AreaKN": "93: ದೇವಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿತ್ಯ ಕೆ.ಎ.",
-    "cellRef": "A104"
+    "NameKN": "ನಿತ್ಯ ಕೆ.ಎ."
   },
   {
     "Department": "bbmp_wards",
@@ -1556,8 +1453,7 @@
     "Unnamed: 3": "",
     "AreaKN": "160: ಧರ್ಮರಾಯ ಸ್ವಾಮಿ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಲು ರಾಥೋರ್",
-    "cellRef": "A105"
+    "NameKN": "ವಲು ರಾಥೋರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1571,8 +1467,7 @@
     "Unnamed: 3": "",
     "AreaKN": "26: ದೊಡ್ಡ ಬಿದರಕಲ್ಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಿದ್ಧರಾಜ್",
-    "cellRef": "A106"
+    "NameKN": "ಸಿದ್ಧರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1586,8 +1481,7 @@
     "Unnamed: 3": "",
     "AreaKN": "12: ದೊಡ್ಡ ಬೊಮ್ಮಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬೀರೇಶ್",
-    "cellRef": "A107"
+    "NameKN": "ಬೀರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1601,8 +1495,7 @@
     "Unnamed: 3": "",
     "AreaKN": "198: ದೊಡ್ಡ ಗಣಪತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗಸ್ವಾಮಿ",
-    "cellRef": "A108"
+    "NameKN": "ರಂಗಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1616,8 +1509,7 @@
     "Unnamed: 3": "",
     "AreaKN": "101: ದೊಡ್ಡ ನೆಕ್ಕುಂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್",
-    "cellRef": "A109"
+    "NameKN": "ರವಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1631,8 +1523,7 @@
     "Unnamed: 3": "",
     "AreaKN": "171: ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪ್ಪುರಾಜ್",
-    "cellRef": "A110"
+    "NameKN": "ಅಪ್ಪುರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1646,8 +1537,7 @@
     "Unnamed: 3": "",
     "AreaKN": "47: ಡಾ. ಪುನೀತ್ ರಾಜ್ ಕುಮಾರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ",
-    "cellRef": "A111"
+    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1661,8 +1551,7 @@
     "Unnamed: 3": "",
     "AreaKN": "135: ಡಾ. ರಾಜ್ ಕುಮಾರ್ ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್",
-    "cellRef": "A112"
+    "NameKN": "ಪ್ರಕಾಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1676,8 +1565,7 @@
     "Unnamed: 3": "",
     "AreaKN": "173: ಈಜಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನುಪಮಾ",
-    "cellRef": "A113"
+    "NameKN": "ಡಾ. ಅನುಪಮಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1691,8 +1579,7 @@
     "Unnamed: 3": "",
     "AreaKN": "149: ಗಾಲಿ ಆಂಜನೇಯ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶಿಲ್ಪಾ",
-    "cellRef": "A114"
+    "NameKN": "ಡಾ. ಶಿಲ್ಪಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1706,8 +1593,7 @@
     "Unnamed: 3": "",
     "AreaKN": "123: ಗಾಂಧಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿಯಪ್ಪ",
-    "cellRef": "A115"
+    "NameKN": "ಮುನಿಯಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -1721,8 +1607,7 @@
     "Unnamed: 3": "",
     "AreaKN": "189: ಗಣೇಶ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್",
-    "cellRef": "A116"
+    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1736,8 +1621,7 @@
     "Unnamed: 3": "",
     "AreaKN": "67: ಗಂಗಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಭಿಲಾಷ್",
-    "cellRef": "A117"
+    "NameKN": "ಅಭಿಲಾಷ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1751,8 +1635,7 @@
     "Unnamed: 3": "",
     "AreaKN": "100: ಗರುಡಾಚಾರ್ ಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೂಪ್ರಧಾ",
-    "cellRef": "A118"
+    "NameKN": "ಭೂಪ್ರಧಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1766,8 +1649,7 @@
     "Unnamed: 3": "",
     "AreaKN": "196: ಗವಿ ಗಂಗಾಧರೇಶ್ವರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು",
-    "cellRef": "A119"
+    "NameKN": "ರಘು"
   },
   {
     "Department": "bbmp_wards",
@@ -1781,8 +1663,7 @@
     "Unnamed: 3": "",
     "AreaKN": "60: ಗಾಯಿತ್ರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಕುಮಾರ್",
-    "cellRef": "A120"
+    "NameKN": "ರಾಜಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1796,8 +1677,7 @@
     "Unnamed: 3": "",
     "AreaKN": "220: ಘರೇಭಾವಿಪಾಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A121"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -1811,8 +1691,7 @@
     "Unnamed: 3": "",
     "AreaKN": "209: ಗೊಟ್ಟಿಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ",
-    "cellRef": "A122"
+    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1826,8 +1705,7 @@
     "Unnamed: 3": "",
     "AreaKN": "136: ಗೋವಿಂದರಾಜ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್",
-    "cellRef": "A123"
+    "NameKN": "ಉಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1841,8 +1719,7 @@
     "Unnamed: 3": "",
     "AreaKN": "183: ಗುರಪ್ಪನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್",
-    "cellRef": "A124"
+    "NameKN": "ಸಂತೋಷ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1856,8 +1733,7 @@
     "Unnamed: 3": "",
     "AreaKN": "96: HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "",
-    "cellRef": "A125"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -1871,8 +1747,7 @@
     "Unnamed: 3": "",
     "AreaKN": "147: ಹಂಪಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗರಾಜು",
-    "cellRef": "A126"
+    "NameKN": "ರಂಗರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -1886,8 +1761,7 @@
     "Unnamed: 3": "",
     "AreaKN": "78: HBR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರವಿಕುಮಾರ್",
-    "cellRef": "A127"
+    "NameKN": "ಡಾ. ರವಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1901,8 +1775,7 @@
     "Unnamed: 3": "",
     "AreaKN": "9: ಹೆಬ್ಬಾಳ ಕೆಂಪಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ",
-    "cellRef": "A128"
+    "NameKN": "ಅಕ್ಷತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1916,8 +1789,7 @@
     "Unnamed: 3": "",
     "AreaKN": "63: ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಇಮ್ರಾನ್",
-    "cellRef": "A129"
+    "NameKN": "ಇಮ್ರಾನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1931,8 +1803,7 @@
     "Unnamed: 3": "",
     "AreaKN": "24: ಹೆಗ್ಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹನುಮಂತ ನಾಯಕ್",
-    "cellRef": "A130"
+    "NameKN": "ಹನುಮಂತ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1946,8 +1817,7 @@
     "Unnamed: 3": "",
     "AreaKN": "33: ಹೆಮ್ಮಿಗೆಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ",
-    "cellRef": "A131"
+    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -1961,8 +1831,7 @@
     "Unnamed: 3": "",
     "AreaKN": "76: ಹೆಣ್ಣೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಈರಣ್ಣ",
-    "cellRef": "A132"
+    "NameKN": "ಈರಣ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -1976,8 +1845,7 @@
     "Unnamed: 3": "",
     "AreaKN": "28: ಹೇರೋಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A133"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1991,8 +1859,7 @@
     "Unnamed: 3": "",
     "AreaKN": "164: ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎನ್. ಎಸ್. ನಾಗೇಂದ್ರ",
-    "cellRef": "A134"
+    "NameKN": "ಎನ್. ಎಸ್. ನಾಗೇಂದ್ರ"
   },
   {
     "Department": "bbmp_wards",
@@ -2006,8 +1873,7 @@
     "Unnamed: 3": "",
     "AreaKN": "219: ಹೊಂಗಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಧರ್",
-    "cellRef": "A135"
+    "NameKN": "ಶಶಿಧರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2021,8 +1887,7 @@
     "Unnamed: 3": "",
     "AreaKN": "87: ಹೊರಮಾವು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A136"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2036,8 +1901,7 @@
     "Unnamed: 3": "",
     "AreaKN": "224: ಹೊಸ ರಸ್ತೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A137"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2051,8 +1915,7 @@
     "Unnamed: 3": "",
     "AreaKN": "146: ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
-    "cellRef": "A138"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2066,8 +1929,7 @@
     "Unnamed: 3": "",
     "AreaKN": "195: ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲೋಹಿತ್",
-    "cellRef": "A139"
+    "NameKN": "ಲೋಹಿತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2081,8 +1943,7 @@
     "Unnamed: 3": "",
     "AreaKN": "113: ಹೊಯ್ಸಳ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
-    "cellRef": "A140"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2096,8 +1957,7 @@
     "Unnamed: 3": "",
     "AreaKN": "221: HSR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು",
-    "cellRef": "A141"
+    "NameKN": "ರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -2111,8 +1971,7 @@
     "Unnamed: 3": "",
     "AreaKN": "98: ಹೂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್",
-    "cellRef": "A142"
+    "NameKN": "ಪ್ರಕಾಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2126,8 +1985,7 @@
     "Unnamed: 3": "",
     "AreaKN": "216: ಹುಳಿಮಾವು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A143"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2141,8 +1999,7 @@
     "Unnamed: 3": "",
     "AreaKN": "222: ಇಬ್ಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A144"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2156,8 +2013,7 @@
     "Unnamed: 3": "",
     "AreaKN": "185: ಜೆ ಪಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A145"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2171,8 +2027,7 @@
     "Unnamed: 3": "",
     "AreaKN": "175: ಜಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫಜಲ್ ಅಹಮದ್",
-    "cellRef": "A146"
+    "NameKN": "ಫಜಲ್ ಅಹಮದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2186,8 +2041,7 @@
     "Unnamed: 3": "",
     "AreaKN": "6: ಜಕ್ಕೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರು",
-    "cellRef": "A147"
+    "NameKN": "ಚಂದ್ರು"
   },
   {
     "Department": "bbmp_wards",
@@ -2201,8 +2055,7 @@
     "Unnamed: 3": "",
     "AreaKN": "36: ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರುಣ್",
-    "cellRef": "A148"
+    "NameKN": "ವರುಣ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2216,8 +2069,7 @@
     "Unnamed: 3": "",
     "AreaKN": "213: ಜರಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರ್",
-    "cellRef": "A149"
+    "NameKN": "ವಿಶ್ವೇಶ್ವರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2231,8 +2083,7 @@
     "Unnamed: 3": "",
     "AreaKN": "68: ಜಯಚಾಮರಾಜೇಂದ್ರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್",
-    "cellRef": "A150"
+    "NameKN": "ನಾಗೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2246,8 +2097,7 @@
     "Unnamed: 3": "",
     "AreaKN": "184: ಜಯನಗರ ಪೂರ್ವ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಷ್ಣುಕಾಂತ್",
-    "cellRef": "A151"
+    "NameKN": "ವಿಷ್ಣುಕಾಂತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2261,8 +2111,7 @@
     "Unnamed: 3": "",
     "AreaKN": "114: ಜೀವನಭೀಮ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಚಿಕೇತ್",
-    "cellRef": "A152"
+    "NameKN": "ನಚಿಕೇತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2276,8 +2125,7 @@
     "Unnamed: 3": "",
     "AreaKN": "44: ಜ್ಞಾನ ಭಾರತಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ",
-    "cellRef": "A153"
+    "NameKN": "ಶಿವಶಂಕರ"
   },
   {
     "Department": "bbmp_wards",
@@ -2291,8 +2139,7 @@
     "Unnamed: 3": "",
     "AreaKN": "170: ಜೋಗುಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರನಾರಾಯಣ್",
-    "cellRef": "A154"
+    "NameKN": "ವರನಾರಾಯಣ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2306,8 +2153,7 @@
     "Unnamed: 3": "",
     "AreaKN": "34: ಜೆಪಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಧನ್ಯ ಕುಮಾರ್",
-    "cellRef": "A155"
+    "NameKN": "ಡಾ. ಧನ್ಯ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2321,8 +2167,7 @@
     "Unnamed: 3": "",
     "AreaKN": "157: ಕೆ ಆರ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿಲ್ಪಾ",
-    "cellRef": "A156"
+    "NameKN": "ಶಿಲ್ಪಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2336,8 +2181,7 @@
     "Unnamed: 3": "",
     "AreaKN": "91: ಕೆ ಆರ್ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್",
-    "cellRef": "A157"
+    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2351,8 +2195,7 @@
     "Unnamed: 3": "",
     "AreaKN": "80: ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ",
-    "cellRef": "A158"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2366,8 +2209,7 @@
     "Unnamed: 3": "",
     "AreaKN": "58: ಕಾಡು ಮಲ್ಲೇಶ್ವರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ",
-    "cellRef": "A159"
+    "NameKN": "ಮಮತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2381,8 +2223,7 @@
     "Unnamed: 3": "",
     "AreaKN": "97: ಕಾಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹರ್ಷ ನಾಯಕ್",
-    "cellRef": "A160"
+    "NameKN": "ಹರ್ಷ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2396,8 +2237,7 @@
     "Unnamed: 3": "",
     "AreaKN": "79: ಕಾಡುಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉದಯ್ ಚೌಗಲೆ",
-    "cellRef": "A161"
+    "NameKN": "ಉದಯ್ ಚೌಗಲೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2411,8 +2251,7 @@
     "Unnamed: 3": "",
     "AreaKN": "111: ಕಗ್ಗದಾಸನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ",
-    "cellRef": "A162"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2426,8 +2265,7 @@
     "Unnamed: 3": "",
     "AreaKN": "210: ಕಾಳೇನ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ",
-    "cellRef": "A163"
+    "NameKN": "ಮಂಜುಳಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2441,8 +2279,7 @@
     "Unnamed: 3": "",
     "AreaKN": "88: ಕಲ್ಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A164"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2456,8 +2293,7 @@
     "Unnamed: 3": "",
     "AreaKN": "134: ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ",
-    "cellRef": "A165"
+    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2471,8 +2307,7 @@
     "Unnamed: 3": "",
     "AreaKN": "15: ಕಮ್ಮಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಸವರಾಜ",
-    "cellRef": "A166"
+    "NameKN": "ಬಸವರಾಜ"
   },
   {
     "Department": "bbmp_wards",
@@ -2486,8 +2321,7 @@
     "Unnamed: 3": "",
     "AreaKN": "81: ಕಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ್",
-    "cellRef": "A167"
+    "NameKN": "ಡಾ. ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2501,8 +2335,7 @@
     "Unnamed: 3": "",
     "AreaKN": "201: ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಕುಮಾರ್",
-    "cellRef": "A168"
+    "NameKN": "ವಿಜಯಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2516,8 +2349,7 @@
     "Unnamed: 3": "",
     "AreaKN": "69: ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ದೇವಿಕಾ ರಾಣಿ ",
-    "cellRef": "A169"
+    "NameKN": "ಡಾ. ದೇವಿಕಾ ರಾಣಿ "
   },
   {
     "Department": "bbmp_wards",
@@ -2531,8 +2363,7 @@
     "Unnamed: 3": "",
     "AreaKN": "138: ಕಾವೇರಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ",
-    "cellRef": "A170"
+    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2546,8 +2377,7 @@
     "Unnamed: 3": "",
     "AreaKN": "144: ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್",
-    "cellRef": "A171"
+    "NameKN": "ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2561,8 +2391,7 @@
     "Unnamed: 3": "",
     "AreaKN": "1: ಕೆಂಪೇಗೌಡ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫರ್ಜಾನಾ",
-    "cellRef": "A172"
+    "NameKN": "ಫರ್ಜಾನಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2576,8 +2405,7 @@
     "Unnamed: 3": "",
     "AreaKN": "32: ಕೆಂಗೇರಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ",
-    "cellRef": "A173"
+    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -2591,8 +2419,7 @@
     "Unnamed: 3": "",
     "AreaKN": "217: ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ",
-    "cellRef": "A174"
+    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -2606,8 +2433,7 @@
     "Unnamed: 3": "",
     "AreaKN": "11: ಕೊಡಿಗೇಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A175"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2621,8 +2447,7 @@
     "Unnamed: 3": "",
     "AreaKN": "5: ಕೋಗಿಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್",
-    "cellRef": "A176"
+    "NameKN": "ಪ್ರದೀಪ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2636,8 +2461,7 @@
     "Unnamed: 3": "",
     "AreaKN": "206: ಕೋಣನಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್",
-    "cellRef": "A177"
+    "NameKN": "ರಂಗನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2651,8 +2475,7 @@
     "Unnamed: 3": "",
     "AreaKN": "115: ಕೊನೆನ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಮ್",
-    "cellRef": "A178"
+    "NameKN": "ಜಯರಾಮ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2666,8 +2489,7 @@
     "Unnamed: 3": "",
     "AreaKN": "174: ಕೋರಮಂಗಲ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ",
-    "cellRef": "A179"
+    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2681,8 +2503,7 @@
     "Unnamed: 3": "",
     "AreaKN": "41: ಕೊಟ್ಟಿಗೆಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A180"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2696,8 +2517,7 @@
     "Unnamed: 3": "",
     "AreaKN": "225: ಕೂಡ್ಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ",
-    "cellRef": "A181"
+    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2711,8 +2531,7 @@
     "Unnamed: 3": "",
     "AreaKN": "192: ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A182"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2726,8 +2545,7 @@
     "Unnamed: 3": "",
     "AreaKN": "70: ಕುಶಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
-    "cellRef": "A183"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2741,8 +2559,7 @@
     "Unnamed: 3": "",
     "AreaKN": "14: ಕುವೆಂಪು ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ",
-    "cellRef": "A184"
+    "NameKN": "ಡಾ. ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2756,8 +2573,7 @@
     "Unnamed: 3": "",
     "AreaKN": "39: ಲಗ್ಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ. ಧಾರೇಶ್ವರ್",
-    "cellRef": "A185"
+    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ. ಧಾರೇಶ್ವರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2771,8 +2587,7 @@
     "Unnamed: 3": "",
     "AreaKN": "177: ಲಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ",
-    "cellRef": "A186"
+    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2786,8 +2601,7 @@
     "Unnamed: 3": "",
     "AreaKN": "38: ಲಕ್ಷ್ಮೀದೇವಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್",
-    "cellRef": "A187"
+    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2801,8 +2615,7 @@
     "Unnamed: 3": "",
     "AreaKN": "27: ಲಿಂಗಧೀರನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್",
-    "cellRef": "A188"
+    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2816,8 +2629,7 @@
     "Unnamed: 3": "",
     "AreaKN": "84: ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A189"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2831,8 +2643,7 @@
     "Unnamed: 3": "",
     "AreaKN": "179: ಮಡಿವಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A190"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2846,8 +2657,7 @@
     "Unnamed: 3": "",
     "AreaKN": "48: ಮಹಾಲಕ್ಷ್ಮೀಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾಂತೇಶ್",
-    "cellRef": "A191"
+    "NameKN": "ಮಹಾಂತೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2861,8 +2671,7 @@
     "Unnamed: 3": "",
     "AreaKN": "43: ಮಳತಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್",
-    "cellRef": "A192"
+    "NameKN": "ನಾಗೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2876,8 +2685,7 @@
     "Unnamed: 3": "",
     "AreaKN": "16: ಮಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕುಮಾರ್",
-    "cellRef": "A193"
+    "NameKN": "ಶಶಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2891,8 +2699,7 @@
     "Unnamed: 3": "",
     "AreaKN": "55: ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೀಮಾ ನಾಯಕ್",
-    "cellRef": "A194"
+    "NameKN": "ಭೀಮಾ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2906,8 +2713,7 @@
     "Unnamed: 3": "",
     "AreaKN": "223: ಮಂಗಮ್ಮನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ",
-    "cellRef": "A195"
+    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2921,8 +2727,7 @@
     "Unnamed: 3": "",
     "AreaKN": "65: ಮನೋರಾಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಗೋಪಾಲ್",
-    "cellRef": "A196"
+    "NameKN": "ರಾಜಗೋಪಾಲ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2936,8 +2741,7 @@
     "Unnamed: 3": "",
     "AreaKN": "106: ಮಾರತ್ತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A197"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2951,8 +2755,7 @@
     "Unnamed: 3": "",
     "AreaKN": "137: ಮಾರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರಾಕೇಶ್",
-    "cellRef": "A198"
+    "NameKN": "ಡಾ. ರಾಕೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2966,8 +2769,7 @@
     "Unnamed: 3": "",
     "AreaKN": "140: ಮಾರುತಿ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ",
-    "cellRef": "A199"
+    "NameKN": "ಡಾ. ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2981,8 +2783,7 @@
     "Unnamed: 3": "",
     "AreaKN": "85: ಮಾರುತಿ ಸೇವಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ",
-    "cellRef": "A200"
+    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2996,8 +2797,7 @@
     "Unnamed: 3": "",
     "AreaKN": "54: ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣ ಗೌಡ",
-    "cellRef": "A201"
+    "NameKN": "ಕೃಷ್ಣ ಗೌಡ"
   },
   {
     "Department": "bbmp_wards",
@@ -3011,8 +2811,7 @@
     "Unnamed: 3": "",
     "AreaKN": "139: ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿರ್ಮಲಾ",
-    "cellRef": "A202"
+    "NameKN": "ನಿರ್ಮಲಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3026,8 +2825,7 @@
     "Unnamed: 3": "",
     "AreaKN": "105: ಮುನೆಕೊಳ್ಳಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್",
-    "cellRef": "A203"
+    "NameKN": "ಸೋಮಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3041,8 +2839,7 @@
     "Unnamed: 3": "",
     "AreaKN": "71: ಮುನೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ",
-    "cellRef": "A204"
+    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -3056,8 +2853,7 @@
     "Unnamed: 3": "",
     "AreaKN": "30: ನಾಗದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೇವರಾಜ್ಯ",
-    "cellRef": "A205"
+    "NameKN": "ದೇವರಾಜ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -3071,8 +2867,7 @@
     "Unnamed: 3": "",
     "AreaKN": "212: ನಾಗನಾಥಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಮಂದಯ್ಯ",
-    "cellRef": "A206"
+    "NameKN": "ಸಮಂದಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -3086,8 +2881,7 @@
     "Unnamed: 3": "",
     "AreaKN": "49: ನಾಗಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A207"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3101,8 +2895,7 @@
     "Unnamed: 3": "",
     "AreaKN": "141: ನಾಗರಭಾವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A208"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3116,8 +2909,7 @@
     "Unnamed: 3": "",
     "AreaKN": "77: ನಾಗವಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ",
-    "cellRef": "A209"
+    "NameKN": "ಮಂಜುಳಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3131,8 +2923,7 @@
     "Unnamed: 3": "",
     "AreaKN": "20: ನಾಲಗದರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚರಣ್ ರಾಜ್",
-    "cellRef": "A210"
+    "NameKN": "ಚರಣ್ ರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3146,8 +2937,7 @@
     "Unnamed: 3": "",
     "AreaKN": "50: ನಾಲ್ವಡಿ ಕೃಷ್ಣರಾಜ ಒಡೆಯರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅತೀಫ್ ಅಹಮದ್",
-    "cellRef": "A211"
+    "NameKN": "ಅತೀಫ್ ಅಹಮದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3161,8 +2951,7 @@
     "Unnamed: 3": "",
     "AreaKN": "143: ನಾಯಂಡಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗಭೂಷಣ",
-    "cellRef": "A212"
+    "NameKN": "ನಾಗಭೂಷಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -3176,8 +2965,7 @@
     "Unnamed: 3": "",
     "AreaKN": "148: ಹೊಸ ಗುಡ್ಡದಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್",
-    "cellRef": "A213"
+    "NameKN": "ಸುರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3191,8 +2979,7 @@
     "Unnamed: 3": "",
     "AreaKN": "112: ಹೊಸ ತಿಪ್ಪಸಂದರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ",
-    "cellRef": "A214"
+    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3206,8 +2993,7 @@
     "Unnamed: 3": "",
     "AreaKN": "168: ನೀಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್",
-    "cellRef": "A215"
+    "NameKN": "ಸಂತೋಷ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3221,8 +3007,7 @@
     "Unnamed: 3": "",
     "AreaKN": "125: ಓಕಳಿಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ",
-    "cellRef": "A216"
+    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3236,8 +3021,7 @@
     "Unnamed: 3": "",
     "AreaKN": "153: ಪಾದರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿರೆಡ್ಡಿ",
-    "cellRef": "A217"
+    "NameKN": "ಮುನಿರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3251,8 +3035,7 @@
     "Unnamed: 3": "",
     "AreaKN": "193: ಪದ್ಮನಾಭ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A218"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3266,8 +3049,7 @@
     "Unnamed: 3": "",
     "AreaKN": "37: ಪೀಣ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆಯಿಷಾ",
-    "cellRef": "A219"
+    "NameKN": "ಆಯಿಷಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3281,8 +3063,7 @@
     "Unnamed: 3": "",
     "AreaKN": "22: ಪೀಣ್ಯ ಕೈಗಾರಿಕಾ ಪ್ರದೇಶ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೀಪಶ್ರೀ",
-    "cellRef": "A220"
+    "NameKN": "ದೀಪಶ್ರೀ"
   },
   {
     "Department": "bbmp_wards",
@@ -3296,8 +3077,7 @@
     "Unnamed: 3": "",
     "AreaKN": "75: ಪುಲಿಕೇಶಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್",
-    "cellRef": "A221"
+    "NameKN": "ಸುರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3311,8 +3091,7 @@
     "Unnamed: 3": "",
     "AreaKN": "214: ಪುಟ್ಟೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್",
-    "cellRef": "A222"
+    "NameKN": "ಜಯಶಂಕರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3326,8 +3105,7 @@
     "Unnamed: 3": "",
     "AreaKN": "61: ರಾಧಾಕೃಷ್ಣ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್",
-    "cellRef": "A223"
+    "NameKN": "ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3341,8 +3119,7 @@
     "Unnamed: 3": "",
     "AreaKN": "23: ರಾಜಗೋಪಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ",
-    "cellRef": "A224"
+    "NameKN": "ರವಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3356,8 +3133,7 @@
     "Unnamed: 3": "",
     "AreaKN": "132: ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪದ್ಮರಾಜ್",
-    "cellRef": "A225"
+    "NameKN": "ಪದ್ಮರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3371,8 +3147,7 @@
     "Unnamed: 3": "",
     "AreaKN": "57: ರಾಜಮಹಲ್ ಗುಟ್ಟಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ",
-    "cellRef": "A226"
+    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -3386,8 +3161,7 @@
     "Unnamed: 3": "",
     "AreaKN": "45: ರಾಜರಾಜೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗಂಗಾಧರ್",
-    "cellRef": "A227"
+    "NameKN": "ಗಂಗಾಧರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3401,8 +3175,7 @@
     "Unnamed: 3": "",
     "AreaKN": "46: ರಾಜೀವ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುಹಮ್ಮದ್ ಹಾಲಿ ಪಿಂಚಾರ್",
-    "cellRef": "A228"
+    "NameKN": "ಮುಹಮ್ಮದ್ ಹಾಲಿ ಪಿಂಚಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3416,8 +3189,7 @@
     "Unnamed: 3": "",
     "AreaKN": "90: ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ",
-    "cellRef": "A229"
+    "NameKN": "ಶಂಕರಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -3431,8 +3203,7 @@
     "Unnamed: 3": "",
     "AreaKN": "116: ರಾಮಸ್ವಾಮಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್",
-    "cellRef": "A230"
+    "NameKN": "ರಂಗನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3446,8 +3217,7 @@
     "Unnamed: 3": "",
     "AreaKN": "154: ರಾಯಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ",
-    "cellRef": "A231"
+    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ"
   },
   {
     "Department": "bbmp_wards",
@@ -3461,8 +3231,7 @@
     "Unnamed: 3": "",
     "AreaKN": "207: RBI ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್",
-    "cellRef": "A232"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3476,8 +3245,7 @@
     "Unnamed: 3": "",
     "AreaKN": "73: ಎಸ್ ಕೆ ಗಾರ್ಡನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್",
-    "cellRef": "A233"
+    "NameKN": "ಉಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3491,8 +3259,7 @@
     "Unnamed: 3": "",
     "AreaKN": "74: ಸಗಾಯರಪುರಂ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A234"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3506,8 +3273,7 @@
     "Unnamed: 3": "",
     "AreaKN": "118: ಸಂಪಂಗಿರಾಮ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿವಡ್ಡರ್",
-    "cellRef": "A235"
+    "NameKN": "ರವಿವಡ್ಡರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3521,8 +3287,7 @@
     "Unnamed: 3": "",
     "AreaKN": "62: ಸಂಜಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ",
-    "cellRef": "A236"
+    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3536,8 +3301,7 @@
     "Unnamed: 3": "",
     "AreaKN": "187: ಸಾರಕ್ಕಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A237"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3551,8 +3315,7 @@
     "Unnamed: 3": "",
     "AreaKN": "186: ಶಾಕಾಂಬರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಾಧವ್ ರಾವ್",
-    "cellRef": "A238"
+    "NameKN": "ಮಾಧವ್ ರಾವ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3566,8 +3329,7 @@
     "Unnamed: 3": "",
     "AreaKN": "52: ಶಕ್ತಿ ಗಣಪತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್",
-    "cellRef": "A239"
+    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3581,8 +3343,7 @@
     "Unnamed: 3": "",
     "AreaKN": "51: ಶಂಕರ್ ಮಟ್ಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಖಾ",
-    "cellRef": "A240"
+    "NameKN": "ರೇಖಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3596,8 +3357,7 @@
     "Unnamed: 3": "",
     "AreaKN": "166: ಶಾಂತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಧು",
-    "cellRef": "A241"
+    "NameKN": "ಮಧು"
   },
   {
     "Department": "bbmp_wards",
@@ -3611,8 +3371,7 @@
     "Unnamed: 3": "",
     "AreaKN": "119: ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A242"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3626,8 +3385,7 @@
     "Unnamed: 3": "",
     "AreaKN": "131: ಶಿವನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್",
-    "cellRef": "A243"
+    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3641,8 +3399,7 @@
     "Unnamed: 3": "",
     "AreaKN": "161: ಸಿಲ್ವರ್ ಜೂಬ್ಲಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಯಶೋವರ್ದನ್",
-    "cellRef": "A244"
+    "NameKN": "ಡಾ. ಯಶೋವರ್ದನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3656,8 +3413,7 @@
     "Unnamed: 3": "",
     "AreaKN": "180: ಸೋಮೇಶ್ವರ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮದಾಸ್",
-    "cellRef": "A245"
+    "NameKN": "ರಾಮದಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3671,8 +3427,7 @@
     "Unnamed: 3": "",
     "AreaKN": "42: ಶ್ರೀಗಂಧದಕಾವಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
-    "cellRef": "A246"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3686,8 +3441,7 @@
     "Unnamed: 3": "",
     "AreaKN": "197: ಶ್ರೀನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ",
-    "cellRef": "A247"
+    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3701,8 +3455,7 @@
     "Unnamed: 3": "",
     "AreaKN": "130: ಶ್ರೀರಾಮಮಂದಿರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಘವೇಂದ್ರ",
-    "cellRef": "A248"
+    "NameKN": "ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "bbmp_wards",
@@ -3716,8 +3469,7 @@
     "Unnamed: 3": "",
     "AreaKN": "83: ಸುಬ್ಬಯ್ಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಣ್ಣ",
-    "cellRef": "A249"
+    "NameKN": "ಶಿವಣ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -3731,8 +3483,7 @@
     "Unnamed: 3": "",
     "AreaKN": "124: ಸುಭಾಷ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಲಾ",
-    "cellRef": "A250"
+    "NameKN": "ಶಾಂತಲಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3746,8 +3497,7 @@
     "Unnamed: 3": "",
     "AreaKN": "203: ಸುಬ್ರಹ್ಮಣ್ಯಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ",
-    "cellRef": "A251"
+    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -3761,8 +3511,7 @@
     "Unnamed: 3": "",
     "AreaKN": "59: ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್",
-    "cellRef": "A252"
+    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3776,8 +3525,7 @@
     "Unnamed: 3": "",
     "AreaKN": "178: ಸುದ್ದಗುಂಟೆ ಪಾಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A253"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3791,8 +3539,7 @@
     "Unnamed: 3": "",
     "AreaKN": "25: ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮನೋಹರ್",
-    "cellRef": "A254"
+    "NameKN": "ಮನೋಹರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3806,8 +3553,7 @@
     "Unnamed: 3": "",
     "AreaKN": "162: ಸುಂಕೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್",
-    "cellRef": "A255"
+    "NameKN": "ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3821,8 +3567,7 @@
     "Unnamed: 3": "",
     "AreaKN": "200: ಸ್ವಾಮಿ ವಿವೇಕಾನಂದ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ",
-    "cellRef": "A256"
+    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3836,8 +3581,7 @@
     "Unnamed: 3": "",
     "AreaKN": "19: ಟಿ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಕೋಮಲ್ ಕೆ.ಆರ್",
-    "cellRef": "A257"
+    "NameKN": "ಡಾ. ಕೋಮಲ್ ಕೆ.ಆರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3851,8 +3595,7 @@
     "Unnamed: 3": "",
     "AreaKN": "7: ಥಣಿಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಗೌಡ",
-    "cellRef": "A258"
+    "NameKN": "ಚನ್ನಗೌಡ"
   },
   {
     "Department": "bbmp_wards",
@@ -3866,8 +3609,7 @@
     "Unnamed: 3": "",
     "AreaKN": "29: ಉಲ್ಲಾಳು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್",
-    "cellRef": "A259"
+    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3881,8 +3623,7 @@
     "Unnamed: 3": "",
     "AreaKN": "121: ಹಲಸೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾದೇವ",
-    "cellRef": "A260"
+    "NameKN": "ಮಹಾದೇವ"
   },
   {
     "Department": "bbmp_wards",
@@ -3896,8 +3637,7 @@
     "Unnamed: 3": "",
     "AreaKN": "202: ಉತ್ತರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಾಮರಾಜು",
-    "cellRef": "A261"
+    "NameKN": "ಚಾಮರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -3911,8 +3651,7 @@
     "Unnamed: 3": "",
     "AreaKN": "169: ವನ್ನಾರಪೇಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪರ್ಣಾ",
-    "cellRef": "A262"
+    "NameKN": "ಅಪರ್ಣಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3926,8 +3665,7 @@
     "Unnamed: 3": "",
     "AreaKN": "104: ವರ್ತೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೋಹಿತ್",
-    "cellRef": "A263"
+    "NameKN": "ರೋಹಿತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3941,8 +3679,7 @@
     "Unnamed: 3": "",
     "AreaKN": "117: ವಸಂತನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A264"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3956,8 +3693,7 @@
     "Unnamed: 3": "",
     "AreaKN": "204: ವಸಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಜ್",
-    "cellRef": "A265"
+    "NameKN": "ಜಯರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3971,8 +3707,7 @@
     "Unnamed: 3": "",
     "AreaKN": "199: ವಿದ್ಯಾಪೀಠ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಪ್ಪ",
-    "cellRef": "A266"
+    "NameKN": "ಕೃಷ್ಣಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -3986,8 +3721,7 @@
     "Unnamed: 3": "",
     "AreaKN": "13: ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಣ್ಣ",
-    "cellRef": "A267"
+    "NameKN": "ರಾಜಣ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -4001,8 +3735,7 @@
     "Unnamed: 3": "",
     "AreaKN": "145: ವಿಜಯನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಟರಾಜ್",
-    "cellRef": "A268"
+    "NameKN": "ನಟರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4016,8 +3749,7 @@
     "Unnamed: 3": "",
     "AreaKN": "89: ವಿಜಿನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A269"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4031,8 +3763,7 @@
     "Unnamed: 3": "",
     "AreaKN": "95: ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್",
-    "cellRef": "A270"
+    "NameKN": "ಜಯಶಂಕರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4046,8 +3777,7 @@
     "Unnamed: 3": "",
     "AreaKN": "163: ವಿಶ್ವೇಶ್ವರ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಶೀಲಾ ಎನ್.",
-    "cellRef": "A271"
+    "NameKN": "ಸುಶೀಲಾ ಎನ್."
   },
   {
     "Department": "bbmp_wards",
@@ -4061,8 +3791,7 @@
     "Unnamed: 3": "",
     "AreaKN": "64: ವಿಶ್ವನಾಥ ನಾಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್ ಕುಮಾರ್",
-    "cellRef": "A272"
+    "NameKN": "ಶರತ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4076,8 +3805,7 @@
     "Unnamed: 3": "",
     "AreaKN": "53: ವೃಷಭಾವತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್",
-    "cellRef": "A273"
+    "NameKN": "ಡಾ. ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4091,8 +3819,7 @@
     "Unnamed: 3": "",
     "AreaKN": "103: ವೈಟ್ ಫೀಲ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರುದ್ರಮುನಿ",
-    "cellRef": "A274"
+    "NameKN": "ರುದ್ರಮುನಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -4106,8 +3833,7 @@
     "Unnamed: 3": "",
     "AreaKN": "188: ಯಡಿಯೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A275"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4121,8 +3847,7 @@
     "Unnamed: 3": "",
     "AreaKN": "4: ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರುರಾಜ್",
-    "cellRef": "A276"
+    "NameKN": "ಗುರುರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4136,8 +3861,7 @@
     "Unnamed: 3": "",
     "AreaKN": "205: ಯೆಲ್ಚೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸನ್",
-    "cellRef": "A277"
+    "NameKN": "ಶ್ರೀನಿವಾಸನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4151,8 +3875,7 @@
     "Unnamed: 3": "",
     "AreaKN": "35: ಯಶವಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ",
-    "cellRef": "A278"
+    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_zone",
@@ -4166,8 +3889,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ರಮ್ಯಾ ಎಸ್.",
-    "cellRef": "A279"
+    "NameKN": "ರಮ್ಯಾ ಎಸ್."
   },
   {
     "Department": "bbmp_zone",
@@ -4181,8 +3903,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಹೆಚ್ .ಸಿ. ಗಿರೀಶ್",
-    "cellRef": "A280"
+    "NameKN": "ಹೆಚ್ .ಸಿ. ಗಿರೀಶ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4196,8 +3917,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್.",
-    "cellRef": "A281"
+    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್."
   },
   {
     "Department": "bbmp_zone",
@@ -4211,8 +3931,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕೆ.ಎನ್. ರಮೇಶ್",
-    "cellRef": "A282"
+    "NameKN": "ಕೆ.ಎನ್. ರಮೇಶ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4226,8 +3945,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸತೀಶ ಬಿ.ಸಿ",
-    "cellRef": "A283"
+    "NameKN": "ಸತೀಶ ಬಿ.ಸಿ"
   },
   {
     "Department": "bbmp_zone",
@@ -4241,8 +3959,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್",
-    "cellRef": "A284"
+    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4256,8 +3973,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಅರ್ಚನಾ ಎಂ.ಎಸ್",
-    "cellRef": "A285"
+    "NameKN": "ಅರ್ಚನಾ ಎಂ.ಎಸ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4271,8 +3987,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕರೀಗೌಡ",
-    "cellRef": "A286"
+    "NameKN": "ಕರೀಗೌಡ"
   },
   {
     "Department": "bescom_division",
@@ -4286,8 +4001,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A287"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4301,8 +4015,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A288"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4316,8 +4029,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A289"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4331,8 +4043,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A290"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4346,8 +4057,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A291"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4361,8 +4071,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A292"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4376,8 +4085,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A293"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4391,8 +4099,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A294"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4406,8 +4113,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A295"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4421,8 +4127,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A296"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4436,8 +4141,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A297"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4451,8 +4155,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A298"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4466,8 +4169,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A299"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4481,8 +4183,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A300"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4496,8 +4197,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A301"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4511,8 +4211,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A302"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4526,8 +4225,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A303"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4541,8 +4239,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A304"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4556,8 +4253,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A305"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4571,8 +4267,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A306"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4586,8 +4281,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A307"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4601,8 +4295,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A308"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4616,8 +4309,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A309"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4631,8 +4323,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನ ಸೌಧ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A310"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4646,8 +4337,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A311"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4661,8 +4351,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A312"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4676,8 +4365,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A313"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4691,8 +4379,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A314"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4706,8 +4393,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ1 ರಾಜಾಜಿನಗರ 2ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A315"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4721,8 +4407,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C2 ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A316"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4736,8 +4421,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C3 ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A317"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4751,8 +4435,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C4 ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A318"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4766,8 +4449,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C5 ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A319"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4781,8 +4463,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ6 ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A320"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4796,8 +4477,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ7 ಯಲಹಂಕ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A321"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4811,8 +4491,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C8 ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A322"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4826,8 +4505,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ9 ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A323"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4841,8 +4519,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A324"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4856,8 +4533,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A325"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4871,8 +4547,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A326"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4886,8 +4561,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A327"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4901,8 +4575,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ1 ಪಿಳ್ಳಣ್ಣ ಗಾರ್ಡನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A328"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4916,8 +4589,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ10 ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A329"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4931,8 +4603,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 11 ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A330"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4946,8 +4617,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 12 ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A331"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4961,8 +4631,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ2 ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A332"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4976,8 +4645,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E3 MG ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A333"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4991,8 +4659,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E4 ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A334"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5006,8 +4673,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E5 ಕುಕ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A335"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5021,8 +4687,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ6 ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A336"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5036,8 +4701,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E7 ದೂರವಾಣಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A337"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5051,8 +4715,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E8 ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A338"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5066,8 +4729,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E9 ನಾಗವಾರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A339"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5081,8 +4743,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A340"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5096,8 +4757,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A341"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5111,8 +4771,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 1 ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A342"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5126,8 +4785,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 2 ಅಂಜನನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A343"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5141,8 +4799,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 3 ಕಗ್ಗಲಿಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A344"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5156,8 +4813,7 @@
     "Unnamed: 3": "",
     "AreaKN": "K4 RR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A345"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5171,8 +4827,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A346"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5186,8 +4841,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A347"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5201,8 +4855,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A348"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5216,8 +4869,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A349"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5231,8 +4883,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A350"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5246,8 +4897,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N1 ವೆಸ್ಟ್ ಕಾರ್ಡ್ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A351"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5261,8 +4911,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N10 ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A352"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5276,8 +4925,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N2 KHB ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A353"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5291,8 +4939,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 3 ಬಸವೇಶ್ವರನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A354"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5306,8 +4953,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N4 ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A355"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5321,8 +4967,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N5 SRS ಗೇಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A356"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5336,8 +4981,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N6 ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A357"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5351,8 +4995,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N7 ಕುರುಬರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A358"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5366,8 +5009,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 8 ಉಳ್ಳಾಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A359"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5381,8 +5023,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N9 ಸೋಲದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A360"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5396,8 +5037,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A361"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5411,8 +5051,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 1 ಜಯನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A362"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5426,8 +5065,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 10 ಬನ್ನೇರುಘಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A363"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5441,8 +5079,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S11 HSR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A364"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5456,8 +5093,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 12 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A365"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5471,8 +5107,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 13 ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A366"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5486,8 +5121,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 14 ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A367"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5501,8 +5135,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 15 ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A368"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5516,8 +5149,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S16 ಮಡಿವಾಳ SDO",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A369"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5531,8 +5163,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S17 HAL",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A370"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5546,8 +5177,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S18 ಚಿಕ್ಕ ಕಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A371"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5561,8 +5191,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 19 ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A372"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5576,8 +5205,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 2 ವಿಲ್ಸ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A373"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5591,8 +5219,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷ್೨೦ ಆಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A374"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5606,8 +5233,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S3 ಆಸ್ಟಿನ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A375"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5621,8 +5247,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S4 ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A376"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5636,8 +5261,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S5 ISRO ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A377"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5651,8 +5275,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 6 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A378"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5666,8 +5289,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್7 ಮುರುಗೇಶಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A379"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5681,8 +5303,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 8 ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A380"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5696,8 +5317,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S9 ಬನಶಂಕರಿ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A381"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5711,8 +5331,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A382"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5726,8 +5345,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ1",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A383"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5741,8 +5359,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ2",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A384"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5756,8 +5373,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ3 (ಕ್ಯಾತ್ಸಂದ್ರ)",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A385"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5771,8 +5387,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W1 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A386"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5786,8 +5401,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W2 ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A387"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5801,8 +5415,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W3 ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A388"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5816,8 +5429,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W4 AR ವೃತ್ತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A389"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5831,8 +5443,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W5 ಕಬ್ಬನ್‌ಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A390"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5846,8 +5457,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W6 ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A391"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5861,8 +5471,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W7 ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A392"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5876,8 +5485,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W8 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A393"
+    "NameKN": "-"
   },
   {
     "Department": "bwssb_division",
@@ -5891,8 +5499,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇಂದ್ರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ",
-    "cellRef": "A394"
+    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ"
   },
   {
     "Department": "bwssb_division",
@@ -5906,8 +5513,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್",
-    "cellRef": "A395"
+    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್"
   },
   {
     "Department": "bwssb_division",
@@ -5921,8 +5527,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಜಯಪ್ರಕಾಶ್",
-    "cellRef": "A396"
+    "NameKN": "ಜಯಪ್ರಕಾಶ್"
   },
   {
     "Department": "bwssb_division",
@@ -5936,8 +5541,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಈಶಾನ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ",
-    "cellRef": "A397"
+    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ"
   },
   {
     "Department": "bwssb_division",
@@ -5951,8 +5555,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A398"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -5966,8 +5569,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A399"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -5981,8 +5583,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A400"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -5996,8 +5597,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಹರಿನಾಥ್ ಆರ್",
-    "cellRef": "A401"
+    "NameKN": "ಹರಿನಾಥ್ ಆರ್"
   },
   {
     "Department": "bwssb_division",
@@ -6011,8 +5611,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್",
-    "cellRef": "A402"
+    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್"
   },
   {
     "Department": "bwssb_division",
@@ -6026,8 +5625,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್.",
-    "cellRef": "A403"
+    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್."
   },
   {
     "Department": "bwssb_division",
@@ -6041,8 +5639,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A404"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -6056,8 +5653,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗರಾಜ್ ಕೆ.",
-    "cellRef": "A405"
+    "NameKN": "ನಾಗರಾಜ್ ಕೆ."
   },
   {
     "Department": "bwssb_division",
@@ -6071,8 +5667,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಬಸವರಾಜ ಎನ್.",
-    "cellRef": "A406"
+    "NameKN": "ಬಸವರಾಜ ಎನ್."
   },
   {
     "Department": "bwssb_division",
@@ -6086,8 +5681,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೈಋತ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಸ್ನೇಹಾ ವಿ.",
-    "cellRef": "A407"
+    "NameKN": "ಸ್ನೇಹಾ ವಿ."
   },
   {
     "Department": "bwssb_division",
@@ -6101,8 +5695,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಟಿ. ಚಂದ್ರಶೇಖರ್ ಪ್ರಸಾದ್",
-    "cellRef": "A408"
+    "NameKN": "ಟಿ. ಚಂದ್ರಶೇಖರ್ ಪ್ರಸಾದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6116,8 +5709,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A409"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6131,8 +5723,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ",
-    "cellRef": "A410"
+    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6146,8 +5737,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್",
-    "cellRef": "A411"
+    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6161,8 +5751,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
-    "cellRef": "A412"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6176,8 +5765,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನಂದ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್",
-    "cellRef": "A413"
+    "NameKN": " ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6191,8 +5779,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A414"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6206,8 +5793,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಶ್ವನಾಥ್",
-    "cellRef": "A415"
+    "NameKN": " ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6221,8 +5807,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಹುಬಲಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
-    "cellRef": "A416"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -6236,8 +5821,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪೂರ್ಣಿಮಾ",
-    "cellRef": "A417"
+    "NameKN": " ಪೂರ್ಣಿಮಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6251,8 +5835,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A418"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6266,8 +5849,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A419"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6281,8 +5863,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನಪ ಪಾರ್ಕ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A420"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6296,8 +5877,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A421"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6311,8 +5891,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "",
-    "cellRef": "A422"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6326,8 +5905,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BEML ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A423"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6341,8 +5919,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಷ್ಯಂ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್",
-    "cellRef": "A424"
+    "NameKN": " ಕಿಶೋರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6356,8 +5933,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-I",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A425"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6371,8 +5947,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-II",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A426"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6386,8 +5961,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM I & II",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ.ಪಿ.",
-    "cellRef": "A427"
+    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ.ಪಿ."
   },
   {
     "Department": "bwssb_service_station",
@@ -6401,8 +5975,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ",
-    "cellRef": "A428"
+    "NameKN": " ಶ್ರೀಜಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6416,8 +5989,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ.ರಾಮನ್ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A429"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6431,8 +6003,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ / ಹೊರಮಾವು / ಕಲ್ಕೆರೆ / ಕೊತ್ತನೂರು-ಬೈರತಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್",
-    "cellRef": "A430"
+    "NameKN": " ಆನಂದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6446,8 +6017,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ",
-    "cellRef": "A431"
+    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6461,8 +6031,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ",
-    "cellRef": "A432"
+    "NameKN": " ರಾಮೇಗೌಡ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6476,8 +6045,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಾಲಭಾಗ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ",
-    "cellRef": "A433"
+    "NameKN": " ಸೀಮಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6491,8 +6059,7 @@
     "Unnamed: 3": "",
     "AreaKN": "CLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಡಿ.ಎಸ್. ರಂಗಯ್ಯ",
-    "cellRef": "A434"
+    "NameKN": " ಡಿ.ಎಸ್. ರಂಗಯ್ಯ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6506,8 +6073,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲ್ಸ್ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಶ್ ಎಸ್.ಡಿ",
-    "cellRef": "A435"
+    "NameKN": " ರಾಜೇಶ್ ಎಸ್.ಡಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6521,8 +6087,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಗಿರಿ I&II",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A436"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6536,8 +6101,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು",
-    "cellRef": "A437"
+    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು"
   },
   {
     "Department": "bwssb_service_station",
@@ -6551,8 +6115,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡನೆಕುಂದಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A438"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6566,8 +6129,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಮತಾ ಎಂ.ಎಚ್",
-    "cellRef": "A439"
+    "NameKN": " ಮಮತಾ ಎಂ.ಎಚ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6581,8 +6143,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಜರ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್",
-    "cellRef": "A440"
+    "NameKN": " ರಾಹುಲ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6596,8 +6157,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನ ಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A441"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6611,8 +6171,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್",
-    "cellRef": "A442"
+    "NameKN": " ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6626,8 +6185,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್",
-    "cellRef": "A443"
+    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6641,8 +6199,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "",
-    "cellRef": "A444"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6656,8 +6213,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಂಜನ್",
-    "cellRef": "A445"
+    "NameKN": " ರಂಜನ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6671,8 +6227,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
-    "cellRef": "A446"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6686,8 +6241,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಡಿಶ್",
-    "cellRef": "A447"
+    "NameKN": " ನಾಡಿಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6701,8 +6255,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HGR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್",
-    "cellRef": "A448"
+    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6716,8 +6269,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ",
-    "cellRef": "A449"
+    "NameKN": " ಶ್ರೀಜಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6731,8 +6283,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕುಮಾರ್",
-    "cellRef": "A450"
+    "NameKN": " ರವಿ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6746,8 +6297,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸ್ವಾತಿ",
-    "cellRef": "A451"
+    "NameKN": " ಸ್ವಾತಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6761,8 +6311,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಧರ್ ಎಸ್",
-    "cellRef": "A452"
+    "NameKN": " ಶ್ರೀಧರ್ ಎಸ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6776,8 +6325,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HRBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
-    "cellRef": "A453"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6791,8 +6339,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A454"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6806,8 +6353,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಐಡಿಯಲ್ ಹೋಮ್ಸ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
-    "cellRef": "A455"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6821,8 +6367,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಶಿ ಕುಮಾರ್",
-    "cellRef": "A456"
+    "NameKN": " ಶಶಿ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6836,8 +6381,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಸ್ರೋ ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A457"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6851,8 +6395,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಟ್ಟಮಡು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಿಂಗರಾಜು",
-    "cellRef": "A458"
+    "NameKN": " ಲಿಂಗರಾಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -6866,8 +6409,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ ಜೆ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ",
-    "cellRef": "A459"
+    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6881,8 +6423,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರದೀಪ್",
-    "cellRef": "A460"
+    "NameKN": " ಪ್ರದೀಪ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6896,8 +6437,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಮಹಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ",
-    "cellRef": "A461"
+    "NameKN": " ಜಯಶ್ರೀ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6911,8 +6451,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ 'ಟಿ' ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ",
-    "cellRef": "A462"
+    "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6926,8 +6465,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ",
-    "cellRef": "A463"
+    "NameKN": " ಶ್ರೀಜಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6941,8 +6479,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಬಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "",
-    "cellRef": "A464"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6956,8 +6493,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾನ್ಸನ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ",
-    "cellRef": "A465"
+    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6971,8 +6507,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 1ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ",
-    "cellRef": "A466"
+    "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6986,8 +6521,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ರಮ್",
-    "cellRef": "A467"
+    "NameKN": " ಅಕ್ರಮ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7001,8 +6535,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 3ನೇ ಹಂತ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A468"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7016,8 +6549,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A469"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7031,8 +6563,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪುರಂ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A470"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7046,8 +6577,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ/ ಕಮಲಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಿವಕುಮಾರ್",
-    "cellRef": "A471"
+    "NameKN": " ಶಿವಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7061,8 +6591,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮುದಾ",
-    "cellRef": "A472"
+    "NameKN": " ಕುಮುದಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7076,8 +6605,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
-    "cellRef": "A473"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7091,8 +6619,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇತಮಾರನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ",
-    "cellRef": "A474"
+    "NameKN": " ಪುಷ್ಪಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7106,8 +6633,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ಟವರ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ",
-    "cellRef": "A475"
+    "NameKN": " ಜಯಶ್ರೀ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7121,8 +6647,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಕಾಸ್ ಡಿ.ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್.ಆರ್",
-    "cellRef": "A476"
+    "NameKN": " ವಿಕಾಸ್ ಡಿ.ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್.ಆರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7136,8 +6661,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A477"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7151,8 +6675,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A478"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7166,8 +6689,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A479"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7181,8 +6703,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಜಾನನ",
-    "cellRef": "A480"
+    "NameKN": " ಗಜಾನನ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7196,8 +6717,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರುದಿನ್ನೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ಷಯ್ ಸಿ",
-    "cellRef": "A481"
+    "NameKN": " ಅಕ್ಷಯ್ ಸಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7211,8 +6731,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
-    "cellRef": "A482"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7226,8 +6745,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರೀತಿ ಜೆ",
-    "cellRef": "A483"
+    "NameKN": " ಪ್ರೀತಿ ಜೆ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7241,8 +6759,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಜಿನಿ ಎ",
-    "cellRef": "A484"
+    "NameKN": " ರಜಿನಿ ಎ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7256,8 +6773,7 @@
     "Unnamed: 3": "",
     "AreaKN": "LLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ",
-    "cellRef": "A485"
+    "NameKN": " ಸೀಮಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7271,8 +6787,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಚಲಿಬೆಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
-    "cellRef": "A486"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7286,8 +6801,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್",
-    "cellRef": "A487"
+    "NameKN": " ದಿನೇಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7301,8 +6815,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಯೂಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ",
-    "cellRef": "A488"
+    "NameKN": " ಪುಷ್ಪಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7316,8 +6829,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾನಾ",
-    "cellRef": "A489"
+    "NameKN": " ಸುಹಾನಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7331,8 +6843,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MEI ಲೇಔಟ್ (ದಾಸರಹಳ್ಳಿ)",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
-    "cellRef": "A490"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -7346,8 +6857,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MNK ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ",
-    "cellRef": "A491"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7361,8 +6871,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಲ ಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸತೀಶ್ ಟಿ",
-    "cellRef": "A492"
+    "NameKN": " ಸತೀಶ್ ಟಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7376,8 +6885,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೌಂಟ್ ಜಾಯ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುದರ್ಶನ್ ಡಿ.ಎನ್",
-    "cellRef": "A493"
+    "NameKN": " ಸುದರ್ಶನ್ ಡಿ.ಎನ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7391,8 +6899,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್",
-    "cellRef": "A494"
+    "NameKN": " ದಿನೇಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7406,8 +6913,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹರ್ಷ ವಿ",
-    "cellRef": "A495"
+    "NameKN": " ಹರ್ಷ ವಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7421,8 +6927,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗೇಂದ್ರ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್",
-    "cellRef": "A496"
+    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7436,8 +6941,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದುಷ್ಯಂತ್",
-    "cellRef": "A497"
+    "NameKN": " ದುಷ್ಯಂತ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7451,8 +6955,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ BEL ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ",
-    "cellRef": "A498"
+    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7466,8 +6969,7 @@
     "Unnamed: 3": "",
     "AreaKN": "OMBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ",
-    "cellRef": "A499"
+    "NameKN": " ಮಂಜುನಾಥ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7481,8 +6983,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಣೇಶ್",
-    "cellRef": "A500"
+    "NameKN": " ಗಣೇಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7496,8 +6997,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಂದೀಪ್",
-    "cellRef": "A501"
+    "NameKN": " ಸಂದೀಪ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7511,8 +7011,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್",
-    "cellRef": "A502"
+    "NameKN": " ರಾಹುಲ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7526,8 +7025,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
-    "cellRef": "A503"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7541,8 +7039,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಪಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶೇಖರ್",
-    "cellRef": "A504"
+    "NameKN": " ಶೇಖರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7556,8 +7053,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ",
-    "cellRef": "A505"
+    "NameKN": " ಪುಷ್ಪಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7571,8 +7067,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್",
-    "cellRef": "A506"
+    "NameKN": " ಆನಂದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7586,8 +7081,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್",
-    "cellRef": "A507"
+    "NameKN": " ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7601,8 +7095,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಚಿಂತನ ಕೆ",
-    "cellRef": "A508"
+    "NameKN": " ಚಿಂತನ ಕೆ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7616,8 +7109,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ್ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
-    "cellRef": "A509"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7631,8 +7123,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಿದ್ದರಾಜು",
-    "cellRef": "A510"
+    "NameKN": " ಸಿದ್ದರಾಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -7646,8 +7137,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಧಾಮ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾಸ್",
-    "cellRef": "A511"
+    "NameKN": " ಸುಹಾಸ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7661,8 +7151,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕಿರಣ್ (ಐ/ಸಿ)",
-    "cellRef": "A512"
+    "NameKN": " ರವಿ ಕಿರಣ್ (ಐ/ಸಿ)"
   },
   {
     "Department": "bwssb_service_station",
@@ -7676,8 +7165,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ",
-    "cellRef": "A513"
+    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7691,8 +7179,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್",
-    "cellRef": "A514"
+    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7706,8 +7193,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯ್ ನಗರ OHT",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A515"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7721,8 +7207,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ಆ.ರ್",
-    "cellRef": "A516"
+    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ಆ.ರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7736,8 +7221,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್",
-    "cellRef": "A517"
+    "NameKN": " ಆನಂದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7751,8 +7235,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಬಡಾವಣೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A518"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7766,8 +7249,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ OHT",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ ಬಿ",
-    "cellRef": "A519"
+    "NameKN": " ರಾಮೇಗೌಡ ಬಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7781,8 +7263,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವಿ ಪುರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಪ್ರಹ್ಲಾದ್",
-    "cellRef": "A520"
+    "NameKN": "ಪ್ರಹ್ಲಾದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7796,8 +7277,7 @@
     "Unnamed: 3": "",
     "AreaKN": "WCR-I",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
-    "cellRef": "A521"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7811,8 +7291,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು",
-    "cellRef": "A522"
+    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು"
   },
   {
     "Department": "bwssb_service_station",
@@ -7826,8 +7305,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಓಲ್ಡ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ.ಬಿ",
-    "cellRef": "A523"
+    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ.ಬಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7841,8 +7319,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್",
-    "cellRef": "A524"
+    "NameKN": " ಕಿಶೋರ್"
   },
   {
     "Department": "police_city",
@@ -7856,8 +7333,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A525"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7871,8 +7347,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A526"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7886,8 +7361,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A527"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7901,8 +7375,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A528"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7916,8 +7389,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಂಡರ್ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A529"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7931,8 +7403,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A530"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7946,8 +7417,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A531"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7961,8 +7431,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನುಗೊಂಡನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A532"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7976,8 +7445,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A533"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7991,8 +7459,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A534"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8006,8 +7473,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A535"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8021,8 +7487,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಡವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A536"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8036,8 +7501,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಗುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A537"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8051,8 +7515,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A538"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8066,8 +7529,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A539"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8081,8 +7543,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A540"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8096,8 +7557,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A541"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8111,8 +7571,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಡೆಪಾಳ್ಯ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A542"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8126,8 +7585,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A543"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8141,8 +7599,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A544"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8156,8 +7613,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವೇಶ್ವರ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A545"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8171,8 +7627,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A546"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8186,8 +7641,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A547"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8201,8 +7655,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಕವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A548"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8216,8 +7669,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A549"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8231,8 +7683,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಾವಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A550"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8246,8 +7697,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಇಎಂಎಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A551"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8261,8 +7711,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಸಗರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A552"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8276,8 +7725,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇತಮಂಗಲ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A553"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8291,8 +7739,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A554"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8306,8 +7753,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A555"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8321,8 +7767,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A556"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8336,8 +7781,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A557"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8351,8 +7795,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A558"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8366,8 +7809,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A559"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8381,8 +7823,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ಕೆ.ಅಚ್ಚುಕಟ್ಟು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A560"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8396,8 +7837,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A561"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8411,8 +7851,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A562"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8426,8 +7865,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ ರೀಫ್ಸ್ PS",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A563"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8441,8 +7879,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರಾ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A564"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8456,8 +7893,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A565"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8471,8 +7907,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A566"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8486,8 +7921,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A567"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8501,8 +7935,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A568"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8516,8 +7949,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A569"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8531,8 +7963,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A570"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8546,8 +7977,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A571"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8561,8 +7991,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A572"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8576,8 +8005,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A573"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8591,8 +8019,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A574"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8606,8 +8033,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A575"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8621,8 +8047,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮರ್ಷಿಯಲ್ ಸ್ಟ್ರೀಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A576"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8636,8 +8061,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಟನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A577"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8651,8 +8075,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A578"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8666,8 +8089,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A579"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8681,8 +8103,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಜೀವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A580"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8696,8 +8117,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಿಬ್ಬೂರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A581"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8711,8 +8131,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A582"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8726,8 +8145,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A583"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8741,8 +8159,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A584"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8756,8 +8173,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A585"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8771,8 +8187,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A586"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8786,8 +8201,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಮ್ಮಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A587"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8801,8 +8215,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A588"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8816,8 +8229,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A589"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8831,8 +8243,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A590"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8846,8 +8257,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A591"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8861,8 +8271,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A592"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8876,8 +8285,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A593"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8891,8 +8299,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A594"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8906,8 +8313,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A595"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8921,8 +8327,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಪೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A596"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8936,8 +8341,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A597"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8951,8 +8355,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A598"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8966,8 +8369,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಗೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A599"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8981,8 +8383,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A600"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8996,8 +8397,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A601"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9011,8 +8411,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನುಮತಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A602"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9026,8 +8425,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A603"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9041,8 +8439,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A604"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9056,8 +8453,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A605"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9071,8 +8467,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A606"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9086,8 +8481,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A607"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9101,8 +8495,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A608"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9116,8 +8509,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A609"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9131,8 +8523,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A610"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9146,8 +8537,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಳಿಮಾವು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A611"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9161,8 +8551,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A612"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9176,8 +8565,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಜೂರ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A613"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9191,8 +8579,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A614"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9206,8 +8593,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ.ಸಿ.ನಗರಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A615"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9221,8 +8607,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಜೀವನರಾಮ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A616"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9236,8 +8621,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A617"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9251,8 +8635,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A618"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9266,8 +8649,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಪ್ರಕಾಶ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A619"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9281,8 +8663,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A620"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9296,8 +8677,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A621"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9311,8 +8691,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜ್ಞಾನಭಾರತಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A622"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9326,8 +8705,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಜಿ.ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A623"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9341,8 +8719,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಎಂ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A624"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9356,8 +8733,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A625"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9371,8 +8747,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A626"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9386,8 +8761,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A627"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9401,8 +8775,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಗ್ಗಲೀಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A628"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9416,8 +8789,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಲಂಬೆಳ್ಳ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A629"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9431,8 +8803,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A630"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9446,8 +8817,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A631"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9461,8 +8831,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A632"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9476,8 +8845,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A633"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9491,8 +8859,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪೇಗೌಡ ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A634"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9506,8 +8873,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಚಾರ್ಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A635"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9521,8 +8887,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A636"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9536,8 +8901,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಸ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A637"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9551,8 +8915,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿರುಗಾವಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A638"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9566,8 +8929,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A639"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9581,8 +8943,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A640"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9596,8 +8957,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A641"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9611,8 +8971,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A642"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9626,8 +8985,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A643"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9641,8 +8999,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A644"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9656,8 +9013,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A645"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9671,8 +9027,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A646"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9686,8 +9041,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಣನಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A647"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9701,8 +9055,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A648"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9716,8 +9069,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A649"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9731,8 +9083,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A650"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9746,8 +9097,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A651"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9761,8 +9111,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A652"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9776,8 +9125,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A653"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9791,8 +9139,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A654"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9806,8 +9153,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೂಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A655"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9821,8 +9167,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A656"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9836,8 +9181,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A657"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9851,8 +9195,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A658"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9866,8 +9209,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಕೆ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A659"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9881,8 +9223,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಎಂ. ಹಿಲ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A660"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9896,8 +9237,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A661"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9911,8 +9251,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A662"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9926,8 +9265,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A663"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9941,8 +9279,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A664"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9956,8 +9293,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A665"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9971,8 +9307,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A666"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9986,8 +9321,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A667"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10001,8 +9335,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A668"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10016,8 +9349,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A669"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10031,8 +9363,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A670"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10046,8 +9377,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A671"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10061,8 +9391,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A672"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10076,8 +9405,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಂಬಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A673"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10091,8 +9419,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A674"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10106,8 +9433,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A675"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10121,8 +9447,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರತ್ತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A676"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10136,8 +9461,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರಿಕುಪ್ಪಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A677"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10151,8 +9475,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A678"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10166,8 +9489,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಡಿಗೇಶಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A679"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10181,8 +9503,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಕೋ ಲೇಔಟ್ ಬೆಂಗಳೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A680"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10196,8 +9517,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A681"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10211,8 +9531,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A682"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10226,8 +9545,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A683"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10241,8 +9559,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ ಗಿರಿಘಾಮ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A684"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10256,8 +9573,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A685"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10271,8 +9587,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಗಲಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A686"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10286,8 +9601,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A687"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10301,8 +9615,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A688"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10316,8 +9629,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A689"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10331,8 +9643,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A690"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10346,8 +9657,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪರಪ್ಪನ ಅಗ್ರಹಾರ",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A691"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10361,8 +9671,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಟನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A692"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10376,8 +9685,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾತಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A693"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10391,8 +9699,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A694"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10406,8 +9713,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A695"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10421,8 +9727,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A696"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10436,8 +9741,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಟ್ಟೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A697"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10451,8 +9755,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A698"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10466,8 +9769,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A699"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10481,8 +9783,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾನುಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A700"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10496,8 +9797,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A701"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10511,8 +9811,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಗೋಪಾಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A702"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10526,8 +9825,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A703"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10541,8 +9839,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A704"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10556,8 +9853,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A705"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10571,8 +9867,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A706"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10586,8 +9881,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಲ್ಪಾಡ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A707"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10601,8 +9895,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಬರ್ಟ್‌ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A708"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10616,8 +9909,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್.ಜೆ. ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A709"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10631,8 +9923,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷದಶಿವನಗರ್ Pಷ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A710"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10646,8 +9937,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಂಗಿರಾಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A711"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10661,8 +9951,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಿಗೆಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A712"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10676,8 +9965,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ ನಗರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A713"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10691,8 +9979,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂತೆಮರಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A714"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10706,8 +9993,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A715"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10721,8 +10007,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾತನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A716"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10736,8 +10021,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A717"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10751,8 +10035,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A718"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10766,8 +10049,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A719"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10781,8 +10063,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A720"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10796,8 +10077,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A721"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10811,8 +10091,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A722"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10826,8 +10105,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A723"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10841,8 +10119,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A724"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10856,8 +10133,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A725"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10871,8 +10147,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A726"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10886,8 +10161,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A727"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10901,8 +10175,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A728"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10916,8 +10189,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುದ್ದಗುಂಟೆಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A729"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10931,8 +10203,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗಟೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A730"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10946,8 +10217,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A731"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10961,8 +10231,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೈಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A732"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10976,8 +10245,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಕಾಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A733"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10991,8 +10259,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A734"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11006,8 +10273,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A735"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11021,8 +10287,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A736"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11036,8 +10301,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A737"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11051,8 +10315,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A738"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11066,8 +10329,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A739"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11081,8 +10343,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A740"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11096,8 +10357,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A741"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11111,8 +10371,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A742"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11126,8 +10385,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A743"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11141,8 +10399,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A744"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11156,8 +10413,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A745"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11171,8 +10427,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನಸೌಧ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A746"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11186,8 +10441,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A747"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11201,8 +10455,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A748"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11216,8 +10469,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A749"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11231,8 +10483,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವನಾಥಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A750"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11246,8 +10497,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವೇಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A751"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11261,8 +10511,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಯಾಲಿಕಾವಲ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A752"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11276,8 +10525,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A753"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11291,8 +10539,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A754"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11306,8 +10553,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A755"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11321,8 +10567,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A756"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11336,8 +10581,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A757"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11351,8 +10595,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A758"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11366,8 +10609,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A759"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11381,8 +10623,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಆರ್‌ಎಂಸಿ ಯಾರ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A760"
+    "NameKN": "-"
   },
   {
     "Department": "election_ac",
@@ -11396,8 +10637,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಶಿವಣ್ಣ",
-    "cellRef": "A761"
+    "NameKN": "ಬಿ. ಶಿವಣ್ಣ"
   },
   {
     "Department": "election_ac",
@@ -11411,8 +10651,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಟಿಎಂ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ",
-    "cellRef": "A762"
+    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ"
   },
   {
     "Department": "election_ac",
@@ -11426,8 +10665,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A763"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11441,8 +10679,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ",
-    "cellRef": "A764"
+    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
   },
   {
     "Department": "election_ac",
@@ -11456,8 +10693,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A765"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11471,8 +10707,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ ಎಲ್.ಎ",
-    "cellRef": "A766"
+    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ ಎಲ್.ಎ"
   },
   {
     "Department": "election_ac",
@@ -11486,8 +10721,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ",
-    "cellRef": "A767"
+    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ"
   },
   {
     "Department": "election_ac",
@@ -11501,8 +10735,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ",
-    "cellRef": "A768"
+    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -11516,8 +10749,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ. ರಾಮಣ್ಣನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ರಘು",
-    "cellRef": "A769"
+    "NameKN": "ಎಸ್. ರಘು"
   },
   {
     "Department": "election_ac",
@@ -11531,8 +10763,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಜೆಡ್ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್",
-    "cellRef": "A770"
+    "NameKN": "ಬಿ.ಜೆಡ್ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್"
   },
   {
     "Department": "election_ac",
@@ -11546,8 +10777,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "MLA",
-    "NameKN": "",
-    "cellRef": "A771"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11561,8 +10791,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್",
-    "cellRef": "A772"
+    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್"
   },
   {
     "Department": "election_ac",
@@ -11576,8 +10805,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್",
-    "cellRef": "A773"
+    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್"
   },
   {
     "Department": "election_ac",
@@ -11591,8 +10819,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A774"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11606,8 +10833,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಮುನಿರಾಜು",
-    "cellRef": "A775"
+    "NameKN": "ಎಸ್. ಮುನಿರಾಜು"
   },
   {
     "Department": "election_ac",
@@ -11621,8 +10847,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ. ಎಚ್. ಮುನಿಯಪ್ಪ",
-    "cellRef": "A776"
+    "NameKN": "ಕೆ. ಎಚ್. ಮುನಿಯಪ್ಪ"
   },
   {
     "Department": "election_ac",
@@ -11636,8 +10861,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್",
-    "cellRef": "A777"
+    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್"
   },
   {
     "Department": "election_ac",
@@ -11651,8 +10875,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್",
-    "cellRef": "A778"
+    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್"
   },
   {
     "Department": "election_ac",
@@ -11666,8 +10889,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A779"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11681,8 +10903,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ",
-    "cellRef": "A780"
+    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ"
   },
   {
     "Department": "election_ac",
@@ -11696,8 +10917,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A781"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11711,8 +10931,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A782"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11726,8 +10945,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎಸ್. ಸುರೇಶ ಬೈರತಿ",
-    "cellRef": "A783"
+    "NameKN": "ಬಿ.ಎಸ್. ಸುರೇಶ ಬೈರತಿ"
   },
   {
     "Department": "election_ac",
@@ -11741,8 +10959,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ",
-    "cellRef": "A784"
+    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -11756,8 +10973,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸಿ.ಕೆ. ರಾಮ ಮೂರ್ತಿ",
-    "cellRef": "A785"
+    "NameKN": "ಸಿ.ಕೆ. ರಾಮ ಮೂರ್ತಿ"
   },
   {
     "Department": "election_ac",
@@ -11771,8 +10987,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎ. ಬಸವರಾಜ",
-    "cellRef": "A786"
+    "NameKN": "ಬಿ.ಎ. ಬಸವರಾಜ"
   },
   {
     "Department": "election_ac",
@@ -11786,8 +11001,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಡಿ.ಕೆ. ಶಿವಕುಮಾರ್",
-    "cellRef": "A787"
+    "NameKN": "ಡಿ.ಕೆ. ಶಿವಕುಮಾರ್"
   },
   {
     "Department": "election_ac",
@@ -11801,8 +11015,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A788"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11816,8 +11029,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಚಿನ್ನದ ಕ್ಷೇತ್ರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A789"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11831,8 +11043,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A790"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11846,8 +11057,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಜಿ. ಪರಮೇಶ್ವರ",
-    "cellRef": "A791"
+    "NameKN": "ಜಿ. ಪರಮೇಶ್ವರ"
   },
   {
     "Department": "election_ac",
@@ -11861,8 +11071,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A792"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11876,8 +11085,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A793"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11891,8 +11099,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A794"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11906,8 +11113,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಚ್.ಸಿ ಬಾಲಕೃಷ್ಣ",
-    "cellRef": "A795"
+    "NameKN": "ಎಚ್.ಸಿ ಬಾಲಕೃಷ್ಣ"
   },
   {
     "Department": "election_ac",
@@ -11921,8 +11127,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮಂಜುಳಾ ಎಸ್",
-    "cellRef": "A796"
+    "NameKN": "ಮಂಜುಳಾ ಎಸ್"
   },
   {
     "Department": "election_ac",
@@ -11936,8 +11141,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ",
-    "cellRef": "A797"
+    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ"
   },
   {
     "Department": "election_ac",
@@ -11951,8 +11155,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A798"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11966,8 +11169,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "MLA",
-    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿ.ಎನ್",
-    "cellRef": "A799"
+    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿ.ಎನ್"
   },
   {
     "Department": "election_ac",
@@ -11981,8 +11183,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಎನ್. ನಂಜೇಗೌಡ",
-    "cellRef": "A800"
+    "NameKN": "ಕೆ.ಎನ್. ನಂಜೇಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -11996,8 +11197,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A801"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12011,8 +11211,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A802"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12026,8 +11225,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A803"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12041,8 +11239,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್",
-    "cellRef": "A804"
+    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್"
   },
   {
     "Department": "election_ac",
@@ -12056,8 +11253,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪದ್ಮನಾಬನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಆರ್. ಅಶೋಕ",
-    "cellRef": "A805"
+    "NameKN": "ಆರ್. ಅಶೋಕ"
   },
   {
     "Department": "election_ac",
@@ -12071,8 +11267,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A806"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12086,8 +11281,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎ.ಸಿ. ಶ್ರೀನಿವಾಸ",
-    "cellRef": "A807"
+    "NameKN": "ಎ.ಸಿ. ಶ್ರೀನಿವಾಸ"
   },
   {
     "Department": "election_ac",
@@ -12101,8 +11295,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಸುರೇಶ್ ಕುಮಾರ್",
-    "cellRef": "A808"
+    "NameKN": "ಎಸ್. ಸುರೇಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "election_ac",
@@ -12116,8 +11309,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮುನಿರತ್ನ",
-    "cellRef": "A809"
+    "NameKN": "ಮುನಿರತ್ನ"
   },
   {
     "Department": "election_ac",
@@ -12131,8 +11323,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "H.A. ಇಕ್ಬಾಲ್ ಹುಸೇನ್",
-    "cellRef": "A810"
+    "NameKN": "H.A. ಇಕ್ಬಾಲ್ ಹುಸೇನ್"
   },
   {
     "Department": "election_ac",
@@ -12146,8 +11337,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ವಜ್ಞನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಜೆ. ಜಾರ್ಜ್",
-    "cellRef": "A811"
+    "NameKN": "ಕೆ.ಜೆ. ಜಾರ್ಜ್"
   },
   {
     "Department": "election_ac",
@@ -12161,8 +11351,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎನ್.ಎ. ಹರಿಸ್",
-    "cellRef": "A812"
+    "NameKN": "ಎನ್.ಎ. ಹರಿಸ್"
   },
   {
     "Department": "election_ac",
@@ -12176,8 +11365,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್",
-    "cellRef": "A813"
+    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್"
   },
   {
     "Department": "election_ac",
@@ -12191,8 +11379,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎನ್. ರವಿಕುಮಾರ್",
-    "cellRef": "A814"
+    "NameKN": "ಬಿ.ಎನ್. ರವಿಕುಮಾರ್"
   },
   {
     "Department": "election_ac",
@@ -12206,8 +11393,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A815"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12221,8 +11407,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A816"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12236,8 +11421,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A817"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12251,8 +11435,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A818"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12266,8 +11449,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಸುರೇಶ್ ಗೌಡ",
-    "cellRef": "A819"
+    "NameKN": "ಬಿ. ಸುರೇಶ್ ಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -12281,8 +11463,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ",
-    "cellRef": "A820"
+    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
   },
   {
     "Department": "election_ac",
@@ -12296,8 +11477,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಆರ್ ವಿಶ್ವನಾಥ್",
-    "cellRef": "A821"
+    "NameKN": "ಎಸ್.ಆರ್ ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "election_ac",
@@ -12311,8 +11491,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಟಿ. ಸೋಮಶೇಖರ್",
-    "cellRef": "A822"
+    "NameKN": "ಎಸ್.ಟಿ. ಸೋಮಶೇಖರ್"
   },
   {
     "Department": "election_pc",
@@ -12326,8 +11505,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಕೇಂದ್ರ",
     "DesignationKN": "MP",
-    "NameKN": "ಪಿ.ಸಿ. ಮೋಹನ್",
-    "cellRef": "A823"
+    "NameKN": "ಪಿ.ಸಿ. ಮೋಹನ್"
   },
   {
     "Department": "election_pc",
@@ -12341,8 +11519,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
-    "cellRef": "A824"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
   },
   {
     "Department": "election_pc",
@@ -12356,8 +11533,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಸಿ. ಎನ್. ಮಂಜುನಾಥ್",
-    "cellRef": "A825"
+    "NameKN": "ಸಿ. ಎನ್. ಮಂಜುನಾಥ್"
   },
   {
     "Department": "election_pc",
@@ -12371,8 +11547,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MP",
-    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ",
-    "cellRef": "A826"
+    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ"
   },
   {
     "Department": "election_pc",
@@ -12386,8 +11561,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A827"
+    "NameKN": ""
   },
   {
     "Department": "election_pc",
@@ -12401,8 +11575,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MP",
-    "NameKN": "ಕೆ. ಸುಧಾಕರ್",
-    "cellRef": "A828"
+    "NameKN": "ಕೆ. ಸುಧಾಕರ್"
   },
   {
     "Department": "election_pc",
@@ -12416,8 +11589,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A829"
+    "NameKN": ""
   },
   {
     "Department": "election_pc",
@@ -12431,8 +11603,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "MP",
-    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ. ಬಾಬು",
-    "cellRef": "A830"
+    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ. ಬಾಬು"
   },
   {
     "Department": "election_pc",
@@ -12446,8 +11617,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A831"
+    "NameKN": ""
   },
   {
     "Department": "election_pc",
@@ -12461,8 +11631,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "MP",
-    "NameKN": "ವಿ. ಸೋಮಣ್ಣ",
-    "cellRef": "A832"
+    "NameKN": "ವಿ. ಸೋಮಣ್ಣ"
   },
   {
     "Department": "Pin Code",
@@ -12476,8 +11645,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಚಿತ್ನಗರ - 560107",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A833"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12491,8 +11659,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ - 560030",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A834"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12506,8 +11673,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಎಫ್ ಸ್ಟೇಷನ್ ಯಲಹಂಕ - 560063",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A835"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12521,8 +11687,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ರಾಮ್ - 560007",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A836"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12536,8 +11701,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ - 562106",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A837"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12551,8 +11715,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಂಜನಾಪುರ - 560108",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A838"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12566,8 +11729,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಪಿಎಂಸಿ ಯಾರ್ಡ್ ಬಂಗಾರಪೇಟೆ - 563114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A839"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12581,8 +11743,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ - 562107",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A840"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12596,8 +11757,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಸ್ಟಿನ್ ಟೌನ್ - 560047",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A841"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12611,8 +11771,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವತಿ ಅಂಚೆ ಕಛೇರಿ - 562164",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A842"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12626,8 +11785,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಬೆಂಗಳೂರು) - 562149",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A843"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12641,8 +11799,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಕೃಷ್ಣಗಿರಿ) - 635103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A844"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12656,8 +11813,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ - 560050",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A845"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12671,8 +11827,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು GPO - 560001",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A846"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12686,8 +11841,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ - 560300",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A847"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12701,8 +11855,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ವಿಶ್ವವಿದ್ಯಾಲಯ - 560056",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A848"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12716,8 +11869,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೇರುಘಟ್ಟ - 560083",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A849"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12731,8 +11883,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ - 560004",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A850"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12746,8 +11897,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಟ್ಲಹಳ್ಳಿ - 563123",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A851"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12761,8 +11911,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು - 560114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A852"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12776,8 +11925,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳತ್ತೂರು - 635124",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A853"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12791,8 +11939,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು - 560103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A854"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12806,8 +11953,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆನ್ಸನ್ ಟೌನ್ - 560046",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A855"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12821,8 +11967,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆರಿಗೈ - 635105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A856"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12836,8 +11981,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟಹಲಸೂರು - 562157",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A857"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12851,8 +11995,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇವೂರು (ರಾಮನಗರ) - 562108",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A858"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12866,8 +12009,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತನಗರ - 563115",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A859"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12881,8 +12023,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ - 562109",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A860"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12896,8 +12037,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೋಲಾರೆ - 560116",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A861"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12911,8 +12051,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ (ಬೆಂಗಳೂರು) - 560068",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A862"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12926,8 +12065,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮಸಂದ್ರ ಇಂಡಸ್ಟ್ರಿಯಲ್ ಎಸ್ಟೇಟ್ - 560099",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A863"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12941,8 +12079,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೂದಿಕೋಟೆ - 563147",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A864"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12956,8 +12093,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬುರುಡುಗುಂಟೆ - 563159",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A865"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12971,8 +12107,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಮೆಲರಾಮ್ - 560035",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A866"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12986,8 +12121,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ರೀಫ್ಸ್ - 563117",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A867"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13001,8 +12135,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ (ಬೆಂಗಳೂರು) - 560018",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A868"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13016,8 +12149,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ - 560081",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A869"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13031,8 +12163,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ - 562160",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A870"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13046,8 +12177,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ - 562101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A871"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13061,8 +12191,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ - 560053",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A872"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13076,8 +12205,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ - 560090",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A873"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13091,8 +12219,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಸಂದ್ರ - 560061",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A874"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13106,8 +12233,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಮಾರುಕಟ್ಟೆ - 563125",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A875"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13121,8 +12247,7 @@
     "Unnamed: 3": "",
     "AreaKN": "CPC ಆದಾಯ ತೆರಿಗೆ ಇಲಾಖೆ - 560500",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A876"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13136,8 +12261,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿವಿ ರಾಮನ್ ನಗರ - 560093",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A877"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13151,8 +12275,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಲಸನೂರು - 563126",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A878"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13166,8 +12289,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇಶಿಹಳ್ಳಿ ಬಂಗಾರಪೇಟೆ - 563162",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A879"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13181,8 +12303,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ - 562110",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A880"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13196,8 +12317,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸ್ಪೇಟ್ - 562111",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A881"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13211,8 +12331,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಬಜಾರ್ - 561203",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A882"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13226,8 +12345,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ - 561204",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A883"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13241,8 +12359,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡದುನ್ನಸಂದ್ರ - 560117",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A884"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13256,8 +12373,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A885"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13271,8 +12387,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A886"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13286,8 +12401,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು - 560071",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A887"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13301,8 +12415,7 @@
     "Unnamed: 3": "",
     "AreaKN": "EPIP - 560066",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A888"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13316,8 +12429,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಸರ್ ಟೌನ್ - 560005",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A889"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13331,8 +12443,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗವಿಪುರಂ ವಿಸ್ತರಣೆ - 560019",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A890"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13346,8 +12457,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಯತ್ರಿನಗರ - 560021",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A891"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13361,8 +12471,7 @@
     "Unnamed: 3": "",
     "AreaKN": "GCEC ರಾಮನಗರ - 562159",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A892"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13376,8 +12485,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ (ಬೆಂಗಳೂರು) - 560085",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A893"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13391,8 +12499,7 @@
     "Unnamed: 3": "",
     "AreaKN": "GKVK - 560065",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A894"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13406,8 +12513,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ಎಲೆಕ್ಟ್ರಿಕ್ ಫ್ಯಾಕ್ಟರಿ - 560026",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A895"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13421,8 +12527,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ರೇಷ್ಮೆ ಫಾರ್ಮ್ - 562161",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A896"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13436,8 +12541,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಿಪಲ್ಲಿ - 563161",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A897"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13451,8 +12555,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೂಳೂರು - 572118",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A898"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13466,8 +12569,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HA ಫಾರ್ಮ್ - 560024",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A899"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13481,8 +12583,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL II ಹಂತ - 560008",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A900"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13496,8 +12597,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಂಪಿನಗರ - 560104",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A901"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13511,8 +12611,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ - 562112",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A902"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13526,8 +12625,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು - 572120",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A903"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13541,8 +12639,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೇರೋಹಳ್ಳಿ - 560091",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A904"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13556,8 +12653,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ - 560088",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A905"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13571,8 +12667,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸ್ಸರಘಟ್ಟ ಕೆರೆ - 560089",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A906"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13586,8 +12681,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಹಳ್ಳಿ SO - 572168",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A907"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13601,8 +12695,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HKP ರಸ್ತೆ - 560051",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A908"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13616,8 +12709,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳವನಹಳ್ಳಿ - 572121",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A909"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13631,8 +12723,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಗನೂರು - 562138",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A910"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13646,8 +12737,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನುಡಿಕೆ - 572122",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A911"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13661,8 +12751,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊರಮಾವು - 560113",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A912"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13676,8 +12765,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ - 562114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A913"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13691,8 +12779,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು - 561210",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A914"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13706,8 +12793,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಗೋಶಾಲೆ - 635110",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A915"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13721,8 +12807,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಇಂಡಲ್. ಸಂಕೀರ್ಣ - 635126",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A916"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13736,8 +12821,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್ - 560102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A917"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13751,8 +12835,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರು ದುರ್ಗ - 572123",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A918"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13766,8 +12849,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ (ಬೆಂಗಳೂರು) - 560038",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A919"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13781,8 +12863,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ - 560013",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A920"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13796,8 +12877,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪೂರ್ವ - 560014",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A921"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13811,8 +12891,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಶ್ಚಿಮ - 560015",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A922"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13826,8 +12905,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ - 560041",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A923"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13841,8 +12919,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪೂರ್ವ - 560069",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A924"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13856,8 +12933,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಎಕ್ಸ್ಟೆನ್ ತುಮಕೂರು - 572102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A925"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13871,8 +12947,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಶ್ಚಿಮ - 560070",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A926"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13886,8 +12961,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಂಗಾರ್ III ಬ್ಲಾಕ್ - 560011",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A927"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13901,8 +12975,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ - 560105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A928"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13916,8 +12989,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ - 560078",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A929"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13931,8 +13003,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ವಿಸ್ತರಣೆ ಸೋ - 560067",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A930"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13946,8 +13017,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೈವಾರ - 563128",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A931"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13961,8 +13031,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಯಾಣನಗರ - 560043",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A932"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13976,8 +13045,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ - 563129",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A933"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13991,8 +13059,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ - 562117",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A934"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14006,8 +13073,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ನಮಂಗಲ - 560115",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A935"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14021,8 +13087,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪನಹಳ್ಳಿ - 572126",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A936"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14036,8 +13101,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ - 560060",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A937"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14051,8 +13115,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ರಸ್ತೆ - 560009",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A938"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14066,8 +13129,7 @@
     "Unnamed: 3": "",
     "AreaKN": "KHB ಕಾಲೋನಿ - 560079",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A939"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14081,8 +13143,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡೇಹಳ್ಳಿ - 560112",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A940"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14096,8 +13157,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ - 562119",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A941"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14111,8 +13171,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ - 563101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A942"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14126,8 +13185,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ವಿಸ್ತರಣೆ - 563102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A943"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14141,8 +13199,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರ (ತುಮಕೂರು) - 572128",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A944"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14156,8 +13213,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ I ಬ್ಲಾಕ್ - 560034",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A945"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14171,8 +13227,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ VI ಬ್ಲಾಕ್ - 560095",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A946"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14186,8 +13241,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ - 572129",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A947"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14201,8 +13255,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು - 560077",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A948"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14216,8 +13269,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ - 560036",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A949"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14231,8 +13283,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ ಆರ್ ಎಸ್ - 560016",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A950"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14246,8 +13297,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು - 561101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A951"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14261,8 +13311,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ - 560111",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A952"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14276,8 +13325,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೋಡು - 560074",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A953"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14291,8 +13339,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಪ್ಪಂ - 517425",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A954"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14306,8 +13353,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುವೆಂಪುನಗರ - 572103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A955"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14321,8 +13367,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸಂದ್ರ - 572104",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A956"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14336,8 +13381,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ - 562162",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A957"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14351,8 +13395,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ - 562120",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A958"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14366,8 +13409,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ - 560023",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A959"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14381,8 +13423,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ - 560048",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A960"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14396,8 +13437,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ - 560003",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A961"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14411,8 +13451,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು - 563130",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A962"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14426,8 +13465,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ರೈಲು ನಿಲ್ದಾಣ - 563160",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A963"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14441,8 +13479,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೆನಹಳ್ಳಿ - 561211",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A964"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14456,8 +13493,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳವಾಡಿ - 562121",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A965"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14471,8 +13507,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳೂರು ಎಸ್‌ಒ - 572105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A966"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14486,8 +13521,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಸೇವಾನಗರ - 560033",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A967"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14501,8 +13535,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ - 563139",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A968"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14516,8 +13549,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಠಗೊಂಡಪಲ್ಲಿ - 635114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A969"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14531,8 +13563,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಳೆಕೋಟೆ - 561205",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A970"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14546,8 +13577,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೇಲೂರು (ಕೋಲಾರ) - 562102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A971"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14561,8 +13591,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ - 560076",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A972"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14576,8 +13605,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿಲ್ಕ್ ಕಾಲೋನಿ - 560055",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A973"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14591,8 +13619,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MSRIT - 560054",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A974"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14606,8 +13633,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರುಗಮಲೆ - 563146",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A975"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14621,8 +13647,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮ್ಯೂಸಿಯಂ ರಸ್ತೆ - 560025",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A976"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14636,8 +13661,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇನಹಳ್ಳಿ - 562163",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A977"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14651,8 +13675,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ - 560072",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A978"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14666,8 +13689,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಸಂದ್ರ (ಬೆಂಗಳೂರು) - 560073",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A979"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14681,8 +13703,7 @@
     "Unnamed: 3": "",
     "AreaKN": "NAL - 560017",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A980"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14696,8 +13717,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ - 562122",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A981"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14711,8 +13731,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ (ಕೋಲಾರ) - 562103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A982"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14726,8 +13745,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಣನ್ದಿನಿ ಳಯೋಉತ್ - ೫೬೦೦೯೬",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A983"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14741,8 +13759,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ - 563133",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A984"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14756,8 +13773,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಯಂಡಹಳ್ಳಿ - 560039",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A985"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14771,8 +13787,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ - 562123",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A986"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14786,8 +13801,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ತಿಪ್ಪಸಂದ್ರ - 560075",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A987"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14801,8 +13815,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಡಘಟ್ಟ - 571433",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A988"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14816,8 +13829,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ ವಿಸ್ತರಣೆ - 572106",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A989"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14831,8 +13843,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಮ್ - 563120",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A990"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14846,8 +13857,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ - 560057",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A991"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14861,8 +13871,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಸಣ್ಣ ಕೈಗಾರಿಕೆಗಳು - 560058",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A992"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14876,8 +13885,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೆರೇಸಂದ್ರ - 562104",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A993"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14891,8 +13899,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ - 560010",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A994"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14906,8 +13913,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ - 560098",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A995"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14921,8 +13927,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಮೇಶ್‌ನಗರ - 560037",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A996"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14936,8 +13941,7 @@
     "Unnamed: 3": "",
     "AreaKN": "RMV ವಿಸ್ತರಣೆ II ಹಂತ - 560094",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A997"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14951,8 +13955,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ - 560032",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A998"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14966,8 +13969,7 @@
     "Unnamed: 3": "",
     "AreaKN": "RV ನಿಕೇತನ್ - 560059",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A999"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14981,8 +13983,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ - 560080",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1000"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14996,8 +13997,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರನಗರ PO - 560092",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1001"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15011,8 +14011,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ - 562125",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1002"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15026,8 +14025,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ಸಂಸ್ಥೆ - 560012",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1003"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15041,8 +14039,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ - 560020",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1004"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15056,8 +14053,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ - 560027",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1005"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15071,8 +14067,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಗಟ್ಟಾ ಬಜಾರ್ - 562105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1006"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15086,8 +14081,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವನ್ ಚೆಟ್ಟಿ ಗಾರ್ಡನ್ಸ್ - 560042",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1007"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15101,8 +14095,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲೂರು - 562127",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1008"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15116,8 +14109,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀ ಜಯಚಾಮರಾಜೇಂದ್ರ ರಸ್ತೆ - 560002",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1009"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15131,8 +14123,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ - 563135",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1010"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15146,8 +14137,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಂಟ್ ಥಾಮಸ್ ಟೌನ್ - 560084",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1011"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15161,8 +14151,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗ್ಗನಹಳ್ಳಿ - 562128",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1012"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15176,8 +14165,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲೇಬೆಲೆ - 562129",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1013"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15191,8 +14179,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಮಾಕಾ - 563103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1014"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15206,8 +14193,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ - 560029",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1015"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15221,8 +14207,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ (ಬೆಂಗಳೂರು) - 562130",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1016"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15236,8 +14221,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ - 563137",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1017"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15251,8 +14235,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ - 560109",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1018"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15266,8 +14249,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಥಾಲಿ - 635118",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1019"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15281,8 +14263,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪ್ಪಸಂದ್ರ - 562131",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1020"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15296,8 +14277,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೊಂಡೇಭಾವಿ - 561213",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1021"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15311,8 +14291,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೋವಿನಕೆರೆ - 572138",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1022"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15326,8 +14305,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರಬೇತಿ ಕಮಾಂಡ್ IAF - 560006",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1023"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15341,8 +14319,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು - 572101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1024"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15356,8 +14333,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು - 562132",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1025"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15371,8 +14347,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉದಯಪುರ - 560082",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1026"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15386,8 +14361,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಲ್ಲಾಳು ಉಪನಗರ - 560110",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1027"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15401,8 +14375,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಡಿಗೆರೆ - 572140",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1028"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15416,8 +14389,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು - 560087",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1029"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15431,8 +14403,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತ ನಗರ - 560052",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1030"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15446,8 +14417,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರೇಗೌಡನದೊಡ್ಡಿ - 561201",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1031"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15461,8 +14431,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ - 563157",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1032"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15476,8 +14445,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಂಕಟೇಶಪುರ - 560045",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1033"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15491,8 +14459,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಪ್ಪನಪಲ್ಲಿ - 635121",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1034"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15506,8 +14473,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ - 560097",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1035"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15521,8 +14487,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ (ಬೆಂಗಳೂರು) - 560040",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1036"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15536,8 +14501,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ - 562135",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1037"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15551,8 +14515,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ಯಾನಗರ - 560049",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1038"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15566,8 +14529,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಸ್ಟ್ ಆಫ್ ಕಾರ್ಡ್ ರೋಡ್ II ಹಂತ - 560086",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1039"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15581,8 +14543,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಪ್ರೋ ಲಿಮಿಟೆಡ್ - 560100",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1040"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15596,8 +14557,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್ - 560064",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1041"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15611,8 +14571,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಬಜಾರ್ - 560022",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1042"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15626,8 +14585,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1043"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15641,8 +14599,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ.",
-    "cellRef": "A1044"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ."
   },
   {
     "Department": "stamps_dro",
@@ -15656,8 +14613,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ. ಬೆಳಗಲಿ",
-    "cellRef": "A1045"
+    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ. ಬೆಳಗಲಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15671,8 +14627,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1046"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15686,8 +14641,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1047"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15701,8 +14655,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1048"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15716,8 +14669,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1049"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15731,8 +14683,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1050"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15746,8 +14697,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ",
-    "cellRef": "A1051"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15761,8 +14711,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1052"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15776,8 +14725,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1053"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15791,8 +14739,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1054"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15806,8 +14753,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1055"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15821,8 +14767,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1056"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15836,8 +14781,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎ.ಎನ್. ಭಾರತಿ",
-    "cellRef": "A1057"
+    "NameKN": "ಎ.ಎನ್. ಭಾರತಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15851,8 +14795,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1058"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15866,8 +14809,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1059"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15881,8 +14823,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ.ಎಚ್. ಶಂಕರೇಗೌಡ",
-    "cellRef": "A1060"
+    "NameKN": "ಬಿ.ಎಚ್. ಶಂಕರೇಗೌಡ"
   },
   {
     "Department": "stamps_dro",
@@ -15896,8 +14837,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಬುರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1061"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15911,8 +14851,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1062"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15926,8 +14865,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಗು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1063"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15941,8 +14879,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎನ್. ಶ್ರೀನಿಧಿ",
-    "cellRef": "A1064"
+    "NameKN": "ಎನ್. ಶ್ರೀನಿಧಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15956,8 +14893,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1065"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15971,8 +14907,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1066"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15986,8 +14921,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1067"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16001,8 +14935,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1068"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16016,8 +14949,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1069"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16031,8 +14963,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್",
-    "cellRef": "A1070"
+    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್"
   },
   {
     "Department": "stamps_dro",
@@ -16046,8 +14977,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಂ. ಶ್ರೀದೇವಿ",
-    "cellRef": "A1071"
+    "NameKN": "ಎಂ. ಶ್ರೀದೇವಿ"
   },
   {
     "Department": "stamps_dro",
@@ -16061,8 +14991,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1072"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16076,8 +15005,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಸ್.ಬಿ. ದವಳೇಶ್ವರ",
-    "cellRef": "A1073"
+    "NameKN": "ಎಸ್.ಬಿ. ದವಳೇಶ್ವರ"
   },
   {
     "Department": "stamps_dro",
@@ -16091,8 +15019,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ. ಶ್ರೀಕಾಂತ್",
-    "cellRef": "A1074"
+    "NameKN": "ಬಿ. ಶ್ರೀಕಾಂತ್"
   },
   {
     "Department": "stamps_dro",
@@ -16106,8 +15033,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1075"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16121,8 +15047,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1076"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16136,8 +15061,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಫಜಲಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1077"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16151,8 +15075,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಳಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1078"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16166,8 +15089,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1079"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16181,8 +15103,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ",
-    "cellRef": "A1080"
+    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16196,8 +15117,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಣ್ಣಿಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1081"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16211,8 +15131,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಕಲಗೂಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1082"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16226,8 +15145,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಸೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1083"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16241,8 +15159,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಥಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1084"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16256,8 +15173,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ",
-    "cellRef": "A1085"
+    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16271,8 +15187,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಔರಾದ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1086"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16286,8 +15201,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾದಾಮಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1087"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16301,8 +15215,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1088"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16316,8 +15229,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1089"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16331,8 +15243,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಲಹೊಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1090"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16346,8 +15257,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1091"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16361,8 +15271,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್",
-    "cellRef": "A1092"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್"
   },
   {
     "Department": "stamps_sro",
@@ -16376,8 +15285,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ",
-    "cellRef": "A1093"
+    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16391,8 +15299,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1094"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16406,8 +15313,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1095"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16421,8 +15327,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಾವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1096"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16436,8 +15341,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1097"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16451,8 +15355,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1098"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16466,8 +15369,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಟವಾಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1099"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16481,8 +15383,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವಕಲ್ಯಾಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1100"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16496,8 +15397,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಬಾಗೇವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1101"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16511,8 +15411,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎ. ರಾಘವೇಂದ್ರ",
-    "cellRef": "A1102"
+    "NameKN": "ಎ. ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "stamps_sro",
@@ -16526,8 +15425,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್. ಕಟ್ಟಿಮನಿ",
-    "cellRef": "A1103"
+    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್. ಕಟ್ಟಿಮನಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16541,8 +15439,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1104"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16556,8 +15453,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1105"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16571,8 +15467,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1106"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16586,8 +15481,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ತಂಗಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1107"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16601,8 +15495,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1108"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16616,8 +15509,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟದಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1109"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16631,8 +15523,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭದ್ರಾವತಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1110"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16646,8 +15537,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1111"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16661,8 +15551,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಟ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1112"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16676,8 +15565,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1113"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16691,8 +15579,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿದರಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್",
-    "cellRef": "A1114"
+    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -16706,8 +15593,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1115"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16721,8 +15607,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಳಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1116"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16736,8 +15621,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಸನ್ನ ಜಿ",
-    "cellRef": "A1117"
+    "NameKN": "ಪ್ರಸನ್ನ ಜಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16751,8 +15635,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ರಹ್ಮಾವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1118"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16766,8 +15649,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM ಲೇಔಟ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಾವ್ಯ ಕೆ. ಕೋರ",
-    "cellRef": "A1119"
+    "NameKN": "ಕಾವ್ಯ ಕೆ. ಕೋರ"
   },
   {
     "Department": "stamps_sro",
@@ -16781,8 +15663,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1120"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16796,8 +15677,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ.ವಿ. ರವಿಕುಮಾರ್",
-    "cellRef": "A1121"
+    "NameKN": "ಕೆ.ವಿ. ರವಿಕುಮಾರ್"
   },
   {
     "Department": "stamps_sro",
@@ -16811,8 +15691,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1122"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16826,8 +15705,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1123"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16841,8 +15719,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಉಮಾದೇವಿ ಎ.ಎಸ್",
-    "cellRef": "A1124"
+    "NameKN": "ಉಮಾದೇವಿ ಎ.ಎಸ್"
   },
   {
     "Department": "stamps_sro",
@@ -16856,8 +15733,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1125"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16871,8 +15747,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1126"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -16886,8 +15761,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1127"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16901,8 +15775,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1128"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -16916,8 +15789,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1129"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16931,8 +15803,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1130"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16946,8 +15817,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕೋಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1131"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16961,8 +15831,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂಚೋಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1132"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16976,8 +15845,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1133"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16991,8 +15859,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1134"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17006,8 +15873,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ತಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1135"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17021,8 +15887,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸನಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ",
-    "cellRef": "A1136"
+    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17036,8 +15901,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1137"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17051,8 +15915,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1138"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17066,8 +15929,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್",
-    "cellRef": "A1139"
+    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್"
   },
   {
     "Department": "stamps_sro",
@@ -17081,8 +15943,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1140"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17096,8 +15957,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಎಚ್.ಎಸ್",
-    "cellRef": "A1141"
+    "NameKN": "ಸತೀಶ್ ಎಚ್.ಎಸ್"
   },
   {
     "Department": "stamps_sro",
@@ -17111,8 +15971,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1142"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17126,8 +15985,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಜೇಂದ್ರಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1143"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17141,8 +15999,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ",
-    "cellRef": "A1144"
+    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17156,8 +16013,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ಕೆ. ಶಾಂತಮೂರ್ತಿ",
-    "cellRef": "A1145"
+    "NameKN": "ಎಂ.ಕೆ. ಶಾಂತಮೂರ್ತಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17171,8 +16027,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾವತಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1146"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17186,8 +16041,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1147"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17201,8 +16055,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋಕಾಕ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1148"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17216,8 +16069,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1149"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17231,8 +16083,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1150"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17246,8 +16097,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಬರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1151"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17261,8 +16111,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಳೇದಗುಡ್ಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1152"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17276,8 +16125,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಂಡ್ಲುಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1153"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17291,8 +16139,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಗರಿಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1154"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17306,8 +16153,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಳಿಯಾಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1155"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17321,8 +16167,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್",
-    "cellRef": "A1156"
+    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್"
   },
   {
     "Department": "stamps_sro",
@@ -17336,8 +16181,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾನಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1157"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17351,8 +16195,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1158"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17366,8 +16209,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1159"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17381,8 +16223,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಿಹರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1160"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17396,8 +16237,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1161"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17411,8 +16251,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1162"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17426,8 +16265,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚೈತ್ರಾ ಬಿ.ಎ",
-    "cellRef": "A1163"
+    "NameKN": "ಚೈತ್ರಾ ಬಿ.ಎ"
   },
   {
     "Department": "stamps_sro",
@@ -17441,8 +16279,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗಡದೇವನ ಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1164"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17456,8 +16293,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್",
-    "cellRef": "A1165"
+    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್"
   },
   {
     "Department": "stamps_sro",
@@ -17471,8 +16307,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1166"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17486,8 +16321,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರಿಯೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1167"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17501,8 +16335,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳಲ್ಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1168"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17516,8 +16349,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳೆನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1169"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17531,8 +16363,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1170"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17546,8 +16377,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1171"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17561,8 +16391,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1172"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17576,8 +16405,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿ. ಗೀತಾ",
-    "cellRef": "A1173"
+    "NameKN": "ವಿ. ಗೀತಾ"
   },
   {
     "Department": "stamps_sro",
@@ -17591,8 +16419,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1174"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17606,8 +16433,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1175"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17621,8 +16447,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ ಉತ್ತರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1176"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17636,8 +16461,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ (ದಕ್ಷಿಣ)",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1177"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17651,8 +16475,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಕ್ಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1178"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17666,8 +16489,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1179"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17681,8 +16503,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಮ್ನಾಬಾದ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1180"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17696,8 +16517,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುನಗುಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1181"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17711,8 +16531,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1182"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17726,8 +16545,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1183"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17741,8 +16559,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂವಿನ ಹಡಗಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1184"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17756,8 +16573,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಳಕಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1185"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17771,8 +16587,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1186"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17786,8 +16601,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಿ.ಜೆ. ಪ್ರಭಾಕರ್",
-    "cellRef": "A1187"
+    "NameKN": "ಸಿ.ಜೆ. ಪ್ರಭಾಕರ್"
   },
   {
     "Department": "stamps_sro",
@@ -17801,8 +16615,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1188"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17816,8 +16629,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಸ್. ಎಸ್. ಸ್ವರ್ಣಲತಾ",
-    "cellRef": "A1189"
+    "NameKN": "ಎಸ್. ಎಸ್. ಸ್ವರ್ಣಲತಾ"
   },
   {
     "Department": "stamps_sro",
@@ -17831,8 +16643,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಮಖಂಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1190"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17846,8 +16657,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಬಿ. ಗುರು ರಾಘವೇಂದ್ರ",
-    "cellRef": "A1191"
+    "NameKN": "ಬಿ. ಗುರು ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "stamps_sro",
@@ -17861,8 +16671,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೇವರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1192"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17876,8 +16685,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಜಲಿ ಸಿ",
-    "cellRef": "A1193"
+    "NameKN": "ಅಂಜಲಿ ಸಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17891,8 +16699,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ. ಆರ್. ದೇವರಾಜು",
-    "cellRef": "A1194"
+    "NameKN": "ಕೆ. ಆರ್. ದೇವರಾಜು"
   },
   {
     "Department": "stamps_sro",
@@ -17906,8 +16713,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1195"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17921,8 +16727,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1196"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17936,8 +16741,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ",
-    "cellRef": "A1197"
+    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17951,8 +16755,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಡೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1198"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17966,8 +16769,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲಘಟಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1199"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17981,8 +16783,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಂಪ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1200"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17996,8 +16797,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1201"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18011,8 +16811,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರಟಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1202"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18026,8 +16825,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1203"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18041,8 +16839,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1204"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18056,8 +16853,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವೈ.ಎಚ್. ವೆಂಕಟೇಶ್",
-    "cellRef": "A1205"
+    "NameKN": "ವೈ.ಎಚ್. ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -18071,8 +16867,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1206"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18086,8 +16881,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಖಾನಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1207"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18101,8 +16895,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1208"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18116,8 +16909,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1209"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18131,8 +16923,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1210"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18146,8 +16937,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1211"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18161,8 +16951,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1212"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18176,8 +16965,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1213"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18191,8 +16979,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಆರ್. ರಾಮಪ್ರಸಾದ್",
-    "cellRef": "A1214"
+    "NameKN": "ಆರ್. ರಾಮಪ್ರಸಾದ್"
   },
   {
     "Department": "stamps_sro",
@@ -18206,8 +16993,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೇರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1215"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18221,8 +17007,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೂಡ್ಲಿಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1216"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18236,8 +17021,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಟಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1217"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18251,8 +17035,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಗೋಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1218"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18266,8 +17049,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1219"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18281,8 +17063,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1220"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18296,8 +17077,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುರುಗೋಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1221"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18311,8 +17091,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಷ್ಟಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1222"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18326,8 +17105,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್",
-    "cellRef": "A1223"
+    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್"
   },
   {
     "Department": "stamps_sro",
@@ -18341,8 +17119,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1224"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18356,8 +17133,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಷ್ಮೇಶ್ವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1225"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18371,8 +17147,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗಶುಗರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1226"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18386,8 +17161,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ವಿ. ಸತೀಶ್",
-    "cellRef": "A1227"
+    "NameKN": "ಎಂ.ವಿ. ಸತೀಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -18401,8 +17175,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1228"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18416,8 +17189,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1229"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18431,8 +17203,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1230"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18446,8 +17217,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1231"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18461,8 +17231,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಮ್ಯಾ ಎನ್",
-    "cellRef": "A1232"
+    "NameKN": "ರಮ್ಯಾ ಎನ್"
   },
   {
     "Department": "stamps_sro",
@@ -18476,8 +17245,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1233"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18491,8 +17259,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿಕ್ರಮ್ ಕೆ. ಮಗರ್",
-    "cellRef": "A1234"
+    "NameKN": "ವಿಕ್ರಮ್ ಕೆ. ಮಗರ್"
   },
   {
     "Department": "stamps_sro",
@@ -18506,8 +17273,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1235"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18521,8 +17287,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1236"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18536,8 +17301,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1237"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18551,8 +17315,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ತಾಲೂಕು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1238"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18566,8 +17329,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾನ್ವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1239"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18581,8 +17343,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿರ್ಲೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1240"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18596,8 +17357,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೊಳಕಾಲ್ಮೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1241"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18611,8 +17371,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಬಿದ್ರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1242"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18626,8 +17385,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುದ್ದೇಬಿಹಾಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1243"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18641,8 +17399,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಧೋಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1244"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18656,8 +17413,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಿಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1245"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18671,8 +17427,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1246"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18686,8 +17441,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1247"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18701,8 +17455,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡಗೋಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1248"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18716,8 +17469,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡರಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1249"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18731,8 +17483,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರಗೋಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1250"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18746,8 +17497,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪೂರ್ವ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1251"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18761,8 +17511,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1252"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18776,8 +17525,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪಶ್ಚಿಮ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1253"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18791,8 +17539,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು (ಉತ್ತರ)",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1254"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18806,8 +17553,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1255"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18821,8 +17567,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚಂಪಾ ಎಲ್",
-    "cellRef": "A1256"
+    "NameKN": "ಚಂಪಾ ಎಲ್"
   },
   {
     "Department": "stamps_sro",
@@ -18836,8 +17581,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಜನಗೂಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1257"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18851,8 +17595,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಗುಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1258"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18866,8 +17609,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಿಂಹರಾಜಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1259"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18881,8 +17623,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನವಲಗುಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1260"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18896,8 +17637,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆ.ಪಿ",
-    "cellRef": "A1261"
+    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆ.ಪಿ"
   },
   {
     "Department": "stamps_sro",
@@ -18911,8 +17651,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಪ್ಪಾಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1262"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18926,8 +17665,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನುಗ್ಗೇಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1263"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18941,8 +17679,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾಂಡವಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1264"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18956,8 +17693,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1265"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18971,8 +17707,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕರಿಬಸವ ಗೌಡ",
-    "cellRef": "A1266"
+    "NameKN": "ಕರಿಬಸವ ಗೌಡ"
   },
   {
     "Department": "stamps_sro",
@@ -18986,8 +17721,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿರಿಯಾಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1267"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19001,8 +17735,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೊನ್ನಂಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1268"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19016,8 +17749,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1269"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19031,8 +17763,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಬಾಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1270"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19046,8 +17777,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1271"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19061,8 +17791,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ.",
-    "cellRef": "A1272"
+    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ."
   },
   {
     "Department": "stamps_sro",
@@ -19076,8 +17805,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1273"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -19091,8 +17819,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1274"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19106,8 +17833,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಣಿಬೆನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1275"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19121,8 +17847,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರೋಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1276"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19136,8 +17861,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ. ಗಿರೀಶ್",
-    "cellRef": "A1277"
+    "NameKN": "ಎಂ. ಗಿರೀಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -19151,8 +17875,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಲಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1278"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19166,8 +17889,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1279"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19181,8 +17903,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಕಲೇಶಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1280"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19196,8 +17917,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಡೂರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1281"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19211,8 +17931,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ",
-    "cellRef": "A1282"
+    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ"
   },
   {
     "Department": "stamps_sro",
@@ -19226,8 +17945,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸವಣೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1283"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19241,8 +17959,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಡಮ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1284"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19256,8 +17973,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಹಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1285"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19271,8 +17987,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರನಾರಾಯಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1286"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19286,8 +18001,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಘವೇಂದ್ರ",
-    "cellRef": "A1287"
+    "NameKN": "ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "stamps_sro",
@@ -19301,8 +18015,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1288"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -19316,8 +18029,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಗ್ಗೋನ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1289"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19331,8 +18043,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಕಾರಿಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1290"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19346,8 +18057,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1291"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19361,8 +18071,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಗುಪ್ಪಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1292"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19376,8 +18085,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಹಟ್ಟಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1293"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19391,8 +18099,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅನಿತಾ ಜಿ. ಬಡಿಗೇರ್",
-    "cellRef": "A1294"
+    "NameKN": "ಅನಿತಾ ಜಿ. ಬಡಿಗೇರ್"
   },
   {
     "Department": "stamps_sro",
@@ -19406,8 +18113,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೋರಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1295"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19421,8 +18127,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೃಂಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1296"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19436,8 +18141,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1297"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19451,8 +18155,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂದಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1298"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19466,8 +18169,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂಧನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1299"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19481,8 +18183,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1300"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19496,8 +18197,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರ್ಸಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1301"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19511,8 +18211,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಮವಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1302"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19526,8 +18225,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೊರಬ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1303"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19541,8 +18239,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೌದತ್ತಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1304"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19556,8 +18253,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1305"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19571,8 +18267,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಮಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಚ್. ಎಸ್. ಅರವಿಂದ್",
-    "cellRef": "A1306"
+    "NameKN": "ಎಚ್. ಎಸ್. ಅರವಿಂದ್"
   },
   {
     "Department": "stamps_sro",
@@ -19586,8 +18281,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಂಗಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1307"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19601,8 +18295,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1308"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19616,8 +18309,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1309"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19631,8 +18323,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1310"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19646,8 +18337,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್",
-    "cellRef": "A1311"
+    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್"
   },
   {
     "Department": "stamps_sro",
@@ -19661,8 +18351,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೇರಾಡಲ್\\r\\n",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1312"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19676,8 +18365,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೀರ್ಥಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1313"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19691,8 +18379,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪಟೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1314"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19706,8 +18393,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1315"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -19721,8 +18407,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುರುವೇಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1316"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19736,8 +18421,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1317"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19751,8 +18435,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ",
-    "cellRef": "A1318"
+    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ"
   },
   {
     "Department": "stamps_sro",
@@ -19766,8 +18449,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರಾಜಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1319"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19781,8 +18463,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಮೀಳಾ ಜಿ.ಜೆ",
-    "cellRef": "A1320"
+    "NameKN": "ಪ್ರಮೀಳಾ ಜಿ.ಜೆ"
   },
   {
     "Department": "stamps_sro",
@@ -19796,8 +18477,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಟ್ಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1321"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19811,8 +18491,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1322"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19826,8 +18505,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್",
-    "cellRef": "A1323"
+    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್"
   },
   {
     "Department": "stamps_sro",
@@ -19841,8 +18519,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1324"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19856,8 +18533,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯೆಲ್ಬುರ್ಗಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1325"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19871,8 +18547,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲ್ಲಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1326"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19886,8 +18561,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವತಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸುರೇಶ್ ಜಿ",
-    "cellRef": "A1327"
+    "NameKN": "ಸುರೇಶ್ ಜಿ"
   },
   {
     "Department": "police_traffic",
@@ -19901,8 +18575,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1328"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19916,8 +18589,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1329"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19931,8 +18603,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1330"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19946,8 +18617,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1331"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19961,8 +18631,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1332"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19976,8 +18645,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1333"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19991,8 +18659,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1334"
+    "NameKN": ""
   },
   {
     "Department": "police_traffic",
@@ -20006,8 +18673,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1335"
+    "NameKN": ""
   },
   {
     "Department": "police_traffic",
@@ -20021,8 +18687,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1336"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20036,8 +18701,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1337"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20051,8 +18715,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1338"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20066,8 +18729,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1339"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20081,8 +18743,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1340"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20096,8 +18757,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1341"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20111,8 +18771,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1342"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20126,8 +18785,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1343"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20141,8 +18799,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1344"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20156,8 +18813,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1345"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20171,8 +18827,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1346"
+    "NameKN": ""
   },
   {
     "Department": "police_traffic",
@@ -20186,8 +18841,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1347"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20201,8 +18855,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1348"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20216,8 +18869,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1349"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20231,8 +18883,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1350"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20246,8 +18897,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1351"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20261,8 +18911,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1352"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20276,8 +18925,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1353"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20291,8 +18939,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1354"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20306,8 +18953,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1355"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20321,8 +18967,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1356"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20336,8 +18981,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1357"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20351,8 +18995,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1358"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20366,8 +19009,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ ಬೆಂಗಳೂರು PS",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1359"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20381,8 +19023,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1360"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20396,8 +19037,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1361"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20411,8 +19051,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1362"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20426,8 +19065,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1363"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20441,8 +19079,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1364"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20456,8 +19093,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1365"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20471,8 +19107,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1366"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20486,8 +19121,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1367"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20501,8 +19135,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1368"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20516,8 +19149,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1369"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20531,8 +19163,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1370"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20546,8 +19177,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1371"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20561,7 +19191,6 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1372"
+    "NameKN": "-"
   }
 ]

--- a/scripts/xls2json.py
+++ b/scripts/xls2json.py
@@ -8,9 +8,6 @@ df2 = pd.read_excel('./officials/master-list.xlsx', sheet_name=1)
 # Merge the two dataframes by row number
 df = pd.concat([df1, df2], axis=1)
 
-# Add cell references
-df['cellRef'] = df.index.map(lambda x: f'A{x+2}')  # +2 because Excel is 1-based and has header
-
 # Rename columns
 df = df.rename(columns={
     'Area (Kannada)': 'AreaKN',

--- a/src/components/Sidebar/DistrictDetails.svelte
+++ b/src/components/Sidebar/DistrictDetails.svelte
@@ -61,120 +61,101 @@
 />
 {#if $selectedBoundaryMap}
   {#if $selectedDistrict}
-    {#await getOfficialDetails($selectedBoundaryMap, $selectedDistrict) then officials}
-      {#if officials}
-        <div class="py-4 px-4 mt-4 pb-4">
-          <div class="flex flex-wrap items-center justify-between mb-4">
-            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-              {$_('details_title')}
-            </h3>
-            <a
-              href={Array.isArray(officials)
-                ? officials[0].Source
-                : officials.Source}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 inline-flex items-center"
+    {#if currentOfficials}
+      <div class="py-4 px-4 mt-4 pb-4">
+        <div class="flex flex-wrap items-center justify-between mb-4">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            {$_('details_title')}
+          </h3>
+          <a
+            href={Array.isArray(currentOfficials)
+              ? currentOfficials[0].Source
+              : currentOfficials.Source}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 inline-flex items-center"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4 mr-1"
+              viewBox="0 0 20 20"
+              fill="currentColor"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-4 w-4 mr-1"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"
-                />
-                <path
-                  d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"
-                />
-              </svg>
-              {$_('details_source')}
-            </a>
-          </div>
-          {#if (Array.isArray(officials) && officials[0].Department === 'bbmp_wards') || (!Array.isArray(officials) && officials.Department === 'bbmp_wards')}
-            <div
-              class="bg-white dark:bg-neutral-800 p-4 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 break-words mb-4"
-            >
-              {#if $locale?.startsWith('kn')}
-                <div
-                  class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
-                >
-                  ಕಾರ್ಪೊರೇಟರ್
-                </div>
-                <div
-                  class="text-ml font-medium text-gray-900 dark:text-gray-100 mb-4"
-                >
-                  ಯಾರೂ ಇಲ್ಲ
-                </div>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                  2020 ರಿಂದ ಯಾವುದೇ ಚುನಾಯಿತ ಕಾರ್ಪೊರೇಟರ್ ಇಲ್ಲ.
-                </p>
-              {:else}
-                <div
-                  class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
-                >
-                  Corporator
-                </div>
-                <div
-                  class="text-ml font-medium text-gray-900 dark:text-gray-100 mb-4"
-                >
-                  N/A
-                </div>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                  No elected corporator since 2020.
-                </p>
-              {/if}
-            </div>
-          {/if}
-
-          <div class="grid gap-4 grid-cols-1">
-            {#each Array.isArray(officials) ? officials : [officials] as official}
+              <path
+                d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"
+              />
+              <path
+                d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"
+              />
+            </svg>
+            {$_('details_source')}
+          </a>
+        </div>
+        {#if (Array.isArray(currentOfficials) && currentOfficials[0].Department === 'bbmp_wards') || (!Array.isArray(currentOfficials) && currentOfficials.Department === 'bbmp_wards')}
+          <div
+            class="bg-white dark:bg-neutral-800 p-4 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 break-words mb-4"
+          >
+            {#if $locale?.startsWith('kn')}
               <div
-                class="bg-white dark:bg-neutral-800 p-4 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 break-words"
+                class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
               >
-                {#if official.Designation && official.Designation !== '-'}
-                  <div
-                    class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
-                  >
-                    {$locale.startsWith('kn')
-                      ? official.DesignationKN
-                      : official.Designation}
-                  </div>
-                {/if}
+                ಕಾರ್ಪೊರೇಟರ್
+              </div>
+              <div
+                class="text-ml font-medium text-gray-900 dark:text-gray-100 mb-4"
+              >
+                ಯಾರೂ ಇಲ್ಲ
+              </div>
+              <p class="text-sm text-gray-500 dark:text-gray-400">
+                2020 ರಿಂದ ಯಾವುದೇ ಚುನಾಯಿತ ಕಾರ್ಪೊರೇಟರ್ ಇಲ್ಲ.
+              </p>
+            {:else}
+              <div
+                class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+              >
+                Corporator
+              </div>
+              <div
+                class="text-ml font-medium text-gray-900 dark:text-gray-100 mb-4"
+              >
+                N/A
+              </div>
+              <p class="text-sm text-gray-500 dark:text-gray-400">
+                No elected corporator since 2020.
+              </p>
+            {/if}
+          </div>
+        {/if}
 
-                {#if official.Name && official.Name !== '-'}
-                  <div
-                    class="text-ml font-medium text-gray-900 dark:text-gray-100 mb-4"
-                  >
-                    {$locale.startsWith('kn') ? official.NameKN : official.Name}
-                  </div>
-                {/if}
+        <div class="grid gap-4 grid-cols-1">
+          {#each Array.isArray(currentOfficials) ? currentOfficials : [currentOfficials] as official}
+            <div
+              class="bg-white dark:bg-neutral-800 p-4 rounded-lg shadow-sm border border-gray-200 dark:border-neutral-700 break-words"
+            >
+              {#if official.Designation && official.Designation !== '-'}
+                <div
+                  class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1"
+                >
+                  {$locale?.startsWith('kn')
+                    ? official.DesignationKN
+                    : official.Designation}
+                </div>
+              {/if}
 
-                <div class="flex flex-wrap gap-2">
-                  {#if official.Phone && typeof official.Phone === 'string'}
-                    {#if official.Phone.includes(',')}
-                      {#each official.Phone.split(',').map( (p: string) => p.trim() ) as phone}
-                        <a
-                          href="tel:{phone}"
-                          class="inline-flex items-center px-3 py-1 text-sm rounded bg-gray-50 dark:bg-neutral-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-neutral-600 border border-gray-200 dark:border-neutral-600 transition-colors max-w-full"
-                        >
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-4 w-4 mr-2 flex-shrink-0"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                          >
-                            <path
-                              d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"
-                            />
-                          </svg>
-                          <span class="truncate">{phone}</span>
-                        </a>
-                      {/each}
-                    {:else}
+              {#if official.Name && official.Name !== '-'}
+                <div
+                  class="text-ml font-medium text-gray-900 dark:text-gray-100 mb-4"
+                >
+                  {$locale?.startsWith('kn') ? official.NameKN : official.Name}
+                </div>
+              {/if}
+
+              <div class="flex flex-wrap gap-2">
+                {#if official.Phone && typeof official.Phone === 'string'}
+                  {#if official.Phone.includes(',')}
+                    {#each official.Phone.split(',').map( (p: string) => p.trim() ) as phone}
                       <a
-                        href="tel:{official.Phone}"
+                        href="tel:{phone}"
                         class="inline-flex items-center px-3 py-1 text-sm rounded bg-gray-50 dark:bg-neutral-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-neutral-600 border border-gray-200 dark:border-neutral-600 transition-colors max-w-full"
                       >
                         <svg
@@ -187,13 +168,12 @@
                             d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"
                           />
                         </svg>
-                        <span class="truncate">{official.Phone}</span>
+                        <span class="truncate">{phone}</span>
                       </a>
-                    {/if}
-                  {/if}
-                  {#if official['E-Mail']}
+                    {/each}
+                  {:else}
                     <a
-                      href="mailto:{official['E-Mail']}"
+                      href="tel:{official.Phone}"
                       class="inline-flex items-center px-3 py-1 text-sm rounded bg-gray-50 dark:bg-neutral-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-neutral-600 border border-gray-200 dark:border-neutral-600 transition-colors max-w-full"
                     >
                       <svg
@@ -203,55 +183,73 @@
                         fill="currentColor"
                       >
                         <path
-                          d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"
-                        />
-                        <path
-                          d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"
+                          d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z"
                         />
                       </svg>
-                      <span class="truncate">{official['E-Mail']}</span>
+                      <span class="truncate">{official.Phone}</span>
                     </a>
                   {/if}
-                  {#if !official.Phone && !official['E-Mail']}
-                    <span class="text-gray-500 dark:text-gray-400 italic"
-                      >No contact information available</span
+                {/if}
+                {#if official['E-Mail']}
+                  <a
+                    href="mailto:{official['E-Mail']}"
+                    class="inline-flex items-center px-3 py-1 text-sm rounded bg-gray-50 dark:bg-neutral-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-neutral-600 border border-gray-200 dark:border-neutral-600 transition-colors max-w-full"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="h-4 w-4 mr-2 flex-shrink-0"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
                     >
-                  {/if}
-                </div>
+                      <path
+                        d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z"
+                      />
+                      <path
+                        d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z"
+                      />
+                    </svg>
+                    <span class="truncate">{official['E-Mail']}</span>
+                  </a>
+                {/if}
+                {#if !official.Phone && !official['E-Mail']}
+                  <span class="text-gray-500 dark:text-gray-400 italic"
+                    >No contact information available</span
+                  >
+                {/if}
               </div>
-            {/each}
-          </div>
+            </div>
+          {/each}
         </div>
-      {:else}
-        <div class="px-4 mt-4 pb-4">
-          <div class="bg-white dark:bg-neutral-900 p-4 rounded-lg">
-            {#if layers[$selectedBoundaryMap]?.formatUrl}
-              <a
-                href={layers[$selectedBoundaryMap].formatUrl($selectedDistrict)}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="inline-flex items-center text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+      </div>
+    {:else}
+      <div class="px-4 mt-4 pb-4">
+        <div class="bg-white dark:bg-neutral-900 p-4 rounded-lg">
+          {#if layers[$selectedBoundaryMap]?.formatUrl}
+            <a
+              href={layers[$selectedBoundaryMap].formatUrl($selectedDistrict)}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="h-5 w-5 mr-2"
+                viewBox="0 0 20 20"
+                fill="currentColor"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-5 w-5 mr-2"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
-                  <path
-                    d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"
-                  />
-                  <path
-                    d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"
-                  />
-                </svg>
-                Source
-              </a>
-            {/if}
-          </div>
+                <path
+                  d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"
+                />
+                <path
+                  d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"
+                />
+              </svg>
+              Source
+            </a>
+          {/if}
         </div>
-      {/if}
-    {/await}
+      </div>
+    {/if}
   {/if}
 {/if}
 <div class="px-4 mt-4 pb-4">

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -85,9 +85,14 @@ export function getOfficialDetails(
   districtId: string | null
 ) {
   if (!boundaryId || !districtId) return null;
-  return officials.find(
-    official =>
+  return officials.find((official, index) => {
+    if (
       official.Department.toLowerCase() === boundaryId.toLowerCase() &&
       official.Area.toLowerCase() === districtId.toLowerCase()
-  );
+    ) {
+      official.cellRef = `A${index + 2}`;
+      return true;
+    }
+    return false;
+  });
 }

--- a/src/officials.json
+++ b/src/officials.json
@@ -11,8 +11,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ ಎನ್",
-    "cellRef": "A2"
+    "NameKN": "ಶಿವಶಂಕರ ಎನ್"
   },
   {
     "Department": "admin_district",
@@ -26,8 +25,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ನಗರ",
     "DesignationKN": "ಜಿಲ್ಲಾಧಿಕಾರಿ",
-    "NameKN": "ಜಗದೀಶ ಜಿ",
-    "cellRef": "A3"
+    "NameKN": "ಜಗದೀಶ ಜಿ"
   },
   {
     "Department": "admin_district",
@@ -41,8 +39,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A4"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -56,8 +53,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A5"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -71,8 +67,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A6"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -86,8 +81,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A7"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -101,8 +95,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A8"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -116,8 +109,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A9"
+    "NameKN": ""
   },
   {
     "Department": "admin_district",
@@ -131,8 +123,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A10"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -146,8 +137,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಪಿ ದಿನೇಶ್",
-    "cellRef": "A11"
+    "NameKN": "ಪಿ ದಿನೇಶ್"
   },
   {
     "Department": "admin_taluk",
@@ -161,8 +151,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A12"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -176,8 +165,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಪೂರ್ವ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ರಾಜೀವ್",
-    "cellRef": "A13"
+    "NameKN": "ರಾಜೀವ್"
   },
   {
     "Department": "admin_taluk",
@@ -191,8 +179,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಬಾಲಕೃಷ್ಣ",
-    "cellRef": "A14"
+    "NameKN": "ಬಾಲಕೃಷ್ಣ"
   },
   {
     "Department": "admin_taluk",
@@ -206,8 +193,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ",
-    "cellRef": "A15"
+    "NameKN": "ಎಚ್ ಟಿ ಮಂಜಪ್ಪ"
   },
   {
     "Department": "admin_taluk",
@@ -221,8 +207,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A16"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -236,8 +221,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A17"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -251,8 +235,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A18"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -266,8 +249,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A19"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -281,8 +263,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A20"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -296,8 +277,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A21"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -311,8 +291,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A22"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -326,8 +305,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A23"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -341,8 +319,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A24"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -356,8 +333,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A25"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -371,8 +347,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A26"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -386,8 +361,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A27"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -401,8 +375,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A28"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -416,8 +389,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A29"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -431,8 +403,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A30"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -446,8 +417,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ಎಫ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A31"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -461,8 +431,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A32"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -476,8 +445,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A33"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -491,8 +459,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A34"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -506,8 +473,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A35"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -521,8 +487,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A36"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -536,8 +501,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A37"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -551,8 +515,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A38"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -566,8 +529,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A39"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -581,8 +543,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A40"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -596,8 +557,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A41"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -611,8 +571,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A42"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -626,8 +585,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A43"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -641,8 +599,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A44"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -656,8 +613,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A45"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -671,8 +627,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A46"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -686,8 +641,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A47"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -701,8 +655,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A48"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -716,8 +669,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A49"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -731,8 +683,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A50"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -746,8 +697,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A51"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -761,8 +711,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A52"
+    "NameKN": ""
   },
   {
     "Department": "admin_taluk",
@@ -776,8 +725,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ತಹಶೀಲ್ದಾರ್",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ",
-    "cellRef": "A53"
+    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -791,8 +739,7 @@
     "Unnamed: 3": "",
     "AreaKN": "94: ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ",
-    "cellRef": "A54"
+    "NameKN": "ಅಕ್ಷತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -806,8 +753,7 @@
     "Unnamed: 3": "",
     "AreaKN": "176: ಆಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್",
-    "cellRef": "A55"
+    "NameKN": "ರವಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -821,8 +767,7 @@
     "Unnamed: 3": "",
     "AreaKN": "102: ಎ.ಇ.ಸಿ.ಎಸ್. ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಿ. ಶ್ರೀನಿವಾಸ ಮೂರ್ತಿ",
-    "cellRef": "A56"
+    "NameKN": "ಜಿ. ಶ್ರೀನಿವಾಸ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -836,8 +781,7 @@
     "Unnamed: 3": "",
     "AreaKN": "172: ಅಗರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ",
-    "cellRef": "A57"
+    "NameKN": "ಕೃಷ್ಣಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -851,8 +795,7 @@
     "Unnamed: 3": "",
     "AreaKN": "8: ಅಮೃತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್",
-    "cellRef": "A58"
+    "NameKN": "ಸೋಮಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -866,8 +809,7 @@
     "Unnamed: 3": "",
     "AreaKN": "208: ಅಂಜನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು",
-    "cellRef": "A59"
+    "NameKN": "ರಘು"
   },
   {
     "Department": "bbmp_wards",
@@ -881,8 +823,7 @@
     "Unnamed: 3": "",
     "AreaKN": "56: ಅರಮನೆ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜ್ ಕುಮಾರ್",
-    "cellRef": "A60"
+    "NameKN": "ರಾಜ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -896,8 +837,7 @@
     "Unnamed: 3": "",
     "AreaKN": "167: ಅಶೋಕ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೇಖ್ ಅಹಮದ್",
-    "cellRef": "A61"
+    "NameKN": "ಶೇಖ್ ಅಹಮದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -911,8 +851,7 @@
     "Unnamed: 3": "",
     "AreaKN": "150: ಅತ್ತಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜ್ಯೋತಿ",
-    "cellRef": "A62"
+    "NameKN": "ಜ್ಯೋತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -926,8 +865,7 @@
     "Unnamed: 3": "",
     "AreaKN": "3: ಅಟ್ಟೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ",
-    "cellRef": "A63"
+    "NameKN": "ರಘುನಂದನ್ ಮಂತ್ರಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -941,8 +879,7 @@
     "Unnamed: 3": "",
     "AreaKN": "152: ಆವಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್",
-    "cellRef": "A64"
+    "NameKN": "ಪ್ರದೀಪ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -956,8 +893,7 @@
     "Unnamed: 3": "",
     "AreaKN": "159: ಆಜಾದ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್",
-    "cellRef": "A65"
+    "NameKN": "ಸೈಯದ್ ಫಾರೂಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -971,8 +907,7 @@
     "Unnamed: 3": "",
     "AreaKN": "165: ಬಿ ವೆಂಕಟ ರೆಡ್ಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ",
-    "cellRef": "A66"
+    "NameKN": "ಮಮತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -986,8 +921,7 @@
     "Unnamed: 3": "",
     "AreaKN": "18: ಬಾಗಲಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
-    "cellRef": "A67"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1001,8 +935,7 @@
     "Unnamed: 3": "",
     "AreaKN": "82: ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ",
-    "cellRef": "A68"
+    "NameKN": "ಕಲ್ಲೇಶಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -1016,8 +949,7 @@
     "Unnamed: 3": "",
     "AreaKN": "191: ಬನಶಂಕರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಮಾ",
-    "cellRef": "A69"
+    "NameKN": "ಸುಮಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1031,8 +963,7 @@
     "Unnamed: 3": "",
     "AreaKN": "31: ಬಂಡೆ ಮಠ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪೂರ್ಣಿಮಾ",
-    "cellRef": "A70"
+    "NameKN": "ಪೂರ್ಣಿಮಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1046,8 +977,7 @@
     "Unnamed: 3": "",
     "AreaKN": "92: ಬಸವನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ.",
-    "cellRef": "A71"
+    "NameKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಡಾ."
   },
   {
     "Department": "bbmp_wards",
@@ -1061,8 +991,7 @@
     "Unnamed: 3": "",
     "AreaKN": "133: ಬಸವೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್",
-    "cellRef": "A72"
+    "NameKN": "ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1076,8 +1005,7 @@
     "Unnamed: 3": "",
     "AreaKN": "211: ಬೇಗೂರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನೀಲಕಂಠಯ್ಯ",
-    "cellRef": "A73"
+    "NameKN": "ನೀಲಕಂಠಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -1091,8 +1019,7 @@
     "Unnamed: 3": "",
     "AreaKN": "107: ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A74"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -1106,8 +1033,7 @@
     "Unnamed: 3": "",
     "AreaKN": "109: ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ",
-    "cellRef": "A75"
+    "NameKN": "ಅರ್ಪಿತಾ ಸಿಪಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1121,8 +1047,7 @@
     "Unnamed: 3": "",
     "AreaKN": "120: ಭಾರತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಾವಿತ್ರಿ",
-    "cellRef": "A76"
+    "NameKN": "ಸಾವಿತ್ರಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1136,8 +1061,7 @@
     "Unnamed: 3": "",
     "AreaKN": "215: ಬಿಳೇಕಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A77"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1151,8 +1075,7 @@
     "Unnamed: 3": "",
     "AreaKN": "126: ಬಿನ್ನಿಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್",
-    "cellRef": "A78"
+    "NameKN": "ನರಸಿಂಹ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1166,8 +1089,7 @@
     "Unnamed: 3": "",
     "AreaKN": "218: ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್ ದೇವಾ",
-    "cellRef": "A79"
+    "NameKN": "ರಮೇಶ್ ದೇವಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1181,8 +1103,7 @@
     "Unnamed: 3": "",
     "AreaKN": "181: ಬಿ ಟಿ ಎಂ ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕಲಾ",
-    "cellRef": "A80"
+    "NameKN": "ಶಶಿಕಲಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1196,8 +1117,7 @@
     "Unnamed: 3": "",
     "AreaKN": "10: ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಕುಮಾರ್",
-    "cellRef": "A81"
+    "NameKN": "ಶಿವಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1211,8 +1131,7 @@
     "Unnamed: 3": "",
     "AreaKN": "182: ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅನುಷಾ",
-    "cellRef": "A82"
+    "NameKN": "ಅನುಷಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1226,8 +1145,7 @@
     "Unnamed: 3": "",
     "AreaKN": "99: ಬೈರತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಿ.ಎನ್. ರಾಘವೇಂದ್ರ",
-    "cellRef": "A83"
+    "NameKN": "ಬಿ.ಎನ್. ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "bbmp_wards",
@@ -1241,8 +1159,7 @@
     "Unnamed: 3": "",
     "AreaKN": "110: ಸಿ ವಿ ರಾಮನ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ",
-    "cellRef": "A84"
+    "NameKN": "ರವಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1256,8 +1173,7 @@
     "Unnamed: 3": "",
     "AreaKN": "156: ಚಲವಾದಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಸಂತ್",
-    "cellRef": "A85"
+    "NameKN": "ವಸಂತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1271,8 +1187,7 @@
     "Unnamed: 3": "",
     "AreaKN": "86: ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ",
-    "cellRef": "A86"
+    "NameKN": "ಎಂ.ಎಸ್.ಭಾಗ್ಯಮ್ಮ"
   },
   {
     "Department": "bbmp_wards",
@@ -1286,8 +1201,7 @@
     "Unnamed: 3": "",
     "AreaKN": "158: ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೌಮ್ಯಾ",
-    "cellRef": "A87"
+    "NameKN": "ಸೌಮ್ಯಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1301,8 +1215,7 @@
     "Unnamed: 3": "",
     "AreaKN": "66: ಚಾಮುಂಡಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಯನತಾರಾ ಡಾ.",
-    "cellRef": "A88"
+    "NameKN": "ನಯನತಾರಾ ಡಾ."
   },
   {
     "Department": "bbmp_wards",
@@ -1316,8 +1229,7 @@
     "Unnamed: 3": "",
     "AreaKN": "142: ಚಂದ್ರಾಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾರತಿ",
-    "cellRef": "A89"
+    "NameKN": "ಭಾರತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1331,8 +1243,7 @@
     "Unnamed: 3": "",
     "AreaKN": "128: ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ",
-    "cellRef": "A90"
+    "NameKN": "ಶಂಕರಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -1346,8 +1257,7 @@
     "Unnamed: 3": "",
     "AreaKN": "194: ಚಿಕ್ಕಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್",
-    "cellRef": "A91"
+    "NameKN": "ಶರತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1361,8 +1271,7 @@
     "Unnamed: 3": "",
     "AreaKN": "17: ಚಿಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯದುಕೃಷ್ಣ",
-    "cellRef": "A92"
+    "NameKN": "ಯದುಕೃಷ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -1376,8 +1285,7 @@
     "Unnamed: 3": "",
     "AreaKN": "21: ಚೊಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ",
-    "cellRef": "A93"
+    "NameKN": "ಗುರಪ್ಪ ದೊಡ್ಡಮನಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1391,8 +1299,7 @@
     "Unnamed: 3": "",
     "AreaKN": "40: ಚೌಡೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪಾಪರೆಡ್ಡಿ",
-    "cellRef": "A94"
+    "NameKN": "ಪಾಪರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1406,8 +1313,7 @@
     "Unnamed: 3": "",
     "AreaKN": "2: ಚೌಡೇಶ್ವರಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೆ.ಜಿ. ಸುಂದರೇಶ್",
-    "cellRef": "A95"
+    "NameKN": "ಕೆ.ಜಿ. ಸುಂದರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1421,8 +1327,7 @@
     "Unnamed: 3": "",
     "AreaKN": "127: ಕಾಟನ್ ಪೇಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು",
-    "cellRef": "A96"
+    "NameKN": "ರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -1436,8 +1341,7 @@
     "Unnamed: 3": "",
     "AreaKN": "108: ಕಾಕ್ಸ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ",
-    "cellRef": "A97"
+    "NameKN": "ಯರಪ್ಪರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1451,8 +1355,7 @@
     "Unnamed: 3": "",
     "AreaKN": "122: ದತ್ತಾತ್ರೇಯ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್",
-    "cellRef": "A98"
+    "NameKN": "ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1466,8 +1369,7 @@
     "Unnamed: 3": "",
     "AreaKN": "129: ದಯಾನಂದ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮು",
-    "cellRef": "A99"
+    "NameKN": "ರಾಮು"
   },
   {
     "Department": "bbmp_wards",
@@ -1481,8 +1383,7 @@
     "Unnamed: 3": "",
     "AreaKN": "151: ದೀಪಾಂಜಲಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು",
-    "cellRef": "A100"
+    "NameKN": "ಸತ್ಯನಾರಾಯಣ ರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -1496,8 +1397,7 @@
     "Unnamed: 3": "",
     "AreaKN": "190: ದೇವಗಿರಿ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್",
-    "cellRef": "A101"
+    "NameKN": "ಕೊಟ್ರೇಶ್ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1511,8 +1411,7 @@
     "Unnamed: 3": "",
     "AreaKN": "72: ದೇವರ ಜೀವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್",
-    "cellRef": "A102"
+    "NameKN": "ಉಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1526,8 +1425,7 @@
     "Unnamed: 3": "",
     "AreaKN": "155: ದೇವರಾಜ್ ಅರಸ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ",
-    "cellRef": "A103"
+    "NameKN": "ಭಾಸ್ಕರ್ ರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1541,8 +1439,7 @@
     "Unnamed: 3": "",
     "AreaKN": "93: ದೇವಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿತ್ಯ ಕೆ.ಎ.",
-    "cellRef": "A104"
+    "NameKN": "ನಿತ್ಯ ಕೆ.ಎ."
   },
   {
     "Department": "bbmp_wards",
@@ -1556,8 +1453,7 @@
     "Unnamed: 3": "",
     "AreaKN": "160: ಧರ್ಮರಾಯ ಸ್ವಾಮಿ ದೇವಸ್ಥಾನ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಲು ರಾಥೋರ್",
-    "cellRef": "A105"
+    "NameKN": "ವಲು ರಾಥೋರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1571,8 +1467,7 @@
     "Unnamed: 3": "",
     "AreaKN": "26: ದೊಡ್ಡ ಬಿದರಕಲ್ಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಿದ್ಧರಾಜ್",
-    "cellRef": "A106"
+    "NameKN": "ಸಿದ್ಧರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1586,8 +1481,7 @@
     "Unnamed: 3": "",
     "AreaKN": "12: ದೊಡ್ಡ ಬೊಮ್ಮಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬೀರೇಶ್",
-    "cellRef": "A107"
+    "NameKN": "ಬೀರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1601,8 +1495,7 @@
     "Unnamed: 3": "",
     "AreaKN": "198: ದೊಡ್ಡ ಗಣಪತಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗಸ್ವಾಮಿ",
-    "cellRef": "A108"
+    "NameKN": "ರಂಗಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1616,8 +1509,7 @@
     "Unnamed: 3": "",
     "AreaKN": "101: ದೊಡ್ಡ ನೆಕ್ಕುಂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿಕುಮಾರ್",
-    "cellRef": "A109"
+    "NameKN": "ರವಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1631,8 +1523,7 @@
     "Unnamed: 3": "",
     "AreaKN": "171: ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪ್ಪುರಾಜ್",
-    "cellRef": "A110"
+    "NameKN": "ಅಪ್ಪುರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1646,8 +1537,7 @@
     "Unnamed: 3": "",
     "AreaKN": "47: ಡಾ. ಪುನೀತ್ ರಾಜ್ ಕುಮಾರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ",
-    "cellRef": "A111"
+    "NameKN": "ರೇಣುಕಾಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1661,8 +1551,7 @@
     "Unnamed: 3": "",
     "AreaKN": "135: ಡಾ. ರಾಜ್ ಕುಮಾರ್ ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್",
-    "cellRef": "A112"
+    "NameKN": "ಪ್ರಕಾಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1676,8 +1565,7 @@
     "Unnamed: 3": "",
     "AreaKN": "173: ಈಜಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನುಪಮಾ",
-    "cellRef": "A113"
+    "NameKN": "ಡಾ. ಅನುಪಮಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1691,8 +1579,7 @@
     "Unnamed: 3": "",
     "AreaKN": "149: ಗಾಲಿ ಆಂಜನೇಯ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶಿಲ್ಪಾ",
-    "cellRef": "A114"
+    "NameKN": "ಡಾ. ಶಿಲ್ಪಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1706,8 +1593,7 @@
     "Unnamed: 3": "",
     "AreaKN": "123: ಗಾಂಧಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿಯಪ್ಪ",
-    "cellRef": "A115"
+    "NameKN": "ಮುನಿಯಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -1721,8 +1607,7 @@
     "Unnamed: 3": "",
     "AreaKN": "189: ಗಣೇಶ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್",
-    "cellRef": "A116"
+    "NameKN": "ಮಂಜುನಾಥ್ ಟಿ.ಆರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1736,8 +1621,7 @@
     "Unnamed: 3": "",
     "AreaKN": "67: ಗಂಗಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಭಿಲಾಷ್",
-    "cellRef": "A117"
+    "NameKN": "ಅಭಿಲಾಷ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1751,8 +1635,7 @@
     "Unnamed: 3": "",
     "AreaKN": "100: ಗರುಡಾಚಾರ್ ಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೂಪ್ರಧಾ",
-    "cellRef": "A118"
+    "NameKN": "ಭೂಪ್ರಧಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1766,8 +1649,7 @@
     "Unnamed: 3": "",
     "AreaKN": "196: ಗವಿ ಗಂಗಾಧರೇಶ್ವರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಘು",
-    "cellRef": "A119"
+    "NameKN": "ರಘು"
   },
   {
     "Department": "bbmp_wards",
@@ -1781,8 +1663,7 @@
     "Unnamed: 3": "",
     "AreaKN": "60: ಗಾಯಿತ್ರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಕುಮಾರ್",
-    "cellRef": "A120"
+    "NameKN": "ರಾಜಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1796,8 +1677,7 @@
     "Unnamed: 3": "",
     "AreaKN": "220: ಘರೇಭಾವಿಪಾಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A121"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -1811,8 +1691,7 @@
     "Unnamed: 3": "",
     "AreaKN": "209: ಗೊಟ್ಟಿಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ",
-    "cellRef": "A122"
+    "NameKN": "ವಿರೇಶ ಆಲದಕಟ್ಟಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -1826,8 +1705,7 @@
     "Unnamed: 3": "",
     "AreaKN": "136: ಗೋವಿಂದರಾಜ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್",
-    "cellRef": "A123"
+    "NameKN": "ಉಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1841,8 +1719,7 @@
     "Unnamed: 3": "",
     "AreaKN": "183: ಗುರಪ್ಪನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್",
-    "cellRef": "A124"
+    "NameKN": "ಸಂತೋಷ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1856,8 +1733,7 @@
     "Unnamed: 3": "",
     "AreaKN": "96: HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "",
-    "cellRef": "A125"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -1871,8 +1747,7 @@
     "Unnamed: 3": "",
     "AreaKN": "147: ಹಂಪಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗರಾಜು",
-    "cellRef": "A126"
+    "NameKN": "ರಂಗರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -1886,8 +1761,7 @@
     "Unnamed: 3": "",
     "AreaKN": "78: HBR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರವಿಕುಮಾರ್",
-    "cellRef": "A127"
+    "NameKN": "ಡಾ. ರವಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1901,8 +1775,7 @@
     "Unnamed: 3": "",
     "AreaKN": "9: ಹೆಬ್ಬಾಳ ಕೆಂಪಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಕ್ಷತಾ",
-    "cellRef": "A128"
+    "NameKN": "ಅಕ್ಷತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -1916,8 +1789,7 @@
     "Unnamed: 3": "",
     "AreaKN": "63: ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಇಮ್ರಾನ್",
-    "cellRef": "A129"
+    "NameKN": "ಇಮ್ರಾನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1931,8 +1803,7 @@
     "Unnamed: 3": "",
     "AreaKN": "24: ಹೆಗ್ಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹನುಮಂತ ನಾಯಕ್",
-    "cellRef": "A130"
+    "NameKN": "ಹನುಮಂತ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1946,8 +1817,7 @@
     "Unnamed: 3": "",
     "AreaKN": "33: ಹೆಮ್ಮಿಗೆಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ",
-    "cellRef": "A131"
+    "NameKN": "ಗವಿಸಿದ್ದಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -1961,8 +1831,7 @@
     "Unnamed: 3": "",
     "AreaKN": "76: ಹೆಣ್ಣೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಈರಣ್ಣ",
-    "cellRef": "A132"
+    "NameKN": "ಈರಣ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -1976,8 +1845,7 @@
     "Unnamed: 3": "",
     "AreaKN": "28: ಹೇರೋಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A133"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -1991,8 +1859,7 @@
     "Unnamed: 3": "",
     "AreaKN": "164: ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಎನ್. ಎಸ್. ನಾಗೇಂದ್ರ",
-    "cellRef": "A134"
+    "NameKN": "ಎನ್. ಎಸ್. ನಾಗೇಂದ್ರ"
   },
   {
     "Department": "bbmp_wards",
@@ -2006,8 +1873,7 @@
     "Unnamed: 3": "",
     "AreaKN": "219: ಹೊಂಗಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಧರ್",
-    "cellRef": "A135"
+    "NameKN": "ಶಶಿಧರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2021,8 +1887,7 @@
     "Unnamed: 3": "",
     "AreaKN": "87: ಹೊರಮಾವು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A136"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2036,8 +1901,7 @@
     "Unnamed: 3": "",
     "AreaKN": "224: ಹೊಸ ರಸ್ತೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A137"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2051,8 +1915,7 @@
     "Unnamed: 3": "",
     "AreaKN": "146: ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
-    "cellRef": "A138"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2066,8 +1929,7 @@
     "Unnamed: 3": "",
     "AreaKN": "195: ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲೋಹಿತ್",
-    "cellRef": "A139"
+    "NameKN": "ಲೋಹಿತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2081,8 +1943,7 @@
     "Unnamed: 3": "",
     "AreaKN": "113: ಹೊಯ್ಸಳ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
-    "cellRef": "A140"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2096,8 +1957,7 @@
     "Unnamed: 3": "",
     "AreaKN": "221: HSR ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜು",
-    "cellRef": "A141"
+    "NameKN": "ರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -2111,8 +1971,7 @@
     "Unnamed: 3": "",
     "AreaKN": "98: ಹೂಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್",
-    "cellRef": "A142"
+    "NameKN": "ಪ್ರಕಾಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2126,8 +1985,7 @@
     "Unnamed: 3": "",
     "AreaKN": "216: ಹುಳಿಮಾವು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A143"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2141,8 +1999,7 @@
     "Unnamed: 3": "",
     "AreaKN": "222: ಇಬ್ಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A144"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2156,8 +2013,7 @@
     "Unnamed: 3": "",
     "AreaKN": "185: ಜೆ ಪಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A145"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2171,8 +2027,7 @@
     "Unnamed: 3": "",
     "AreaKN": "175: ಜಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫಜಲ್ ಅಹಮದ್",
-    "cellRef": "A146"
+    "NameKN": "ಫಜಲ್ ಅಹಮದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2186,8 +2041,7 @@
     "Unnamed: 3": "",
     "AreaKN": "6: ಜಕ್ಕೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರು",
-    "cellRef": "A147"
+    "NameKN": "ಚಂದ್ರು"
   },
   {
     "Department": "bbmp_wards",
@@ -2201,8 +2055,7 @@
     "Unnamed: 3": "",
     "AreaKN": "36: ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರುಣ್",
-    "cellRef": "A148"
+    "NameKN": "ವರುಣ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2216,8 +2069,7 @@
     "Unnamed: 3": "",
     "AreaKN": "213: ಜರಗನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವೇಶ್ವರ್",
-    "cellRef": "A149"
+    "NameKN": "ವಿಶ್ವೇಶ್ವರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2231,8 +2083,7 @@
     "Unnamed: 3": "",
     "AreaKN": "68: ಜಯಚಾಮರಾಜೇಂದ್ರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್",
-    "cellRef": "A150"
+    "NameKN": "ನಾಗೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2246,8 +2097,7 @@
     "Unnamed: 3": "",
     "AreaKN": "184: ಜಯನಗರ ಪೂರ್ವ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಷ್ಣುಕಾಂತ್",
-    "cellRef": "A151"
+    "NameKN": "ವಿಷ್ಣುಕಾಂತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2261,8 +2111,7 @@
     "Unnamed: 3": "",
     "AreaKN": "114: ಜೀವನಭೀಮ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಚಿಕೇತ್",
-    "cellRef": "A152"
+    "NameKN": "ನಚಿಕೇತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2276,8 +2125,7 @@
     "Unnamed: 3": "",
     "AreaKN": "44: ಜ್ಞಾನ ಭಾರತಿ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಶಂಕರ",
-    "cellRef": "A153"
+    "NameKN": "ಶಿವಶಂಕರ"
   },
   {
     "Department": "bbmp_wards",
@@ -2291,8 +2139,7 @@
     "Unnamed: 3": "",
     "AreaKN": "170: ಜೋಗುಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವರನಾರಾಯಣ್",
-    "cellRef": "A154"
+    "NameKN": "ವರನಾರಾಯಣ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2306,8 +2153,7 @@
     "Unnamed: 3": "",
     "AreaKN": "34: ಜೆಪಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಧನ್ಯ ಕುಮಾರ್",
-    "cellRef": "A155"
+    "NameKN": "ಡಾ. ಧನ್ಯ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2321,8 +2167,7 @@
     "Unnamed: 3": "",
     "AreaKN": "157: ಕೆ ಆರ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿಲ್ಪಾ",
-    "cellRef": "A156"
+    "NameKN": "ಶಿಲ್ಪಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2336,8 +2181,7 @@
     "Unnamed: 3": "",
     "AreaKN": "91: ಕೆ ಆರ್ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್",
-    "cellRef": "A157"
+    "NameKN": "ಪ್ರದೀಪ್ ರಾಥೋಡ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2351,8 +2195,7 @@
     "Unnamed: 3": "",
     "AreaKN": "80: ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ",
-    "cellRef": "A158"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2366,8 +2209,7 @@
     "Unnamed: 3": "",
     "AreaKN": "58: ಕಾಡು ಮಲ್ಲೇಶ್ವರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಮತಾ",
-    "cellRef": "A159"
+    "NameKN": "ಮಮತಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2381,8 +2223,7 @@
     "Unnamed: 3": "",
     "AreaKN": "97: ಕಾಡುಗೋಡಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಹರ್ಷ ನಾಯಕ್",
-    "cellRef": "A160"
+    "NameKN": "ಹರ್ಷ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2396,8 +2237,7 @@
     "Unnamed: 3": "",
     "AreaKN": "79: ಕಾಡುಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉದಯ್ ಚೌಗಲೆ",
-    "cellRef": "A161"
+    "NameKN": "ಉದಯ್ ಚೌಗಲೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2411,8 +2251,7 @@
     "Unnamed: 3": "",
     "AreaKN": "111: ಕಗ್ಗದಾಸನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ವೇತಾ ಬಿ",
-    "cellRef": "A162"
+    "NameKN": "ಶ್ವೇತಾ ಬಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2426,8 +2265,7 @@
     "Unnamed: 3": "",
     "AreaKN": "210: ಕಾಳೇನ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ",
-    "cellRef": "A163"
+    "NameKN": "ಮಂಜುಳಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2441,8 +2279,7 @@
     "Unnamed: 3": "",
     "AreaKN": "88: ಕಲ್ಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A164"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2456,8 +2293,7 @@
     "Unnamed: 3": "",
     "AreaKN": "134: ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ",
-    "cellRef": "A165"
+    "NameKN": "ಚನ್ನಬಸಪ್ಪ ಮಾಕಾಳೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2471,8 +2307,7 @@
     "Unnamed: 3": "",
     "AreaKN": "15: ಕಮ್ಮಗೊಂಡನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಸವರಾಜ",
-    "cellRef": "A166"
+    "NameKN": "ಬಸವರಾಜ"
   },
   {
     "Department": "bbmp_wards",
@@ -2486,8 +2321,7 @@
     "Unnamed: 3": "",
     "AreaKN": "81: ಕಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ್",
-    "cellRef": "A167"
+    "NameKN": "ಡಾ. ಸುನೀಲ್ ಕುಮಾರ್ ಹಾವನೂರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2501,8 +2335,7 @@
     "Unnamed: 3": "",
     "AreaKN": "201: ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಕುಮಾರ್",
-    "cellRef": "A168"
+    "NameKN": "ವಿಜಯಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2516,8 +2349,7 @@
     "Unnamed: 3": "",
     "AreaKN": "69: ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ದೇವಿಕಾ ರಾಣಿ ",
-    "cellRef": "A169"
+    "NameKN": "ಡಾ. ದೇವಿಕಾ ರಾಣಿ "
   },
   {
     "Department": "bbmp_wards",
@@ -2531,8 +2363,7 @@
     "Unnamed: 3": "",
     "AreaKN": "138: ಕಾವೇರಿಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ",
-    "cellRef": "A170"
+    "NameKN": "ಪ್ರಿಯದರ್ಶಿನಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2546,8 +2377,7 @@
     "Unnamed: 3": "",
     "AreaKN": "144: ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್",
-    "cellRef": "A171"
+    "NameKN": "ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2561,8 +2391,7 @@
     "Unnamed: 3": "",
     "AreaKN": "1: ಕೆಂಪೇಗೌಡ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಫರ್ಜಾನಾ",
-    "cellRef": "A172"
+    "NameKN": "ಫರ್ಜಾನಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -2576,8 +2405,7 @@
     "Unnamed: 3": "",
     "AreaKN": "32: ಕೆಂಗೇರಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ",
-    "cellRef": "A173"
+    "NameKN": "ರಾಮಸಂಜೀವಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -2591,8 +2419,7 @@
     "Unnamed: 3": "",
     "AreaKN": "217: ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ",
-    "cellRef": "A174"
+    "NameKN": "ಬಾಲಗಂಗಾದರಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -2606,8 +2433,7 @@
     "Unnamed: 3": "",
     "AreaKN": "11: ಕೊಡಿಗೇಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A175"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2621,8 +2447,7 @@
     "Unnamed: 3": "",
     "AreaKN": "5: ಕೋಗಿಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರದೀಪ್",
-    "cellRef": "A176"
+    "NameKN": "ಪ್ರದೀಪ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2636,8 +2461,7 @@
     "Unnamed: 3": "",
     "AreaKN": "206: ಕೋಣನಕುಂಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್",
-    "cellRef": "A177"
+    "NameKN": "ರಂಗನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2651,8 +2475,7 @@
     "Unnamed: 3": "",
     "AreaKN": "115: ಕೊನೆನ ಅಗ್ರಹಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಮ್",
-    "cellRef": "A178"
+    "NameKN": "ಜಯರಾಮ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2666,8 +2489,7 @@
     "Unnamed: 3": "",
     "AreaKN": "174: ಕೋರಮಂಗಲ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ",
-    "cellRef": "A179"
+    "NameKN": "ಲಿಯಾಕತ್ ಅಲಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2681,8 +2503,7 @@
     "Unnamed: 3": "",
     "AreaKN": "41: ಕೊಟ್ಟಿಗೆಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A180"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2696,8 +2517,7 @@
     "Unnamed: 3": "",
     "AreaKN": "225: ಕೂಡ್ಲು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ",
-    "cellRef": "A181"
+    "NameKN": "ಆರತಿ ಸುಣಧೋಳಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2711,8 +2531,7 @@
     "Unnamed: 3": "",
     "AreaKN": "192: ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A182"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -2726,8 +2545,7 @@
     "Unnamed: 3": "",
     "AreaKN": "70: ಕುಶಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್",
-    "cellRef": "A183"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2741,8 +2559,7 @@
     "Unnamed: 3": "",
     "AreaKN": "14: ಕುವೆಂಪು ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ",
-    "cellRef": "A184"
+    "NameKN": "ಡಾ. ಅನಂತ ಶ್ರೀಲಕ್ಷ್ಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2756,8 +2573,7 @@
     "Unnamed: 3": "",
     "AreaKN": "39: ಲಗ್ಗೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ. ಧಾರೇಶ್ವರ್",
-    "cellRef": "A185"
+    "NameKN": "ಪ್ರಕಾಶ್ ಎಂ. ಧಾರೇಶ್ವರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2771,8 +2587,7 @@
     "Unnamed: 3": "",
     "AreaKN": "177: ಲಕ್ಕಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ",
-    "cellRef": "A186"
+    "NameKN": "ನಾರಾಯಣ ಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2786,8 +2601,7 @@
     "Unnamed: 3": "",
     "AreaKN": "38: ಲಕ್ಷ್ಮೀದೇವಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್",
-    "cellRef": "A187"
+    "NameKN": "ಅಶೋಕ ಬಿರಾದಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2801,8 +2615,7 @@
     "Unnamed: 3": "",
     "AreaKN": "27: ಲಿಂಗಧೀರನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್",
-    "cellRef": "A188"
+    "NameKN": "ದಿನೇಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2816,8 +2629,7 @@
     "Unnamed: 3": "",
     "AreaKN": "84: ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A189"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2831,8 +2643,7 @@
     "Unnamed: 3": "",
     "AreaKN": "179: ಮಡಿವಾಳ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A190"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2846,8 +2657,7 @@
     "Unnamed: 3": "",
     "AreaKN": "48: ಮಹಾಲಕ್ಷ್ಮೀಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾಂತೇಶ್",
-    "cellRef": "A191"
+    "NameKN": "ಮಹಾಂತೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2861,8 +2671,7 @@
     "Unnamed: 3": "",
     "AreaKN": "43: ಮಳತಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗೇಶ್",
-    "cellRef": "A192"
+    "NameKN": "ನಾಗೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2876,8 +2685,7 @@
     "Unnamed: 3": "",
     "AreaKN": "16: ಮಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಶಿಕುಮಾರ್",
-    "cellRef": "A193"
+    "NameKN": "ಶಶಿಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2891,8 +2699,7 @@
     "Unnamed: 3": "",
     "AreaKN": "55: ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಭೀಮಾ ನಾಯಕ್",
-    "cellRef": "A194"
+    "NameKN": "ಭೀಮಾ ನಾಯಕ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2906,8 +2713,7 @@
     "Unnamed: 3": "",
     "AreaKN": "223: ಮಂಗಮ್ಮನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ",
-    "cellRef": "A195"
+    "NameKN": "ಸುಷ್ಮಾ ರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -2921,8 +2727,7 @@
     "Unnamed: 3": "",
     "AreaKN": "65: ಮನೋರಾಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಗೋಪಾಲ್",
-    "cellRef": "A196"
+    "NameKN": "ರಾಜಗೋಪಾಲ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2936,8 +2741,7 @@
     "Unnamed: 3": "",
     "AreaKN": "106: ಮಾರತ್ತಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A197"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2951,8 +2755,7 @@
     "Unnamed: 3": "",
     "AreaKN": "137: ಮಾರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ರಾಕೇಶ್",
-    "cellRef": "A198"
+    "NameKN": "ಡಾ. ರಾಕೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -2966,8 +2769,7 @@
     "Unnamed: 3": "",
     "AreaKN": "140: ಮಾರುತಿ ಮಂದಿರ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ",
-    "cellRef": "A199"
+    "NameKN": "ಡಾ. ಮನೋರಂಜನ್ ಹೆಗ್ಡೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2981,8 +2783,7 @@
     "Unnamed: 3": "",
     "AreaKN": "85: ಮಾರುತಿ ಸೇವಾ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ",
-    "cellRef": "A200"
+    "NameKN": "ಶ್ರೀಧರ್ ಕೊಡೆರೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -2996,8 +2797,7 @@
     "Unnamed: 3": "",
     "AreaKN": "54: ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣ ಗೌಡ",
-    "cellRef": "A201"
+    "NameKN": "ಕೃಷ್ಣ ಗೌಡ"
   },
   {
     "Department": "bbmp_wards",
@@ -3011,8 +2811,7 @@
     "Unnamed: 3": "",
     "AreaKN": "139: ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಿರ್ಮಲಾ",
-    "cellRef": "A202"
+    "NameKN": "ನಿರ್ಮಲಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3026,8 +2825,7 @@
     "Unnamed: 3": "",
     "AreaKN": "105: ಮುನೆಕೊಳ್ಳಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸೋಮಶೇಖರ್",
-    "cellRef": "A203"
+    "NameKN": "ಸೋಮಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3041,8 +2839,7 @@
     "Unnamed: 3": "",
     "AreaKN": "71: ಮುನೇಶ್ವರ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ",
-    "cellRef": "A204"
+    "NameKN": "ಸ್ವಪ್ನಾ ಎನ್.ಕೆ"
   },
   {
     "Department": "bbmp_wards",
@@ -3056,8 +2853,7 @@
     "Unnamed: 3": "",
     "AreaKN": "30: ನಾಗದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೇವರಾಜ್ಯ",
-    "cellRef": "A205"
+    "NameKN": "ದೇವರಾಜ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -3071,8 +2867,7 @@
     "Unnamed: 3": "",
     "AreaKN": "212: ನಾಗನಾಥಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಮಂದಯ್ಯ",
-    "cellRef": "A206"
+    "NameKN": "ಸಮಂದಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -3086,8 +2881,7 @@
     "Unnamed: 3": "",
     "AreaKN": "49: ನಾಗಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A207"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3101,8 +2895,7 @@
     "Unnamed: 3": "",
     "AreaKN": "141: ನಾಗರಭಾವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A208"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3116,8 +2909,7 @@
     "Unnamed: 3": "",
     "AreaKN": "77: ನಾಗವಾರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಂಜುಳಾ",
-    "cellRef": "A209"
+    "NameKN": "ಮಂಜುಳಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3131,8 +2923,7 @@
     "Unnamed: 3": "",
     "AreaKN": "20: ನಾಲಗದರೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚರಣ್ ರಾಜ್",
-    "cellRef": "A210"
+    "NameKN": "ಚರಣ್ ರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3146,8 +2937,7 @@
     "Unnamed: 3": "",
     "AreaKN": "50: ನಾಲ್ವಡಿ ಕೃಷ್ಣರಾಜ ಒಡೆಯರ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅತೀಫ್ ಅಹಮದ್",
-    "cellRef": "A211"
+    "NameKN": "ಅತೀಫ್ ಅಹಮದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3161,8 +2951,7 @@
     "Unnamed: 3": "",
     "AreaKN": "143: ನಾಯಂಡಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಾಗಭೂಷಣ",
-    "cellRef": "A212"
+    "NameKN": "ನಾಗಭೂಷಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -3176,8 +2965,7 @@
     "Unnamed: 3": "",
     "AreaKN": "148: ಹೊಸ ಗುಡ್ಡದಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್",
-    "cellRef": "A213"
+    "NameKN": "ಸುರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3191,8 +2979,7 @@
     "Unnamed: 3": "",
     "AreaKN": "112: ಹೊಸ ತಿಪ್ಪಸಂದರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ",
-    "cellRef": "A214"
+    "NameKN": "ಸ್ವರ್ಣ ಎಂ.ಬಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3206,8 +2993,7 @@
     "Unnamed: 3": "",
     "AreaKN": "168: ನೀಲಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂತೋಷ್",
-    "cellRef": "A215"
+    "NameKN": "ಸಂತೋಷ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3221,8 +3007,7 @@
     "Unnamed: 3": "",
     "AreaKN": "125: ಓಕಳಿಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ",
-    "cellRef": "A216"
+    "NameKN": "ಶಾಂತಾ ಬಡಗಂಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3236,8 +3021,7 @@
     "Unnamed: 3": "",
     "AreaKN": "153: ಪಾದರಾಯನಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುನಿರೆಡ್ಡಿ",
-    "cellRef": "A217"
+    "NameKN": "ಮುನಿರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3251,8 +3035,7 @@
     "Unnamed: 3": "",
     "AreaKN": "193: ಪದ್ಮನಾಭ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A218"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3266,8 +3049,7 @@
     "Unnamed: 3": "",
     "AreaKN": "37: ಪೀಣ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಆಯಿಷಾ",
-    "cellRef": "A219"
+    "NameKN": "ಆಯಿಷಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3281,8 +3063,7 @@
     "Unnamed: 3": "",
     "AreaKN": "22: ಪೀಣ್ಯ ಕೈಗಾರಿಕಾ ಪ್ರದೇಶ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ದೀಪಶ್ರೀ",
-    "cellRef": "A220"
+    "NameKN": "ದೀಪಶ್ರೀ"
   },
   {
     "Department": "bbmp_wards",
@@ -3296,8 +3077,7 @@
     "Unnamed: 3": "",
     "AreaKN": "75: ಪುಲಿಕೇಶಿನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್",
-    "cellRef": "A221"
+    "NameKN": "ಸುರೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3311,8 +3091,7 @@
     "Unnamed: 3": "",
     "AreaKN": "214: ಪುಟ್ಟೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್",
-    "cellRef": "A222"
+    "NameKN": "ಜಯಶಂಕರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3326,8 +3105,7 @@
     "Unnamed: 3": "",
     "AreaKN": "61: ರಾಧಾಕೃಷ್ಣ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ್",
-    "cellRef": "A223"
+    "NameKN": "ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3341,8 +3119,7 @@
     "Unnamed: 3": "",
     "AreaKN": "23: ರಾಜಗೋಪಾಲ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿ",
-    "cellRef": "A224"
+    "NameKN": "ರವಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3356,8 +3133,7 @@
     "Unnamed: 3": "",
     "AreaKN": "132: ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಪದ್ಮರಾಜ್",
-    "cellRef": "A225"
+    "NameKN": "ಪದ್ಮರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3371,8 +3147,7 @@
     "Unnamed: 3": "",
     "AreaKN": "57: ರಾಜಮಹಲ್ ಗುಟ್ಟಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ",
-    "cellRef": "A226"
+    "NameKN": "ಸುರೇಶ್ ರುದ್ರಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -3386,8 +3161,7 @@
     "Unnamed: 3": "",
     "AreaKN": "45: ರಾಜರಾಜೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗಂಗಾಧರ್",
-    "cellRef": "A227"
+    "NameKN": "ಗಂಗಾಧರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3401,8 +3175,7 @@
     "Unnamed: 3": "",
     "AreaKN": "46: ರಾಜೀವ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮುಹಮ್ಮದ್ ಹಾಲಿ ಪಿಂಚಾರ್",
-    "cellRef": "A228"
+    "NameKN": "ಮುಹಮ್ಮದ್ ಹಾಲಿ ಪಿಂಚಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3416,8 +3189,7 @@
     "Unnamed: 3": "",
     "AreaKN": "90: ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಂಕರಪ್ಪ",
-    "cellRef": "A229"
+    "NameKN": "ಶಂಕರಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -3431,8 +3203,7 @@
     "Unnamed: 3": "",
     "AreaKN": "116: ರಾಮಸ್ವಾಮಿಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಂಗನಾಥ್",
-    "cellRef": "A230"
+    "NameKN": "ರಂಗನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3446,8 +3217,7 @@
     "Unnamed: 3": "",
     "AreaKN": "154: ರಾಯಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ",
-    "cellRef": "A231"
+    "NameKN": "ವಿಜಯಲಕ್ಷ್ಮಿ ಸಂಗನಾಳ"
   },
   {
     "Department": "bbmp_wards",
@@ -3461,8 +3231,7 @@
     "Unnamed: 3": "",
     "AreaKN": "207: RBI ಲೇಔಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್",
-    "cellRef": "A232"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಜಾವೇದ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3476,8 +3245,7 @@
     "Unnamed: 3": "",
     "AreaKN": "73: ಎಸ್ ಕೆ ಗಾರ್ಡನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಉಮೇಶ್",
-    "cellRef": "A233"
+    "NameKN": "ಉಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3491,8 +3259,7 @@
     "Unnamed: 3": "",
     "AreaKN": "74: ಸಗಾಯರಪುರಂ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A234"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3506,8 +3273,7 @@
     "Unnamed: 3": "",
     "AreaKN": "118: ಸಂಪಂಗಿರಾಮ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರವಿವಡ್ಡರ್",
-    "cellRef": "A235"
+    "NameKN": "ರವಿವಡ್ಡರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3521,8 +3287,7 @@
     "Unnamed: 3": "",
     "AreaKN": "62: ಸಂಜಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ",
-    "cellRef": "A236"
+    "NameKN": "ತಿಪ್ಪೇಸ್ವಾಮಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3536,8 +3301,7 @@
     "Unnamed: 3": "",
     "AreaKN": "187: ಸಾರಕ್ಕಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A237"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3551,8 +3315,7 @@
     "Unnamed: 3": "",
     "AreaKN": "186: ಶಾಕಾಂಬರಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಾಧವ್ ರಾವ್",
-    "cellRef": "A238"
+    "NameKN": "ಮಾಧವ್ ರಾವ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3566,8 +3329,7 @@
     "Unnamed: 3": "",
     "AreaKN": "52: ಶಕ್ತಿ ಗಣಪತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್",
-    "cellRef": "A239"
+    "NameKN": "ಧರಣೇಂದ್ರಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3581,8 +3343,7 @@
     "Unnamed: 3": "",
     "AreaKN": "51: ಶಂಕರ್ ಮಟ್ಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೇಖಾ",
-    "cellRef": "A240"
+    "NameKN": "ರೇಖಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3596,8 +3357,7 @@
     "Unnamed: 3": "",
     "AreaKN": "166: ಶಾಂತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಧು",
-    "cellRef": "A241"
+    "NameKN": "ಮಧು"
   },
   {
     "Department": "bbmp_wards",
@@ -3611,8 +3371,7 @@
     "Unnamed: 3": "",
     "AreaKN": "119: ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಂದ್ರಶೇಖರ್",
-    "cellRef": "A242"
+    "NameKN": "ಚಂದ್ರಶೇಖರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3626,8 +3385,7 @@
     "Unnamed: 3": "",
     "AreaKN": "131: ಶಿವನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್",
-    "cellRef": "A243"
+    "NameKN": "ಸಂದೀಪ್ ಸಿಂಗ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3641,8 +3399,7 @@
     "Unnamed: 3": "",
     "AreaKN": "161: ಸಿಲ್ವರ್ ಜೂಬ್ಲಿ ಪಾರ್ಕ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಯಶೋವರ್ದನ್",
-    "cellRef": "A244"
+    "NameKN": "ಡಾ. ಯಶೋವರ್ದನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3656,8 +3413,7 @@
     "Unnamed: 3": "",
     "AreaKN": "180: ಸೋಮೇಶ್ವರ ದೇವಸ್ಥಾನ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮದಾಸ್",
-    "cellRef": "A245"
+    "NameKN": "ರಾಮದಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3671,8 +3427,7 @@
     "Unnamed: 3": "",
     "AreaKN": "42: ಶ್ರೀಗಂಧದಕಾವಲ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್",
-    "cellRef": "A246"
+    "NameKN": "ಕೃಷ್ಣಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3686,8 +3441,7 @@
     "Unnamed: 3": "",
     "AreaKN": "197: ಶ್ರೀನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ",
-    "cellRef": "A247"
+    "NameKN": "ವೆಂಕಟೇಶ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3701,8 +3455,7 @@
     "Unnamed: 3": "",
     "AreaKN": "130: ಶ್ರೀರಾಮಮಂದಿರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಘವೇಂದ್ರ",
-    "cellRef": "A248"
+    "NameKN": "ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "bbmp_wards",
@@ -3716,8 +3469,7 @@
     "Unnamed: 3": "",
     "AreaKN": "83: ಸುಬ್ಬಯ್ಯನಪಾಳ್ಯ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಿವಣ್ಣ",
-    "cellRef": "A249"
+    "NameKN": "ಶಿವಣ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -3731,8 +3483,7 @@
     "Unnamed: 3": "",
     "AreaKN": "124: ಸುಭಾಷ್ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶಾಂತಲಾ",
-    "cellRef": "A250"
+    "NameKN": "ಶಾಂತಲಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3746,8 +3497,7 @@
     "Unnamed: 3": "",
     "AreaKN": "203: ಸುಬ್ರಹ್ಮಣ್ಯಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ",
-    "cellRef": "A251"
+    "NameKN": "ರಾಮಕೃಷ್ಣಯ್ಯ"
   },
   {
     "Department": "bbmp_wards",
@@ -3761,8 +3511,7 @@
     "Unnamed: 3": "",
     "AreaKN": "59: ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್",
-    "cellRef": "A252"
+    "NameKN": "ಮಲ್ಲಿಕಾರ್ಜುನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3776,8 +3525,7 @@
     "Unnamed: 3": "",
     "AreaKN": "178: ಸುದ್ದಗುಂಟೆ ಪಾಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A253"
+    "NameKN": ""
   },
   {
     "Department": "bbmp_wards",
@@ -3791,8 +3539,7 @@
     "Unnamed: 3": "",
     "AreaKN": "25: ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮನೋಹರ್",
-    "cellRef": "A254"
+    "NameKN": "ಮನೋಹರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3806,8 +3553,7 @@
     "Unnamed: 3": "",
     "AreaKN": "162: ಸುಂಕೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ವಿಶ್ವನಾಥ್",
-    "cellRef": "A255"
+    "NameKN": "ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3821,8 +3567,7 @@
     "Unnamed: 3": "",
     "AreaKN": "200: ಸ್ವಾಮಿ ವಿವೇಕಾನಂದ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ",
-    "cellRef": "A256"
+    "NameKN": "ನರಸಿಂಹ ಮೂರ್ತಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -3836,8 +3581,7 @@
     "Unnamed: 3": "",
     "AreaKN": "19: ಟಿ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಕೋಮಲ್ ಕೆ.ಆರ್",
-    "cellRef": "A257"
+    "NameKN": "ಡಾ. ಕೋಮಲ್ ಕೆ.ಆರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3851,8 +3595,7 @@
     "Unnamed: 3": "",
     "AreaKN": "7: ಥಣಿಸಂದ್ರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚನ್ನಗೌಡ",
-    "cellRef": "A258"
+    "NameKN": "ಚನ್ನಗೌಡ"
   },
   {
     "Department": "bbmp_wards",
@@ -3866,8 +3609,7 @@
     "Unnamed: 3": "",
     "AreaKN": "29: ಉಲ್ಲಾಳು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್",
-    "cellRef": "A259"
+    "NameKN": "ರಾಜಪ್ಪ ಕೆ.ಎನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3881,8 +3623,7 @@
     "Unnamed: 3": "",
     "AreaKN": "121: ಹಲಸೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಮಹಾದೇವ",
-    "cellRef": "A260"
+    "NameKN": "ಮಹಾದೇವ"
   },
   {
     "Department": "bbmp_wards",
@@ -3896,8 +3637,7 @@
     "Unnamed: 3": "",
     "AreaKN": "202: ಉತ್ತರಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಚಾಮರಾಜು",
-    "cellRef": "A261"
+    "NameKN": "ಚಾಮರಾಜು"
   },
   {
     "Department": "bbmp_wards",
@@ -3911,8 +3651,7 @@
     "Unnamed: 3": "",
     "AreaKN": "169: ವನ್ನಾರಪೇಟ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಅಪರ್ಣಾ",
-    "cellRef": "A262"
+    "NameKN": "ಅಪರ್ಣಾ"
   },
   {
     "Department": "bbmp_wards",
@@ -3926,8 +3665,7 @@
     "Unnamed: 3": "",
     "AreaKN": "104: ವರ್ತೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರೋಹಿತ್",
-    "cellRef": "A263"
+    "NameKN": "ರೋಹಿತ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3941,8 +3679,7 @@
     "Unnamed: 3": "",
     "AreaKN": "117: ವಸಂತನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಮೇಶ್",
-    "cellRef": "A264"
+    "NameKN": "ರಮೇಶ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3956,8 +3693,7 @@
     "Unnamed: 3": "",
     "AreaKN": "204: ವಸಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯರಾಜ್",
-    "cellRef": "A265"
+    "NameKN": "ಜಯರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -3971,8 +3707,7 @@
     "Unnamed: 3": "",
     "AreaKN": "199: ವಿದ್ಯಾಪೀಠ ವಾರ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಕೃಷ್ಣಪ್ಪ",
-    "cellRef": "A266"
+    "NameKN": "ಕೃಷ್ಣಪ್ಪ"
   },
   {
     "Department": "bbmp_wards",
@@ -3986,8 +3721,7 @@
     "Unnamed: 3": "",
     "AreaKN": "13: ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರಾಜಣ್ಣ",
-    "cellRef": "A267"
+    "NameKN": "ರಾಜಣ್ಣ"
   },
   {
     "Department": "bbmp_wards",
@@ -4001,8 +3735,7 @@
     "Unnamed: 3": "",
     "AreaKN": "145: ವಿಜಯನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ನಟರಾಜ್",
-    "cellRef": "A268"
+    "NameKN": "ನಟರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4016,8 +3749,7 @@
     "Unnamed: 3": "",
     "AreaKN": "89: ವಿಜಿನಾಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A269"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4031,8 +3763,7 @@
     "Unnamed: 3": "",
     "AreaKN": "95: ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಜಯಶಂಕರ್",
-    "cellRef": "A270"
+    "NameKN": "ಜಯಶಂಕರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4046,8 +3777,7 @@
     "Unnamed: 3": "",
     "AreaKN": "163: ವಿಶ್ವೇಶ್ವರ ಪುರಂ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಶೀಲಾ ಎನ್.",
-    "cellRef": "A271"
+    "NameKN": "ಸುಶೀಲಾ ಎನ್."
   },
   {
     "Department": "bbmp_wards",
@@ -4061,8 +3791,7 @@
     "Unnamed: 3": "",
     "AreaKN": "64: ವಿಶ್ವನಾಥ ನಾಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶರತ್ ಕುಮಾರ್",
-    "cellRef": "A272"
+    "NameKN": "ಶರತ್ ಕುಮಾರ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4076,8 +3805,7 @@
     "Unnamed: 3": "",
     "AreaKN": "53: ವೃಷಭಾವತಿ ನಗರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಡಾ. ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್",
-    "cellRef": "A273"
+    "NameKN": "ಡಾ. ಶ್ರೀನಾಥ್ ಡಿ.ಎನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4091,8 +3819,7 @@
     "Unnamed: 3": "",
     "AreaKN": "103: ವೈಟ್ ಫೀಲ್ಡ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ರುದ್ರಮುನಿ",
-    "cellRef": "A274"
+    "NameKN": "ರುದ್ರಮುನಿ"
   },
   {
     "Department": "bbmp_wards",
@@ -4106,8 +3833,7 @@
     "Unnamed: 3": "",
     "AreaKN": "188: ಯಡಿಯೂರು",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸ್",
-    "cellRef": "A275"
+    "NameKN": "ಶ್ರೀನಿವಾಸ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4121,8 +3847,7 @@
     "Unnamed: 3": "",
     "AreaKN": "4: ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಗುರುರಾಜ್",
-    "cellRef": "A276"
+    "NameKN": "ಗುರುರಾಜ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4136,8 +3861,7 @@
     "Unnamed: 3": "",
     "AreaKN": "205: ಯೆಲ್ಚೇನಹಳ್ಳಿ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಶ್ರೀನಿವಾಸನ್",
-    "cellRef": "A277"
+    "NameKN": "ಶ್ರೀನಿವಾಸನ್"
   },
   {
     "Department": "bbmp_wards",
@@ -4151,8 +3875,7 @@
     "Unnamed: 3": "",
     "AreaKN": "35: ಯಶವಂತಪುರ",
     "DesignationKN": "ನೋಡಲ್ ಅಧಿಕಾರಿ",
-    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ",
-    "cellRef": "A278"
+    "NameKN": "ಸುಧಾಕರ ರೆಡ್ಡಿ"
   },
   {
     "Department": "bbmp_zone",
@@ -4166,8 +3889,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ರಮ್ಯಾ ಎಸ್.",
-    "cellRef": "A279"
+    "NameKN": "ರಮ್ಯಾ ಎಸ್."
   },
   {
     "Department": "bbmp_zone",
@@ -4181,8 +3903,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಹೆಚ್ .ಸಿ. ಗಿರೀಶ್",
-    "cellRef": "A280"
+    "NameKN": "ಹೆಚ್ .ಸಿ. ಗಿರೀಶ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4196,8 +3917,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್.",
-    "cellRef": "A281"
+    "NameKN": "ಸ್ನೇಹಲ್ ಆರ್."
   },
   {
     "Department": "bbmp_zone",
@@ -4211,8 +3931,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕೆ.ಎನ್. ರಮೇಶ್",
-    "cellRef": "A282"
+    "NameKN": "ಕೆ.ಎನ್. ರಮೇಶ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4226,8 +3945,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಸತೀಶ ಬಿ.ಸಿ",
-    "cellRef": "A283"
+    "NameKN": "ಸತೀಶ ಬಿ.ಸಿ"
   },
   {
     "Department": "bbmp_zone",
@@ -4241,8 +3959,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್",
-    "cellRef": "A284"
+    "NameKN": "ವಿನೋತ್ ಪ್ರಿಯಾ ಆರ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4256,8 +3973,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಅರ್ಚನಾ ಎಂ.ಎಸ್",
-    "cellRef": "A285"
+    "NameKN": "ಅರ್ಚನಾ ಎಂ.ಎಸ್"
   },
   {
     "Department": "bbmp_zone",
@@ -4271,8 +3987,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ವಲಯ ಆಯುಕ್ತರು",
-    "NameKN": "ಕರೀಗೌಡ",
-    "cellRef": "A286"
+    "NameKN": "ಕರೀಗೌಡ"
   },
   {
     "Department": "bescom_division",
@@ -4286,8 +4001,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A287"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4301,8 +4015,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A288"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4316,8 +4029,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A289"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4331,8 +4043,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A290"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4346,8 +4057,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A291"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4361,8 +4071,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A292"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4376,8 +4085,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A293"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4391,8 +4099,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A294"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4406,8 +4113,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A295"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4421,8 +4127,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A296"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4436,8 +4141,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A297"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4451,8 +4155,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A298"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4466,8 +4169,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A299"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4481,8 +4183,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A300"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4496,8 +4197,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A301"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4511,8 +4211,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A302"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4526,8 +4225,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A303"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4541,8 +4239,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A304"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4556,8 +4253,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A305"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4571,8 +4267,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A306"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4586,8 +4281,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A307"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4601,8 +4295,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A308"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4616,8 +4309,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A309"
+    "NameKN": ""
   },
   {
     "Department": "bescom_division",
@@ -4631,8 +4323,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನ ಸೌಧ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A310"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4646,8 +4337,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A311"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_division",
@@ -4661,8 +4351,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A312"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4676,8 +4365,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A313"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4691,8 +4379,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A314"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4706,8 +4393,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ1 ರಾಜಾಜಿನಗರ 2ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A315"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4721,8 +4407,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C2 ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A316"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4736,8 +4421,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C3 ಜಾಲಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A317"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4751,8 +4435,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C4 ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A318"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4766,8 +4449,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C5 ಕಾವಲ್ ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A319"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4781,8 +4463,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ6 ಮತ್ತಿಕೆರೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A320"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4796,8 +4477,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ7 ಯಲಹಂಕ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A321"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4811,8 +4491,7 @@
     "Unnamed: 3": "",
     "AreaKN": "C8 ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A322"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4826,8 +4505,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ9 ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A323"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4841,8 +4519,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A324"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4856,8 +4533,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A325"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4871,8 +4547,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A326"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -4886,8 +4561,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A327"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4901,8 +4575,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ1 ಪಿಳ್ಳಣ್ಣ ಗಾರ್ಡನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A328"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4916,8 +4589,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ10 ಬೆನ್ನಿಗಾನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A329"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4931,8 +4603,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 11 ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A330"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4946,8 +4617,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ 12 ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A331"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4961,8 +4631,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ2 ಶಿವಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A332"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4976,8 +4645,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E3 MG ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A333"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -4991,8 +4659,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E4 ವೈಟ್‌ಫೀಲ್ಡ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A334"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5006,8 +4673,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E5 ಕುಕ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A335"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5021,8 +4687,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇ6 ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A336"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5036,8 +4701,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E7 ದೂರವಾಣಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A337"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5051,8 +4715,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E8 ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A338"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5066,8 +4729,7 @@
     "Unnamed: 3": "",
     "AreaKN": "E9 ನಾಗವಾರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A339"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5081,8 +4743,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A340"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5096,8 +4757,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A341"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5111,8 +4771,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 1 ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A342"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5126,8 +4785,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 2 ಅಂಜನನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A343"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5141,8 +4799,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ 3 ಕಗ್ಗಲಿಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A344"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5156,8 +4813,7 @@
     "Unnamed: 3": "",
     "AreaKN": "K4 RR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A345"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5171,8 +4827,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A346"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5186,8 +4841,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿಎಫ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A347"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5201,8 +4855,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A348"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5216,8 +4869,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A349"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5231,8 +4883,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಿಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A350"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5246,8 +4897,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N1 ವೆಸ್ಟ್ ಕಾರ್ಡ್ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A351"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5261,8 +4911,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N10 ಮೂಡಲಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A352"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5276,8 +4925,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N2 KHB ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A353"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5291,8 +4939,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 3 ಬಸವೇಶ್ವರನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A354"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5306,8 +4953,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N4 ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A355"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5321,8 +4967,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N5 SRS ಗೇಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A356"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5336,8 +4981,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N6 ಸುಂಕದಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A357"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5351,8 +4995,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N7 ಕುರುಬರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A358"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5366,8 +5009,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎನ್ 8 ಉಳ್ಳಾಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A359"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5381,8 +5023,7 @@
     "Unnamed: 3": "",
     "AreaKN": "N9 ಸೋಲದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A360"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5396,8 +5037,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A361"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5411,8 +5051,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 1 ಜಯನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A362"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5426,8 +5065,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 10 ಬನ್ನೇರುಘಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A363"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5441,8 +5079,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S11 HSR ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A364"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5456,8 +5093,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 12 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A365"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5471,8 +5107,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 13 ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A366"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5486,8 +5121,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 14 ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A367"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5501,8 +5135,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 15 ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A368"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5516,8 +5149,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S16 ಮಡಿವಾಳ SDO",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A369"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5531,8 +5163,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S17 HAL",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A370"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5546,8 +5177,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S18 ಚಿಕ್ಕ ಕಲ್ಲಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A371"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5561,8 +5191,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 19 ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A372"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5576,8 +5205,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 2 ವಿಲ್ಸ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A373"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5591,8 +5219,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷ್೨೦ ಆಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A374"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5606,8 +5233,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S3 ಆಸ್ಟಿನ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A375"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5621,8 +5247,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S4 ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A376"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5636,8 +5261,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S5 ISRO ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A377"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5651,8 +5275,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 6 ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A378"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5666,8 +5289,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್7 ಮುರುಗೇಶಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A379"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5681,8 +5303,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್ 8 ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A380"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5696,8 +5317,7 @@
     "Unnamed: 3": "",
     "AreaKN": "S9 ಬನಶಂಕರಿ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A381"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5711,8 +5331,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A382"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5726,8 +5345,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ1",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A383"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5741,8 +5359,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ2",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A384"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5756,8 +5373,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ ಉಪ ವಿಭಾಗ3 (ಕ್ಯಾತ್ಸಂದ್ರ)",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A385"
+    "NameKN": ""
   },
   {
     "Department": "bescom_subdivision",
@@ -5771,8 +5387,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W1 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A386"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5786,8 +5401,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W2 ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A387"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5801,8 +5415,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W3 ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A388"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5816,8 +5429,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W4 AR ವೃತ್ತ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A389"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5831,8 +5443,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W5 ಕಬ್ಬನ್‌ಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A390"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5846,8 +5457,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W6 ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A391"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5861,8 +5471,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W7 ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A392"
+    "NameKN": "-"
   },
   {
     "Department": "bescom_subdivision",
@@ -5876,8 +5485,7 @@
     "Unnamed: 3": "",
     "AreaKN": "W8 NR ಕಾಲೋನಿ",
     "DesignationKN": "ಸಹಾಯಕ ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "-",
-    "cellRef": "A393"
+    "NameKN": "-"
   },
   {
     "Department": "bwssb_division",
@@ -5891,8 +5499,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇಂದ್ರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ",
-    "cellRef": "A394"
+    "NameKN": "ನಾಗೇಂದ್ರ ಬಿ"
   },
   {
     "Department": "bwssb_division",
@@ -5906,8 +5513,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೂರ್ವ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್",
-    "cellRef": "A395"
+    "NameKN": "ಮಿರ್ಜಾ ಅನ್ವರ್"
   },
   {
     "Department": "bwssb_division",
@@ -5921,8 +5527,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಜಯಪ್ರಕಾಶ್",
-    "cellRef": "A396"
+    "NameKN": "ಜಯಪ್ರಕಾಶ್"
   },
   {
     "Department": "bwssb_division",
@@ -5936,8 +5541,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಈಶಾನ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ",
-    "cellRef": "A397"
+    "NameKN": "ರೂಪಾ ನೀಲಗುಂದ"
   },
   {
     "Department": "bwssb_division",
@@ -5951,8 +5555,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A398"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -5966,8 +5569,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A399"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -5981,8 +5583,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A400"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -5996,8 +5597,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಹರಿನಾಥ್ ಆರ್",
-    "cellRef": "A401"
+    "NameKN": "ಹರಿನಾಥ್ ಆರ್"
   },
   {
     "Department": "bwssb_division",
@@ -6011,8 +5611,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಾಯುವ್ಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್",
-    "cellRef": "A402"
+    "NameKN": "ಮಿರಗಂಜೆ ಮಂಜುನಾಥ್"
   },
   {
     "Department": "bwssb_division",
@@ -6026,8 +5625,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್.",
-    "cellRef": "A403"
+    "NameKN": "ಭರತ್ ಕುಮಾರ್ ಎಸ್."
   },
   {
     "Department": "bwssb_division",
@@ -6041,8 +5639,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A404"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_division",
@@ -6056,8 +5653,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 1",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ನಾಗರಾಜ್ ಕೆ.",
-    "cellRef": "A405"
+    "NameKN": "ನಾಗರಾಜ್ ಕೆ."
   },
   {
     "Department": "bwssb_division",
@@ -6071,8 +5667,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ನೇಯ - 2",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಬಸವರಾಜ ಎನ್.",
-    "cellRef": "A406"
+    "NameKN": "ಬಸವರಾಜ ಎನ್."
   },
   {
     "Department": "bwssb_division",
@@ -6086,8 +5681,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೈಋತ್ಯ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಸ್ನೇಹಾ ವಿ.",
-    "cellRef": "A407"
+    "NameKN": "ಸ್ನೇಹಾ ವಿ."
   },
   {
     "Department": "bwssb_division",
@@ -6101,8 +5695,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಶ್ಚಿಮ",
     "DesignationKN": "ಕಾರ್ಯನಿರ್ವಾಹಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಟಿ. ಚಂದ್ರಶೇಖರ್ ಪ್ರಸಾದ್",
-    "cellRef": "A408"
+    "NameKN": "ಟಿ. ಚಂದ್ರಶೇಖರ್ ಪ್ರಸಾದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6116,8 +5709,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ನಾರಾಯಣಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A409"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6131,8 +5723,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ",
-    "cellRef": "A410"
+    "NameKN": " ಮಂಜುನಾಥ್ / ಸಹನಾಬ್ ಬೇಗಂ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6146,8 +5737,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎ.ಇ.ಸಿ.ಎಸ್ ಲೇಔಟ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್",
-    "cellRef": "A411"
+    "NameKN": " ಲತೀಫ್ ಸಾಹೇಬ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6161,8 +5751,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಗ್ರಹಾರ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
-    "cellRef": "A412"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6176,8 +5765,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನಂದ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್",
-    "cellRef": "A413"
+    "NameKN": " ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6191,8 +5779,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A414"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6206,8 +5793,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಶ್ವನಾಥ್",
-    "cellRef": "A415"
+    "NameKN": " ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6221,8 +5807,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಹುಬಲಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
-    "cellRef": "A416"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -6236,8 +5821,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪೂರ್ಣಿಮಾ",
-    "cellRef": "A417"
+    "NameKN": " ಪೂರ್ಣಿಮಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6251,8 +5835,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A418"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6266,8 +5849,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A419"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6281,8 +5863,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನಪ ಪಾರ್ಕ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A420"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6296,8 +5877,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A421"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6311,8 +5891,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "",
-    "cellRef": "A422"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6326,8 +5905,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BEML ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A423"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6341,8 +5919,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಷ್ಯಂ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್",
-    "cellRef": "A424"
+    "NameKN": " ಕಿಶೋರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6356,8 +5933,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-I",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A425"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6371,8 +5947,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BSK-II",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A426"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6386,8 +5961,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM I & II",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ.ಪಿ.",
-    "cellRef": "A427"
+    "NameKN": " ಹನುಮಂತರಾಜು ಸಿ.ಪಿ."
   },
   {
     "Department": "bwssb_service_station",
@@ -6401,8 +5975,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈರಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ",
-    "cellRef": "A428"
+    "NameKN": " ಶ್ರೀಜಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6416,8 +5989,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ.ರಾಮನ್ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A429"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6431,8 +6003,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ / ಹೊರಮಾವು / ಕಲ್ಕೆರೆ / ಕೊತ್ತನೂರು-ಬೈರತಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್",
-    "cellRef": "A430"
+    "NameKN": " ಆನಂದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6446,8 +6017,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ",
-    "cellRef": "A431"
+    "NameKN": " ಪ್ರವೀಣ್ .ಜಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6461,8 +6031,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ",
-    "cellRef": "A432"
+    "NameKN": " ರಾಮೇಗೌಡ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6476,8 +6045,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಾಲಭಾಗ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ",
-    "cellRef": "A433"
+    "NameKN": " ಸೀಮಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6491,8 +6059,7 @@
     "Unnamed: 3": "",
     "AreaKN": "CLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಡಿ.ಎಸ್. ರಂಗಯ್ಯ",
-    "cellRef": "A434"
+    "NameKN": " ಡಿ.ಎಸ್. ರಂಗಯ್ಯ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6506,8 +6073,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲ್ಸ್ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಶ್ ಎಸ್.ಡಿ",
-    "cellRef": "A435"
+    "NameKN": " ರಾಜೇಶ್ ಎಸ್.ಡಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6521,8 +6087,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಗಿರಿ I&II",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A436"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6536,8 +6101,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಸಂದ್ರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು",
-    "cellRef": "A437"
+    "NameKN": " ದಿನೇಶ್ ಬಳ್ಳು"
   },
   {
     "Department": "bwssb_service_station",
@@ -6551,8 +6115,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡನೆಕುಂದಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A438"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6566,8 +6129,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಮತಾ ಎಂ.ಎಚ್",
-    "cellRef": "A439"
+    "NameKN": " ಮಮತಾ ಎಂ.ಎಚ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6581,8 +6143,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಜರ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್",
-    "cellRef": "A440"
+    "NameKN": " ರಾಹುಲ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6596,8 +6157,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನ ಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A441"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6611,8 +6171,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗೇನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್",
-    "cellRef": "A442"
+    "NameKN": " ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6626,8 +6185,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್",
-    "cellRef": "A443"
+    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6641,8 +6199,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "",
-    "cellRef": "A444"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6656,8 +6213,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL ವಿಮಾನ ನಿಲ್ದಾಣ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಂಜನ್",
-    "cellRef": "A445"
+    "NameKN": " ರಂಜನ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6671,8 +6227,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
-    "cellRef": "A446"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6686,8 +6241,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಡಿಶ್",
-    "cellRef": "A447"
+    "NameKN": " ನಾಡಿಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6701,8 +6255,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HGR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್",
-    "cellRef": "A448"
+    "NameKN": " ಮಹೇಶ್ ಕುಮಾರ್ ಕೆ.ಎಸ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6716,8 +6269,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಬೇಗೌಡ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ",
-    "cellRef": "A449"
+    "NameKN": " ಶ್ರೀಜಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6731,8 +6283,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂಡಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕುಮಾರ್",
-    "cellRef": "A450"
+    "NameKN": " ರವಿ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6746,8 +6297,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸ್ವಾತಿ",
-    "cellRef": "A451"
+    "NameKN": " ಸ್ವಾತಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6761,8 +6311,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೆರೆಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಧರ್ ಎಸ್",
-    "cellRef": "A452"
+    "NameKN": " ಶ್ರೀಧರ್ ಎಸ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6776,8 +6325,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HRBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ",
-    "cellRef": "A453"
+    "NameKN": " ದಾವಲ್ ಸಾಬ್ ಕರ್ನಾಚಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6791,8 +6339,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A454"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6806,8 +6353,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಐಡಿಯಲ್ ಹೋಮ್ಸ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
-    "cellRef": "A455"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6821,8 +6367,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಶಿ ಕುಮಾರ್",
-    "cellRef": "A456"
+    "NameKN": " ಶಶಿ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6836,8 +6381,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಸ್ರೋ ಲೇಔಟ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A457"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6851,8 +6395,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಟ್ಟಮಡು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಿಂಗರಾಜು",
-    "cellRef": "A458"
+    "NameKN": " ಲಿಂಗರಾಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -6866,8 +6409,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ ಜೆ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ",
-    "cellRef": "A459"
+    "NameKN": " ಲಕ್ಷ್ಮೀ ನಾರಾಯಣ ಗೌಡ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6881,8 +6423,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಕ್ಕೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರದೀಪ್",
-    "cellRef": "A460"
+    "NameKN": " ಪ್ರದೀಪ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -6896,8 +6437,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಮಹಲ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ",
-    "cellRef": "A461"
+    "NameKN": " ಜಯಶ್ರೀ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6911,8 +6451,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ 'ಟಿ' ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ",
-    "cellRef": "A462"
+    "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6926,8 +6465,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ 4ನೇ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶ್ರೀಜಾ",
-    "cellRef": "A463"
+    "NameKN": " ಶ್ರೀಜಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6941,8 +6479,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಬಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "",
-    "cellRef": "A464"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -6956,8 +6493,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾನ್ಸನ್ ಮಾರುಕಟ್ಟೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ",
-    "cellRef": "A465"
+    "NameKN": " ಮುರಳಿ ಸಿ ಪಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6971,8 +6507,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 1ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಲಕ್ಷ್ಮಿ",
-    "cellRef": "A466"
+    "NameKN": " ಲಕ್ಷ್ಮಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -6986,8 +6521,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 2ನೇ ಹಂತ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ರಮ್",
-    "cellRef": "A467"
+    "NameKN": " ಅಕ್ರಮ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7001,8 +6535,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ 3ನೇ ಹಂತ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A468"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7016,8 +6549,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಜಿ ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A469"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7031,8 +6563,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪುರಂ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A470"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7046,8 +6577,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ/ ಕಮಲಾನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶಿವಕುಮಾರ್",
-    "cellRef": "A471"
+    "NameKN": " ಶಿವಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7061,8 +6591,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕತ್ರಿಗುಪ್ಪೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮುದಾ",
-    "cellRef": "A472"
+    "NameKN": " ಕುಮುದಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7076,8 +6605,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್",
-    "cellRef": "A473"
+    "NameKN": " ರಾಹುಲ್ ರಾಥೋಡ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7091,8 +6619,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೇತಮಾರನ ಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ",
-    "cellRef": "A474"
+    "NameKN": " ಪುಷ್ಪಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7106,8 +6633,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ಟವರ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಜಯಶ್ರೀ",
-    "cellRef": "A475"
+    "NameKN": " ಜಯಶ್ರೀ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7121,8 +6647,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿಕಾಸ್ ಡಿ.ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್.ಆರ್",
-    "cellRef": "A476"
+    "NameKN": " ವಿಕಾಸ್ ಡಿ.ಎಸ್ / ನಾಗರಾಜ್ ಎಸ್.ಆರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7136,8 +6661,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A477"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7151,8 +6675,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಚಿಕ್ಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A478"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7166,8 +6689,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A479"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7181,8 +6703,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಜಾನನ",
-    "cellRef": "A480"
+    "NameKN": " ಗಜಾನನ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7196,8 +6717,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರುದಿನ್ನೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಅಕ್ಷಯ್ ಸಿ",
-    "cellRef": "A481"
+    "NameKN": " ಅಕ್ಷಯ್ ಸಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7211,8 +6731,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರ ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
-    "cellRef": "A482"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7226,8 +6745,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪ್ರೀತಿ ಜೆ",
-    "cellRef": "A483"
+    "NameKN": " ಪ್ರೀತಿ ಜೆ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7241,8 +6759,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗರಾಜಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಜಿನಿ ಎ",
-    "cellRef": "A484"
+    "NameKN": " ರಜಿನಿ ಎ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7256,8 +6773,7 @@
     "Unnamed: 3": "",
     "AreaKN": "LLR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸೀಮಾ",
-    "cellRef": "A485"
+    "NameKN": " ಸೀಮಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7271,8 +6787,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಚಲಿಬೆಟ್ಟ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
-    "cellRef": "A486"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7286,8 +6801,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್",
-    "cellRef": "A487"
+    "NameKN": " ದಿನೇಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7301,8 +6815,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಯೂಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ",
-    "cellRef": "A488"
+    "NameKN": " ಪುಷ್ಪಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7316,8 +6829,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾನಾ",
-    "cellRef": "A489"
+    "NameKN": " ಸುಹಾನಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7331,8 +6843,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MEI ಲೇಔಟ್ (ದಾಸರಹಳ್ಳಿ)",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು",
-    "cellRef": "A490"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಮಂಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -7346,8 +6857,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MNK ಪಾರ್ಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ",
-    "cellRef": "A491"
+    "NameKN": " ಕಾರ್ತಿಕ್ ಎಂ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7361,8 +6871,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಲ ಪಾಳ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸತೀಶ್ ಟಿ",
-    "cellRef": "A492"
+    "NameKN": " ಸತೀಶ್ ಟಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7376,8 +6885,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೌಂಟ್ ಜಾಯ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುದರ್ಶನ್ ಡಿ.ಎನ್",
-    "cellRef": "A493"
+    "NameKN": " ಸುದರ್ಶನ್ ಡಿ.ಎನ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7391,8 +6899,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಿನೇಶ್",
-    "cellRef": "A494"
+    "NameKN": " ದಿನೇಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7406,8 +6913,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಹರ್ಷ ವಿ",
-    "cellRef": "A495"
+    "NameKN": " ಹರ್ಷ ವಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7421,8 +6927,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗೇಂದ್ರ ಬ್ಲಾಕ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಉಷಾ ಸಿ.ಆರ್",
-    "cellRef": "A496"
+    "NameKN": " ಉಷಾ ಸಿ.ಆರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7436,8 +6941,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದುಷ್ಯಂತ್",
-    "cellRef": "A497"
+    "NameKN": " ದುಷ್ಯಂತ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7451,8 +6955,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ BEL ರಸ್ತೆ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ",
-    "cellRef": "A498"
+    "NameKN": " ದಸ್ತಗೀರ್ ಬಾಷಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7466,8 +6969,7 @@
     "Unnamed: 3": "",
     "AreaKN": "OMBR",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ",
-    "cellRef": "A499"
+    "NameKN": " ಮಂಜುನಾಥ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7481,8 +6983,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಗಣೇಶ್",
-    "cellRef": "A500"
+    "NameKN": " ಗಣೇಶ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7496,8 +6997,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಂದೀಪ್",
-    "cellRef": "A501"
+    "NameKN": " ಸಂದೀಪ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7511,8 +7011,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-1",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಹುಲ್",
-    "cellRef": "A502"
+    "NameKN": " ರಾಹುಲ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7526,8 +7025,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಲ್ಲಾನ ಗಾರ್ಡನ್-2",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ",
-    "cellRef": "A503"
+    "NameKN": " ಮಲ್ಲಪ್ಪ ಮಾಳಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7541,8 +7039,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿಪಿ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಶೇಖರ್",
-    "cellRef": "A504"
+    "NameKN": " ಶೇಖರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7556,8 +7053,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಪುಷ್ಪಾ",
-    "cellRef": "A505"
+    "NameKN": " ಪುಷ್ಪಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7571,8 +7067,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್",
-    "cellRef": "A506"
+    "NameKN": " ಆನಂದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7586,8 +7081,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕುಮಾರ್",
-    "cellRef": "A507"
+    "NameKN": " ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7601,8 +7095,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಚಿಂತನ ಕೆ",
-    "cellRef": "A508"
+    "NameKN": " ಚಿಂತನ ಕೆ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7616,8 +7109,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ್ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ",
-    "cellRef": "A509"
+    "NameKN": " ದಸ್ತಗಿರಿ ಬಾಷಾ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7631,8 +7123,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸಿದ್ದರಾಜು",
-    "cellRef": "A510"
+    "NameKN": " ಸಿದ್ದರಾಜು"
   },
   {
     "Department": "bwssb_service_station",
@@ -7646,8 +7137,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಧಾಮ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಸುಹಾಸ್",
-    "cellRef": "A511"
+    "NameKN": " ಸುಹಾಸ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7661,8 +7151,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರವಿ ಕಿರಣ್ (ಐ/ಸಿ)",
-    "cellRef": "A512"
+    "NameKN": " ರವಿ ಕಿರಣ್ (ಐ/ಸಿ)"
   },
   {
     "Department": "bwssb_service_station",
@@ -7676,8 +7165,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ",
-    "cellRef": "A513"
+    "NameKN": " ಧನಲಕ್ಷ್ಮಿ ಎಂ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7691,8 +7179,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ನಗರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್",
-    "cellRef": "A514"
+    "NameKN": " ಮೊಹಮ್ಮದ್ ಮುದಾಸಿರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7706,8 +7193,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯ್ ನಗರ OHT",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A515"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7721,8 +7207,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಾ ಬ್ಯಾಂಕ್ ಲೇಔಟ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ಆ.ರ್",
-    "cellRef": "A516"
+    "NameKN": " ನಾಗರಾಜ್ ಎಸ್ಆ.ರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7736,8 +7221,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಆನಂದ್",
-    "cellRef": "A517"
+    "NameKN": " ಆನಂದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7751,8 +7235,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವೇಶ್ವರಯ್ಯ ಬಡಾವಣೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A518"
+    "NameKN": ""
   },
   {
     "Department": "bwssb_service_station",
@@ -7766,8 +7249,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ OHT",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಮೇಗೌಡ ಬಿ",
-    "cellRef": "A519"
+    "NameKN": " ರಾಮೇಗೌಡ ಬಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7781,8 +7263,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವಿ ಪುರಂ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": "ಪ್ರಹ್ಲಾದ್",
-    "cellRef": "A520"
+    "NameKN": "ಪ್ರಹ್ಲಾದ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7796,8 +7277,7 @@
     "Unnamed: 3": "",
     "AreaKN": "WCR-I",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್",
-    "cellRef": "A521"
+    "NameKN": " ರಾಜೇಂದ್ರ ಕುಮಾರ್"
   },
   {
     "Department": "bwssb_service_station",
@@ -7811,8 +7291,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು",
-    "cellRef": "A522"
+    "NameKN": " ಮಂಜುನಾಥ ಹಳ್ಳೂರು"
   },
   {
     "Department": "bwssb_service_station",
@@ -7826,8 +7305,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಓಲ್ಡ್ ಟೌನ್",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ.ಬಿ",
-    "cellRef": "A523"
+    "NameKN": " ವಿನಯ್ ಕುಮಾರ್ ಪಿ.ಬಿ"
   },
   {
     "Department": "bwssb_service_station",
@@ -7841,8 +7319,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "ಸಹಾಯಕ ಇಂಜಿನಿಯರ್",
-    "NameKN": " ಕಿಶೋರ್",
-    "cellRef": "A524"
+    "NameKN": " ಕಿಶೋರ್"
   },
   {
     "Department": "police_city",
@@ -7856,8 +7333,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A525"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7871,8 +7347,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A526"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7886,8 +7361,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A527"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7901,8 +7375,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಮೃತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A528"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7916,8 +7389,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಂಡರ್ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A529"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7931,8 +7403,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A530"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7946,8 +7417,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನ್ನಪೂರ್ಣೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A531"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7961,8 +7431,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅನುಗೊಂಡನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A532"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -7976,8 +7445,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A533"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -7991,8 +7459,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A534"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8006,8 +7473,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A535"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8021,8 +7487,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಡವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A536"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8036,8 +7501,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಗುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A537"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8051,8 +7515,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A538"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8066,8 +7529,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A539"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8081,8 +7543,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A540"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8096,8 +7557,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A541"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8111,8 +7571,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಡೆಪಾಳ್ಯ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A542"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8126,8 +7585,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A543"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8141,8 +7599,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A544"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8156,8 +7613,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವೇಶ್ವರ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A545"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8171,8 +7627,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A546"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8186,8 +7641,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A547"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8201,8 +7655,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಕವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A548"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8216,8 +7669,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A549"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8231,8 +7683,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಾವಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A550"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8246,8 +7697,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಇಎಂಎಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A551"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8261,8 +7711,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಸಗರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A552"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8276,8 +7725,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇತಮಂಗಲ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A553"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8291,8 +7739,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A554"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8306,8 +7753,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A555"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8321,8 +7767,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A556"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8336,8 +7781,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A557"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8351,8 +7795,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಯಪ್ಪನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A558"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8366,8 +7809,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A559"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8381,8 +7823,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ಕೆ.ಅಚ್ಚುಕಟ್ಟು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A560"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8396,8 +7837,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A561"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8411,8 +7851,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A562"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8426,8 +7865,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ ರೀಫ್ಸ್ PS",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A563"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8441,8 +7879,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದ್ರಾ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A564"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8456,8 +7893,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಪೂರ್ವ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A565"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8471,8 +7907,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A566"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8486,8 +7921,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A567"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8501,8 +7935,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A568"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8516,8 +7949,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚೇಳೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A569"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8531,8 +7963,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A570"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8546,8 +7977,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A571"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8561,8 +7991,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A572"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8576,8 +8005,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A573"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8591,8 +8019,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A574"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8606,8 +8033,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A575"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8621,8 +8047,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಮರ್ಷಿಯಲ್ ಸ್ಟ್ರೀಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A576"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8636,8 +8061,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಟನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A577"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8651,8 +8075,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A578"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8666,8 +8089,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A579"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8681,8 +8103,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವಜೀವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A580"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8696,8 +8117,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಿಬ್ಬೂರಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A581"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8711,8 +8131,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A582"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8726,8 +8145,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A583"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8741,8 +8159,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A584"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8756,8 +8173,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A585"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8771,8 +8187,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A586"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8786,8 +8201,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಮ್ಮಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A587"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8801,8 +8215,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A588"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8816,8 +8229,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A589"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8831,8 +8243,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A590"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8846,8 +8257,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಪಲ್ಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A591"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8861,8 +8271,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A592"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8876,8 +8285,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A593"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8891,8 +8299,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A594"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8906,8 +8313,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A595"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8921,8 +8327,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಪೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A596"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8936,8 +8341,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A597"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8951,8 +8355,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A598"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8966,8 +8369,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಗೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A599"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -8981,8 +8383,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A600"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -8996,8 +8397,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A601"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9011,8 +8411,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನುಮತಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A602"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9026,8 +8425,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A603"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9041,8 +8439,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A604"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9056,8 +8453,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A605"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9071,8 +8467,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A606"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9086,8 +8481,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A607"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9101,8 +8495,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A608"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9116,8 +8509,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A609"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9131,8 +8523,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A610"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9146,8 +8537,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಳಿಮಾವು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A611"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9161,8 +8551,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A612"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9176,8 +8565,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಜೂರ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A613"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9191,8 +8579,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A614"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9206,8 +8593,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆ.ಸಿ.ನಗರಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A615"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9221,8 +8607,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಜೀವನರಾಮ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A616"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9236,8 +8621,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A617"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9251,8 +8635,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A618"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9266,8 +8649,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಪ್ರಕಾಶ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A619"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9281,8 +8663,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A620"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9296,8 +8677,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A621"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9311,8 +8691,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜ್ಞಾನಭಾರತಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A622"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9326,8 +8705,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಜಿ.ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A623"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9341,8 +8719,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಎಂ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A624"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9356,8 +8733,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A625"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9371,8 +8747,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A626"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9386,8 +8761,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A627"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9401,8 +8775,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಗ್ಗಲೀಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A628"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9416,8 +8789,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಲಂಬೆಳ್ಳ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A629"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9431,8 +8803,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A630"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9446,8 +8817,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A631"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9461,8 +8831,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A632"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9476,8 +8845,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪಾಪುರ ಅಗ್ರಹಾರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A633"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9491,8 +8859,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪೇಗೌಡ ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A634"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9506,8 +8873,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಚಾರ್ಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A635"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9521,8 +8887,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A636"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9536,8 +8901,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಸ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A637"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9551,8 +8915,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿರುಗಾವಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A638"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9566,8 +8929,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A639"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9581,8 +8943,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಿಗೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A640"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9596,8 +8957,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A641"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9611,8 +8971,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳಲ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A642"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9626,8 +8985,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A643"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9641,8 +8999,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A644"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9656,8 +9013,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A645"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9671,8 +9027,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A646"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9686,8 +9041,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಣನಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A647"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9701,8 +9055,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A648"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9716,8 +9069,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A649"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9731,8 +9083,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A650"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9746,8 +9097,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A651"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9761,8 +9111,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A652"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9776,8 +9125,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A653"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9791,8 +9139,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A654"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9806,8 +9153,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೂಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A655"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9821,8 +9167,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A656"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9836,8 +9181,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸದ್ರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A657"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9851,8 +9195,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಕೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A658"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9866,8 +9209,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಕೆ. ದೊಡ್ಡಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A659"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9881,8 +9223,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಂ.ಎಂ. ಹಿಲ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A660"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9896,8 +9237,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A661"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9911,8 +9251,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A662"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9926,8 +9265,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A663"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9941,8 +9279,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A664"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9956,8 +9293,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A665"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -9971,8 +9307,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A666"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -9986,8 +9321,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A667"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10001,8 +9335,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A668"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10016,8 +9349,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A669"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10031,8 +9363,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A670"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10046,8 +9377,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A671"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10061,8 +9391,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A672"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10076,8 +9405,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಂಬಲಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A673"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10091,8 +9419,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A674"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10106,8 +9433,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A675"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10121,8 +9447,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರತ್ತಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A676"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10136,8 +9461,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರಿಕುಪ್ಪಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A677"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10151,8 +9475,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A678"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10166,8 +9489,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಡಿಗೇಶಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A679"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10181,8 +9503,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಕೋ ಲೇಔಟ್ ಬೆಂಗಳೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A680"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10196,8 +9517,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A681"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10211,8 +9531,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A682"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10226,8 +9545,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A683"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10241,8 +9559,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ ಗಿರಿಘಾಮ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A684"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10256,8 +9573,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿನಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A685"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10271,8 +9587,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಗಲಿ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A686"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10286,8 +9601,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A687"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10301,8 +9615,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A688"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10316,8 +9629,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A689"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10331,8 +9643,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಂ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A690"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10346,8 +9657,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪರಪ್ಪನ ಅಗ್ರಹಾರ",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A691"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10361,8 +9671,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಟನಾಯಕನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A692"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10376,8 +9685,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾತಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A693"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10391,8 +9699,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A694"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10406,8 +9713,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A695"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10421,8 +9727,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A696"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10436,8 +9741,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಟ್ಟೇನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A697"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10451,8 +9755,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A698"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10466,8 +9769,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A699"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10481,8 +9783,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾನುಕುಂಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A700"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10496,8 +9797,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A701"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10511,8 +9811,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಗೋಪಾಲ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A702"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10526,8 +9825,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಮೂರ್ತಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A703"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10541,8 +9839,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A704"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10556,8 +9853,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A705"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10571,8 +9867,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A706"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10586,8 +9881,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಲ್ಪಾಡ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A707"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10601,8 +9895,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಬರ್ಟ್‌ಸನ್‌ಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A708"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10616,8 +9909,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಸ್.ಜೆ. ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A709"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10631,8 +9923,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಷದಶಿವನಗರ್ Pಷ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A710"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10646,8 +9937,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಂಗಿರಾಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A711"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10661,8 +9951,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಪಿಗೆಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A712"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10676,8 +9965,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಜಯ ನಗರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A713"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10691,8 +9979,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂತೆಮರಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A714"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10706,8 +9993,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A715"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10721,8 +10007,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾತನೂರು ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A716"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10736,8 +10021,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A717"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10751,8 +10035,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A718"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10766,8 +10049,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A719"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10781,8 +10063,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಗಟ್ಟಾ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A720"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10796,8 +10077,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A721"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10811,8 +10091,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A722"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10826,8 +10105,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A723"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10841,8 +10119,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A724"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10856,8 +10133,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A725"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10871,8 +10147,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಂಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A726"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10886,8 +10161,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A727"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10901,8 +10175,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಬ್ರಹ್ಮಣ್ಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A728"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10916,8 +10189,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುದ್ದಗುಂಟೆಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A729"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -10931,8 +10203,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗಟೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A730"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10946,8 +10217,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲಿಬೆಲೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A731"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10961,8 +10231,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೈಲೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A732"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10976,8 +10245,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಕಾಡು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A733"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -10991,8 +10259,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A734"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11006,8 +10273,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A735"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11021,8 +10287,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A736"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11036,8 +10301,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A737"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11051,8 +10315,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A738"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11066,8 +10329,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಲಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A739"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11081,8 +10343,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A740"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11096,8 +10357,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A741"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11111,8 +10371,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A742"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11126,8 +10385,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A743"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11141,8 +10399,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A744"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11156,8 +10413,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A745"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11171,8 +10427,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಧಾನಸೌಧ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A746"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11186,8 +10441,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A747"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11201,8 +10455,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A748"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11216,8 +10469,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A749"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11231,8 +10483,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಶ್ವನಾಥಪುರ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A750"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11246,8 +10497,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿವೇಕನಗರ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A751"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11261,8 +10511,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಯಾಲಿಕಾವಲ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A752"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11276,8 +10525,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A753"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11291,8 +10539,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A754"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11306,8 +10553,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ನ್ಯೂ ಟೌನ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A755"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11321,8 +10567,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A756"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11336,8 +10581,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A757"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11351,8 +10595,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳದೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A758"
+    "NameKN": ""
   },
   {
     "Department": "police_city",
@@ -11366,8 +10609,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A759"
+    "NameKN": "-"
   },
   {
     "Department": "police_city",
@@ -11381,8 +10623,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಆರ್‌ಎಂಸಿ ಯಾರ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "-",
-    "NameKN": "-",
-    "cellRef": "A760"
+    "NameKN": "-"
   },
   {
     "Department": "election_ac",
@@ -11396,8 +10637,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಶಿವಣ್ಣ",
-    "cellRef": "A761"
+    "NameKN": "ಬಿ. ಶಿವಣ್ಣ"
   },
   {
     "Department": "election_ac",
@@ -11411,8 +10651,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಟಿಎಂ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ",
-    "cellRef": "A762"
+    "NameKN": "ರಾಮಲಿಂಗಾ ರೆಡ್ಡಿ"
   },
   {
     "Department": "election_ac",
@@ -11426,8 +10665,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A763"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11441,8 +10679,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ",
-    "cellRef": "A764"
+    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
   },
   {
     "Department": "election_ac",
@@ -11456,8 +10693,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A765"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11471,8 +10707,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ ಎಲ್.ಎ",
-    "cellRef": "A766"
+    "NameKN": "ರವಿ ಸುಬ್ರಹ್ಮಣ್ಯ ಎಲ್.ಎ"
   },
   {
     "Department": "election_ac",
@@ -11486,8 +10721,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ",
-    "cellRef": "A767"
+    "NameKN": "ಸತೀಶ್ ರೆಡ್ಡಿ ಎಂ"
   },
   {
     "Department": "election_ac",
@@ -11501,8 +10735,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ",
-    "cellRef": "A768"
+    "NameKN": "ಕೃಷ್ಣ ಬೈರೇಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -11516,8 +10749,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿ.ವಿ. ರಾಮಣ್ಣನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ರಘು",
-    "cellRef": "A769"
+    "NameKN": "ಎಸ್. ರಘು"
   },
   {
     "Department": "election_ac",
@@ -11531,8 +10763,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಜೆಡ್ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್",
-    "cellRef": "A770"
+    "NameKN": "ಬಿ.ಜೆಡ್ ಜಮೀರ್ ಅಹ್ಮದ್ ಖಾನ್"
   },
   {
     "Department": "election_ac",
@@ -11546,8 +10777,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "MLA",
-    "NameKN": "",
-    "cellRef": "A771"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11561,8 +10791,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್",
-    "cellRef": "A772"
+    "NameKN": "ಉದಯ್ ಬಿ ಗರುಡಾಚಾರ್"
   },
   {
     "Department": "election_ac",
@@ -11576,8 +10805,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್",
-    "cellRef": "A773"
+    "NameKN": "ಪ್ರದೀಪ್ ಈಶ್ವರ್"
   },
   {
     "Department": "election_ac",
@@ -11591,8 +10819,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A774"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11606,8 +10833,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸರಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಮುನಿರಾಜು",
-    "cellRef": "A775"
+    "NameKN": "ಎಸ್. ಮುನಿರಾಜು"
   },
   {
     "Department": "election_ac",
@@ -11621,8 +10847,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ. ಎಚ್. ಮುನಿಯಪ್ಪ",
-    "cellRef": "A776"
+    "NameKN": "ಕೆ. ಎಚ್. ಮುನಿಯಪ್ಪ"
   },
   {
     "Department": "election_ac",
@@ -11636,8 +10861,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್",
-    "cellRef": "A777"
+    "NameKN": "ಧೀರಜ್ ಮುನಿರಾಜ್"
   },
   {
     "Department": "election_ac",
@@ -11651,8 +10875,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್",
-    "cellRef": "A778"
+    "NameKN": "ದಿನೇಶ್ ಗುಂಡೂರಾವ್"
   },
   {
     "Department": "election_ac",
@@ -11666,8 +10889,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A779"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11681,8 +10903,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋವಿಂದರಾಜನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ",
-    "cellRef": "A780"
+    "NameKN": "ಪ್ರಿಯಾ ಕೃಷ್ಣ"
   },
   {
     "Department": "election_ac",
@@ -11696,8 +10917,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A781"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11711,8 +10931,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A782"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11726,8 +10945,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎಸ್. ಸುರೇಶ ಬೈರತಿ",
-    "cellRef": "A783"
+    "NameKN": "ಬಿ.ಎಸ್. ಸುರೇಶ ಬೈರತಿ"
   },
   {
     "Department": "election_ac",
@@ -11741,8 +10959,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ",
-    "cellRef": "A784"
+    "NameKN": "ಶರತ್‌ಕುಮಾರ್ ಬಚ್ಚೇಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -11756,8 +10973,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಸಿ.ಕೆ. ರಾಮ ಮೂರ್ತಿ",
-    "cellRef": "A785"
+    "NameKN": "ಸಿ.ಕೆ. ರಾಮ ಮೂರ್ತಿ"
   },
   {
     "Department": "election_ac",
@@ -11771,8 +10987,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎ. ಬಸವರಾಜ",
-    "cellRef": "A786"
+    "NameKN": "ಬಿ.ಎ. ಬಸವರಾಜ"
   },
   {
     "Department": "election_ac",
@@ -11786,8 +11001,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಡಿ.ಕೆ. ಶಿವಕುಮಾರ್",
-    "cellRef": "A787"
+    "NameKN": "ಡಿ.ಕೆ. ಶಿವಕುಮಾರ್"
   },
   {
     "Department": "election_ac",
@@ -11801,8 +11015,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A788"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11816,8 +11029,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ಚಿನ್ನದ ಕ್ಷೇತ್ರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A789"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11831,8 +11043,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A790"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11846,8 +11057,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "MLA",
-    "NameKN": "ಜಿ. ಪರಮೇಶ್ವರ",
-    "cellRef": "A791"
+    "NameKN": "ಜಿ. ಪರಮೇಶ್ವರ"
   },
   {
     "Department": "election_ac",
@@ -11861,8 +11071,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A792"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11876,8 +11085,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A793"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11891,8 +11099,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A794"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11906,8 +11113,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಚ್.ಸಿ ಬಾಲಕೃಷ್ಣ",
-    "cellRef": "A795"
+    "NameKN": "ಎಚ್.ಸಿ ಬಾಲಕೃಷ್ಣ"
   },
   {
     "Department": "election_ac",
@@ -11921,8 +11127,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮಂಜುಳಾ ಎಸ್",
-    "cellRef": "A796"
+    "NameKN": "ಮಂಜುಳಾ ಎಸ್"
   },
   {
     "Department": "election_ac",
@@ -11936,8 +11141,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹಾಲಕ್ಷ್ಮಿ ಲೇಔಟ್",
     "DesignationKN": "MLA",
-    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ",
-    "cellRef": "A797"
+    "NameKN": "ಗೋಪಾಲಯ್ಯ ಕೆ"
   },
   {
     "Department": "election_ac",
@@ -11951,8 +11155,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A798"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -11966,8 +11169,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "MLA",
-    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿ.ಎನ್",
-    "cellRef": "A799"
+    "NameKN": "ಅಶ್ವಥ್ ನಾರಾಯಣ ಸಿ.ಎನ್"
   },
   {
     "Department": "election_ac",
@@ -11981,8 +11183,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಎನ್. ನಂಜೇಗೌಡ",
-    "cellRef": "A800"
+    "NameKN": "ಕೆ.ಎನ್. ನಂಜೇಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -11996,8 +11197,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A801"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12011,8 +11211,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A802"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12026,8 +11225,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A803"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12041,8 +11239,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "MLA",
-    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್",
-    "cellRef": "A804"
+    "NameKN": "ಶ್ರೀನಿವಾಸಯ್ಯ ಎನ್"
   },
   {
     "Department": "election_ac",
@@ -12056,8 +11253,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪದ್ಮನಾಬನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಆರ್. ಅಶೋಕ",
-    "cellRef": "A805"
+    "NameKN": "ಆರ್. ಅಶೋಕ"
   },
   {
     "Department": "election_ac",
@@ -12071,8 +11267,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A806"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12086,8 +11281,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎ.ಸಿ. ಶ್ರೀನಿವಾಸ",
-    "cellRef": "A807"
+    "NameKN": "ಎ.ಸಿ. ಶ್ರೀನಿವಾಸ"
   },
   {
     "Department": "election_ac",
@@ -12101,8 +11295,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್. ಸುರೇಶ್ ಕುಮಾರ್",
-    "cellRef": "A808"
+    "NameKN": "ಎಸ್. ಸುರೇಶ್ ಕುಮಾರ್"
   },
   {
     "Department": "election_ac",
@@ -12116,8 +11309,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಮುನಿರತ್ನ",
-    "cellRef": "A809"
+    "NameKN": "ಮುನಿರತ್ನ"
   },
   {
     "Department": "election_ac",
@@ -12131,8 +11323,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "H.A. ಇಕ್ಬಾಲ್ ಹುಸೇನ್",
-    "cellRef": "A810"
+    "NameKN": "H.A. ಇಕ್ಬಾಲ್ ಹುಸೇನ್"
   },
   {
     "Department": "election_ac",
@@ -12146,8 +11337,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ವಜ್ಞನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಕೆ.ಜೆ. ಜಾರ್ಜ್",
-    "cellRef": "A811"
+    "NameKN": "ಕೆ.ಜೆ. ಜಾರ್ಜ್"
   },
   {
     "Department": "election_ac",
@@ -12161,8 +11351,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎನ್.ಎ. ಹರಿಸ್",
-    "cellRef": "A812"
+    "NameKN": "ಎನ್.ಎ. ಹರಿಸ್"
   },
   {
     "Department": "election_ac",
@@ -12176,8 +11365,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್",
-    "cellRef": "A813"
+    "NameKN": "ರಿಜ್ವಾನ್ ಅರ್ಷದ್"
   },
   {
     "Department": "election_ac",
@@ -12191,8 +11379,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ.ಎನ್. ರವಿಕುಮಾರ್",
-    "cellRef": "A814"
+    "NameKN": "ಬಿ.ಎನ್. ರವಿಕುಮಾರ್"
   },
   {
     "Department": "election_ac",
@@ -12206,8 +11393,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A815"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12221,8 +11407,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A816"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12236,8 +11421,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A817"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12251,8 +11435,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A818"
+    "NameKN": ""
   },
   {
     "Department": "election_ac",
@@ -12266,8 +11449,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಬಿ. ಸುರೇಶ್ ಗೌಡ",
-    "cellRef": "A819"
+    "NameKN": "ಬಿ. ಸುರೇಶ್ ಗೌಡ"
   },
   {
     "Department": "election_ac",
@@ -12281,8 +11463,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ",
-    "cellRef": "A820"
+    "NameKN": "ಎಂ. ಕೃಷ್ಣಪ್ಪ"
   },
   {
     "Department": "election_ac",
@@ -12296,8 +11477,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಆರ್ ವಿಶ್ವನಾಥ್",
-    "cellRef": "A821"
+    "NameKN": "ಎಸ್.ಆರ್ ವಿಶ್ವನಾಥ್"
   },
   {
     "Department": "election_ac",
@@ -12311,8 +11491,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ",
     "DesignationKN": "MLA",
-    "NameKN": "ಎಸ್.ಟಿ. ಸೋಮಶೇಖರ್",
-    "cellRef": "A822"
+    "NameKN": "ಎಸ್.ಟಿ. ಸೋಮಶೇಖರ್"
   },
   {
     "Department": "election_pc",
@@ -12326,8 +11505,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಕೇಂದ್ರ",
     "DesignationKN": "MP",
-    "NameKN": "ಪಿ.ಸಿ. ಮೋಹನ್",
-    "cellRef": "A823"
+    "NameKN": "ಪಿ.ಸಿ. ಮೋಹನ್"
   },
   {
     "Department": "election_pc",
@@ -12341,8 +11519,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಉತ್ತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ",
-    "cellRef": "A824"
+    "NameKN": "ಶೋಭಾ ಕರಂದ್ಲಾಜೆ"
   },
   {
     "Department": "election_pc",
@@ -12356,8 +11533,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "MP",
-    "NameKN": "ಸಿ. ಎನ್. ಮಂಜುನಾಥ್",
-    "cellRef": "A825"
+    "NameKN": "ಸಿ. ಎನ್. ಮಂಜುನಾಥ್"
   },
   {
     "Department": "election_pc",
@@ -12371,8 +11547,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "MP",
-    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ",
-    "cellRef": "A826"
+    "NameKN": "ತೇಜಸ್ವಿ ಸೂರ್ಯ"
   },
   {
     "Department": "election_pc",
@@ -12386,8 +11561,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A827"
+    "NameKN": ""
   },
   {
     "Department": "election_pc",
@@ -12401,8 +11575,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "MP",
-    "NameKN": "ಕೆ. ಸುಧಾಕರ್",
-    "cellRef": "A828"
+    "NameKN": "ಕೆ. ಸುಧಾಕರ್"
   },
   {
     "Department": "election_pc",
@@ -12416,8 +11589,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A829"
+    "NameKN": ""
   },
   {
     "Department": "election_pc",
@@ -12431,8 +11603,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "MP",
-    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ. ಬಾಬು",
-    "cellRef": "A830"
+    "NameKN": "ಮಲ್ಲೇಶ್ ಎಂ. ಬಾಬು"
   },
   {
     "Department": "election_pc",
@@ -12446,8 +11617,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A831"
+    "NameKN": ""
   },
   {
     "Department": "election_pc",
@@ -12461,8 +11631,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "MP",
-    "NameKN": "ವಿ. ಸೋಮಣ್ಣ",
-    "cellRef": "A832"
+    "NameKN": "ವಿ. ಸೋಮಣ್ಣ"
   },
   {
     "Department": "Pin Code",
@@ -12476,8 +11645,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಚಿತ್ನಗರ - 560107",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A833"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12491,8 +11659,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ - 560030",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A834"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12506,8 +11673,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಎಫ್ ಸ್ಟೇಷನ್ ಯಲಹಂಕ - 560063",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A835"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12521,8 +11687,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಗ್ರಾಮ್ - 560007",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A836"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12536,8 +11701,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್ - 562106",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A837"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12551,8 +11715,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಂಜನಾಪುರ - 560108",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A838"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12566,8 +11729,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಪಿಎಂಸಿ ಯಾರ್ಡ್ ಬಂಗಾರಪೇಟೆ - 563114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A839"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12581,8 +11743,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ - 562107",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A840"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12596,8 +11757,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಸ್ಟಿನ್ ಟೌನ್ - 560047",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A841"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12611,8 +11771,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆವತಿ ಅಂಚೆ ಕಛೇರಿ - 562164",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A842"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12626,8 +11785,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಬೆಂಗಳೂರು) - 562149",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A843"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12641,8 +11799,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲೂರು (ಕೃಷ್ಣಗಿರಿ) - 635103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A844"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12656,8 +11813,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ - 560050",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A845"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12671,8 +11827,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು GPO - 560001",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A846"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12686,8 +11841,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಅಂತರಾಷ್ಟ್ರೀಯ ವಿಮಾನ ನಿಲ್ದಾಣ - 560300",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A847"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12701,8 +11855,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ವಿಶ್ವವಿದ್ಯಾಲಯ - 560056",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A848"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12716,8 +11869,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೇರುಘಟ್ಟ - 560083",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A849"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12731,8 +11883,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ - 560004",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A850"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12746,8 +11897,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಟ್ಲಹಳ್ಳಿ - 563123",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A851"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12761,8 +11911,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರು - 560114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A852"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12776,8 +11925,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳತ್ತೂರು - 635124",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A853"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12791,8 +11939,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳಂದೂರು - 560103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A854"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12806,8 +11953,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆನ್ಸನ್ ಟೌನ್ - 560046",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A855"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12821,8 +11967,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆರಿಗೈ - 635105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A856"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12836,8 +11981,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟಹಲಸೂರು - 562157",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A857"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12851,8 +11995,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇವೂರು (ರಾಮನಗರ) - 562108",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A858"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12866,8 +12009,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾರತನಗರ - 563115",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A859"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12881,8 +12023,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಡದಿ - 562109",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A860"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12896,8 +12037,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೋಲಾರೆ - 560116",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A861"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12911,8 +12051,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ (ಬೆಂಗಳೂರು) - 560068",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A862"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12926,8 +12065,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮಸಂದ್ರ ಇಂಡಸ್ಟ್ರಿಯಲ್ ಎಸ್ಟೇಟ್ - 560099",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A863"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12941,8 +12079,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೂದಿಕೋಟೆ - 563147",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A864"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12956,8 +12093,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬುರುಡುಗುಂಟೆ - 563159",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A865"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12971,8 +12107,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಮೆಲರಾಮ್ - 560035",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A866"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -12986,8 +12121,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಂಪಿಯನ್ರೀಫ್ಸ್ - 563117",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A867"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13001,8 +12135,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ (ಬೆಂಗಳೂರು) - 560018",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A868"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13016,8 +12149,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಂದಾಪುರ - 560081",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A869"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13031,8 +12163,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ - 562160",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A870"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13046,8 +12177,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ - 562101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A871"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13061,8 +12191,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಪೇಟೆ - 560053",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A872"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13076,8 +12205,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ - 560090",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A873"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13091,8 +12219,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಲಸಂದ್ರ - 560061",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A874"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13106,8 +12233,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ ಮಾರುಕಟ್ಟೆ - 563125",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A875"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13121,8 +12247,7 @@
     "Unnamed: 3": "",
     "AreaKN": "CPC ಆದಾಯ ತೆರಿಗೆ ಇಲಾಖೆ - 560500",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A876"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13136,8 +12261,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿವಿ ರಾಮನ್ ನಗರ - 560093",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A877"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13151,8 +12275,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಲಸನೂರು - 563126",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A878"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13166,8 +12289,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇಶಿಹಳ್ಳಿ ಬಂಗಾರಪೇಟೆ - 563162",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A879"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13181,8 +12303,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ - 562110",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A880"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13196,8 +12317,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಬ್ಬೆಸ್ಪೇಟ್ - 562111",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A881"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13211,8 +12331,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ ಬಜಾರ್ - 561203",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A882"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13226,8 +12345,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬೆಳವಂಗಲ - 561204",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A883"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13241,8 +12359,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡದುನ್ನಸಂದ್ರ - 560117",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A884"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13256,8 +12373,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A885"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13271,8 +12387,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಕಲ್ಲಸಂದ್ರ - 560062",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A886"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13286,8 +12401,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಮ್ಮಲೂರು - 560071",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A887"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13301,8 +12415,7 @@
     "Unnamed: 3": "",
     "AreaKN": "EPIP - 560066",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A888"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13316,8 +12429,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಫ್ರೇಸರ್ ಟೌನ್ - 560005",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A889"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13331,8 +12443,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗವಿಪುರಂ ವಿಸ್ತರಣೆ - 560019",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A890"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13346,8 +12457,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಯತ್ರಿನಗರ - 560021",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A891"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13361,8 +12471,7 @@
     "Unnamed: 3": "",
     "AreaKN": "GCEC ರಾಮನಗರ - 562159",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A892"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13376,8 +12485,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಿರಿನಗರ (ಬೆಂಗಳೂರು) - 560085",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A893"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13391,8 +12499,7 @@
     "Unnamed: 3": "",
     "AreaKN": "GKVK - 560065",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A894"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13406,8 +12513,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ಎಲೆಕ್ಟ್ರಿಕ್ ಫ್ಯಾಕ್ಟರಿ - 560026",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A895"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13421,8 +12527,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಕಾರಿ ರೇಷ್ಮೆ ಫಾರ್ಮ್ - 562161",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A896"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13436,8 +12541,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌನಿಪಲ್ಲಿ - 563161",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A897"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13451,8 +12555,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೂಳೂರು - 572118",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A898"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13466,8 +12569,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HA ಫಾರ್ಮ್ - 560024",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A899"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13481,8 +12583,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HAL II ಹಂತ - 560008",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A900"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13496,8 +12597,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಂಪಿನಗರ - 560104",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A901"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13511,8 +12611,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾರೋಹಳ್ಳಿ - 562112",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A902"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13526,8 +12625,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬೂರು - 572120",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A903"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13541,8 +12639,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೇರೋಹಳ್ಳಿ - 560091",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A904"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13556,8 +12653,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ - 560088",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A905"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13571,8 +12667,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸ್ಸರಘಟ್ಟ ಕೆರೆ - 560089",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A906"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13586,8 +12681,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಹಳ್ಳಿ SO - 572168",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A907"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13601,8 +12695,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HKP ರಸ್ತೆ - 560051",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A908"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13616,8 +12709,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳವನಹಳ್ಳಿ - 572121",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A909"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13631,8 +12723,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಂಗನೂರು - 562138",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A910"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13646,8 +12737,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನುಡಿಕೆ - 572122",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A911"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13661,8 +12751,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊರಮಾವು - 560113",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A912"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13676,8 +12765,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ - 562114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A913"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13691,8 +12779,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು - 561210",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A914"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13706,8 +12793,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಗೋಶಾಲೆ - 635110",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A915"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13721,8 +12807,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸೂರು ಇಂಡಲ್. ಸಂಕೀರ್ಣ - 635126",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A916"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13736,8 +12821,7 @@
     "Unnamed: 3": "",
     "AreaKN": "HSR ಲೇಔಟ್ - 560102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A917"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13751,8 +12835,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರು ದುರ್ಗ - 572123",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A918"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13766,8 +12849,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ (ಬೆಂಗಳೂರು) - 560038",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A919"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13781,8 +12863,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ - 560013",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A920"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13796,8 +12877,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪೂರ್ವ - 560014",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A921"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13811,8 +12891,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಶ್ಚಿಮ - 560015",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A922"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13826,8 +12905,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ - 560041",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A923"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13841,8 +12919,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪೂರ್ವ - 560069",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A924"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13856,8 +12933,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಎಕ್ಸ್ಟೆನ್ ತುಮಕೂರು - 572102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A925"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13871,8 +12947,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಶ್ಚಿಮ - 560070",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A926"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13886,8 +12961,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯಂಗಾರ್ III ಬ್ಲಾಕ್ - 560011",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A927"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13901,8 +12975,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ - 560105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A928"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13916,8 +12989,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ - 560078",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A929"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13931,8 +13003,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೋಡಿ ವಿಸ್ತರಣೆ ಸೋ - 560067",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A930"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13946,8 +13017,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೈವಾರ - 563128",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A931"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13961,8 +13031,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಯಾಣನಗರ - 560043",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A932"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13976,8 +13045,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಸಮುದ್ರ - 563129",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A933"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -13991,8 +13059,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ - 562117",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A934"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14006,8 +13073,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ನಮಂಗಲ - 560115",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A935"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14021,8 +13087,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಪನಹಳ್ಳಿ - 572126",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A936"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14036,8 +13101,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ - 560060",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A937"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14051,8 +13115,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಜಿ ರಸ್ತೆ - 560009",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A938"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14066,8 +13129,7 @@
     "Unnamed: 3": "",
     "AreaKN": "KHB ಕಾಲೋನಿ - 560079",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A939"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14081,8 +13143,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡೇಹಳ್ಳಿ - 560112",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A940"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14096,8 +13157,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಡಿಹಳ್ಳಿ - 562119",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A941"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14111,8 +13171,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ - 563101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A942"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14126,8 +13185,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ ವಿಸ್ತರಣೆ - 563102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A943"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14141,8 +13199,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರ (ತುಮಕೂರು) - 572128",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A944"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14156,8 +13213,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ I ಬ್ಲಾಕ್ - 560034",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A945"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14171,8 +13227,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋರಮಂಗಲ VI ಬ್ಲಾಕ್ - 560095",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A946"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14186,8 +13241,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ - 572129",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A947"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14201,8 +13255,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊತ್ತನೂರು - 560077",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A948"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14216,8 +13269,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ - 560036",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A949"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14231,8 +13283,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ ಆರ್ ಎಸ್ - 560016",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A950"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14246,8 +13297,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೂರು - 561101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A951"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14261,8 +13311,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ - 560111",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A952"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14276,8 +13325,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂಬಳಗೋಡು - 560074",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A953"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14291,8 +13339,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಪ್ಪಂ - 517425",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A954"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14306,8 +13353,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುವೆಂಪುನಗರ - 572103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A955"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14321,8 +13367,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕ್ಯಾತಸಂದ್ರ - 572104",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A956"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14336,8 +13381,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ - 562162",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A957"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14351,8 +13395,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ - 562120",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A958"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14366,8 +13409,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ - 560023",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A959"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14381,8 +13423,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ - 560048",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A960"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14396,8 +13437,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ - 560003",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A961"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14411,8 +13451,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು - 563130",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A962"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14426,8 +13465,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು ರೈಲು ನಿಲ್ದಾಣ - 563160",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A963"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14441,8 +13479,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಚೆನಹಳ್ಳಿ - 561211",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A964"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14456,8 +13493,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳವಾಡಿ - 562121",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A965"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14471,8 +13507,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮರಳೂರು ಎಸ್‌ಒ - 572105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A966"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14486,8 +13521,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾರುತಿ ಸೇವಾನಗರ - 560033",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A967"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14501,8 +13535,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಸ್ತಿ - 563139",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A968"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14516,8 +13549,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಠಗೊಂಡಪಲ್ಲಿ - 635114",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A969"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14531,8 +13563,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೆಳೆಕೋಟೆ - 561205",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A970"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14546,8 +13577,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೇಲೂರು (ಕೋಲಾರ) - 562102",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A971"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14561,8 +13591,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ - 560076",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A972"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14576,8 +13605,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿಲ್ಕ್ ಕಾಲೋನಿ - 560055",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A973"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14591,8 +13619,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MSRIT - 560054",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A974"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14606,8 +13633,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರುಗಮಲೆ - 563146",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A975"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14621,8 +13647,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮ್ಯೂಸಿಯಂ ರಸ್ತೆ - 560025",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A976"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14636,8 +13661,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗದೇನಹಳ್ಳಿ - 562163",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A977"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14651,8 +13675,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ - 560072",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A978"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14666,8 +13689,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಸಂದ್ರ (ಬೆಂಗಳೂರು) - 560073",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A979"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14681,8 +13703,7 @@
     "Unnamed: 3": "",
     "AreaKN": "NAL - 560017",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A980"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14696,8 +13717,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಗುಡಿ - 562122",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A981"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14711,8 +13731,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂದಿ (ಕೋಲಾರ) - 562103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A982"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14726,8 +13745,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಣನ್ದಿನಿ ಳಯೋಉತ್ - ೫೬೦೦೯೬",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A983"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14741,8 +13759,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಾಪುರ - 563133",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A984"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14756,8 +13773,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಯಂಡಹಳ್ಳಿ - 560039",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A985"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14771,8 +13787,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ - 562123",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A986"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14786,8 +13801,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸ ತಿಪ್ಪಸಂದ್ರ - 560075",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A987"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14801,8 +13815,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಡಘಟ್ಟ - 571433",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A988"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14816,8 +13829,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉತ್ತರ ವಿಸ್ತರಣೆ - 572106",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A989"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14831,8 +13843,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಗಾಮ್ - 563120",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A990"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14846,8 +13857,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ದಾಸರಹಳ್ಳಿ - 560057",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A991"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14861,8 +13871,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಸಣ್ಣ ಕೈಗಾರಿಕೆಗಳು - 560058",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A992"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14876,8 +13885,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೆರೇಸಂದ್ರ - 562104",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A993"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14891,8 +13899,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ - 560010",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A994"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14906,8 +13913,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜರಾಜೇಶ್ವರಿನಗರ - 560098",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A995"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14921,8 +13927,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಮೇಶ್‌ನಗರ - 560037",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A996"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14936,8 +13941,7 @@
     "Unnamed: 3": "",
     "AreaKN": "RMV ವಿಸ್ತರಣೆ II ಹಂತ - 560094",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A997"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14951,8 +13955,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್‌ಟಿ ನಗರ - 560032",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A998"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14966,8 +13969,7 @@
     "Unnamed: 3": "",
     "AreaKN": "RV ನಿಕೇತನ್ - 560059",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A999"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14981,8 +13983,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ - 560080",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1000"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -14996,8 +13997,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಹಕಾರನಗರ PO - 560092",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1001"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15011,8 +14011,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ - 562125",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1002"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15026,8 +14025,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜ್ಞಾನ ಸಂಸ್ಥೆ - 560012",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1003"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15041,8 +14039,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೇಷಾದ್ರಿಪುರಂ - 560020",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1004"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15056,8 +14053,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ - 560027",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1005"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15071,8 +14067,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಡ್ಲಗಟ್ಟಾ ಬಜಾರ್ - 562105",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1006"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15086,8 +14081,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವನ್ ಚೆಟ್ಟಿ ಗಾರ್ಡನ್ಸ್ - 560042",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1007"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15101,8 +14095,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಲೂರು - 562127",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1008"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15116,8 +14109,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀ ಜಯಚಾಮರಾಜೇಂದ್ರ ರಸ್ತೆ - 560002",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1009"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15131,8 +14123,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ - 563135",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1010"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15146,8 +14137,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಂಟ್ ಥಾಮಸ್ ಟೌನ್ - 560084",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1011"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15161,8 +14151,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಗ್ಗನಹಳ್ಳಿ - 562128",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1012"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15176,8 +14165,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೂಲೇಬೆಲೆ - 562129",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1013"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15191,8 +14179,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟಮಾಕಾ - 563103",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1014"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15206,8 +14193,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ - 560029",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1015"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15221,8 +14207,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ (ಬೆಂಗಳೂರು) - 562130",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1016"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15236,8 +14221,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಟೇಕಲ್ - 563137",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1017"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15251,8 +14235,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಲಘಟ್ಟಪುರ - 560109",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1018"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15266,8 +14249,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಥಾಲಿ - 635118",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1019"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15281,8 +14263,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪ್ಪಸಂದ್ರ - 562131",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1020"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15296,8 +14277,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೊಂಡೇಭಾವಿ - 561213",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1021"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15311,8 +14291,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೋವಿನಕೆರೆ - 572138",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1022"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15326,8 +14305,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರಬೇತಿ ಕಮಾಂಡ್ IAF - 560006",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1023"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15341,8 +14319,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು - 572101",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1024"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15356,8 +14333,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತ್ಯಾಮಗೊಂಡ್ಲು - 562132",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1025"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15371,8 +14347,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉದಯಪುರ - 560082",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1026"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15386,8 +14361,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಲ್ಲಾಳು ಉಪನಗರ - 560110",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1027"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15401,8 +14375,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಊರ್ಡಿಗೆರೆ - 572140",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1028"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15416,8 +14389,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು - 560087",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1029"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15431,8 +14403,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಸಂತ ನಗರ - 560052",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1030"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15446,8 +14417,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರೇಗೌಡನದೊಡ್ಡಿ - 561201",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1031"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15461,8 +14431,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೇಮಗಲ್ - 563157",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1032"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15476,8 +14445,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಂಕಟೇಶಪುರ - 560045",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1033"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15491,8 +14459,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಪ್ಪನಪಲ್ಲಿ - 635121",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1034"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15506,8 +14473,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿದ್ಯಾರಣ್ಯಪುರ - 560097",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1035"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15521,8 +14487,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ (ಬೆಂಗಳೂರು) - 560040",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1036"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15536,8 +14501,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯಪುರ - 562135",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1037"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15551,8 +14515,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನ್ಯಾನಗರ - 560049",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1038"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15566,8 +14529,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೆಸ್ಟ್ ಆಫ್ ಕಾರ್ಡ್ ರೋಡ್ II ಹಂತ - 560086",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1039"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15581,8 +14543,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಪ್ರೋ ಲಿಮಿಟೆಡ್ - 560100",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1040"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15596,8 +14557,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಸ್ಯಾಟಲೈಟ್ ಟೌನ್ - 560064",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1041"
+    "NameKN": ""
   },
   {
     "Department": "Pin Code",
@@ -15611,8 +14571,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಬಜಾರ್ - 560022",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1042"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15626,8 +14585,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1043"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15641,8 +14599,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಂಗಳೂರು ಗ್ರಾಮಾಂತರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ.",
-    "cellRef": "A1044"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಕೆ."
   },
   {
     "Department": "stamps_dro",
@@ -15656,8 +14613,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ. ಬೆಳಗಲಿ",
-    "cellRef": "A1045"
+    "NameKN": "ಸವಿತಾಲಕ್ಷ್ಮಿ ಪಿ. ಬೆಳಗಲಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15671,8 +14627,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1046"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15686,8 +14641,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1047"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15701,8 +14655,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1048"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15716,8 +14669,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1049"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15731,8 +14683,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1050"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15746,8 +14697,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ",
-    "cellRef": "A1051"
+    "NameKN": "ಮೊಹಮ್ಮದ್ ಅಲಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15761,8 +14711,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1052"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15776,8 +14725,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1053"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15791,8 +14739,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1054"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15806,8 +14753,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1055"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15821,8 +14767,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1056"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15836,8 +14781,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎ.ಎನ್. ಭಾರತಿ",
-    "cellRef": "A1057"
+    "NameKN": "ಎ.ಎನ್. ಭಾರತಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15851,8 +14795,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1058"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15866,8 +14809,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1059"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15881,8 +14823,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ.ಎಚ್. ಶಂಕರೇಗೌಡ",
-    "cellRef": "A1060"
+    "NameKN": "ಬಿ.ಎಚ್. ಶಂಕರೇಗೌಡ"
   },
   {
     "Department": "stamps_dro",
@@ -15896,8 +14837,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲ್ಬುರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1061"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15911,8 +14851,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1062"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15926,8 +14865,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಡಗು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1063"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15941,8 +14879,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎನ್. ಶ್ರೀನಿಧಿ",
-    "cellRef": "A1064"
+    "NameKN": "ಎನ್. ಶ್ರೀನಿಧಿ"
   },
   {
     "Department": "stamps_dro",
@@ -15956,8 +14893,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1065"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15971,8 +14907,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1066"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -15986,8 +14921,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1067"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16001,8 +14935,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1068"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16016,8 +14949,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1069"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16031,8 +14963,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್",
-    "cellRef": "A1070"
+    "NameKN": "ಶಶಿಕಲಾ ಬಿ.ಎನ್"
   },
   {
     "Department": "stamps_dro",
@@ -16046,8 +14977,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಂ. ಶ್ರೀದೇವಿ",
-    "cellRef": "A1071"
+    "NameKN": "ಎಂ. ಶ್ರೀದೇವಿ"
   },
   {
     "Department": "stamps_dro",
@@ -16061,8 +14991,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1072"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16076,8 +15005,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಎಸ್.ಬಿ. ದವಳೇಶ್ವರ",
-    "cellRef": "A1073"
+    "NameKN": "ಎಸ್.ಬಿ. ದವಳೇಶ್ವರ"
   },
   {
     "Department": "stamps_dro",
@@ -16091,8 +15019,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "District Registrar",
-    "NameKN": "ಬಿ. ಶ್ರೀಕಾಂತ್",
-    "cellRef": "A1074"
+    "NameKN": "ಬಿ. ಶ್ರೀಕಾಂತ್"
   },
   {
     "Department": "stamps_dro",
@@ -16106,8 +15033,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1075"
+    "NameKN": ""
   },
   {
     "Department": "stamps_dro",
@@ -16121,8 +15047,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1076"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16136,8 +15061,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಫಜಲಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1077"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16151,8 +15075,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಳಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1078"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16166,8 +15089,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1079"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16181,8 +15103,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆನೇಕಲ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ",
-    "cellRef": "A1080"
+    "NameKN": "ತಿಮ್ಮಾರೆಡ್ಡಿ ಸಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16196,8 +15117,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಣ್ಣಿಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1081"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16211,8 +15131,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಕಲಗೂಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1082"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16226,8 +15145,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅರಸೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1083"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16241,8 +15159,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಥಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1084"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16256,8 +15173,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅತ್ತಿಬೆಲೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ",
-    "cellRef": "A1085"
+    "NameKN": "ರಾಮದಾಸೇಗೌಡ ಬಿ.ಜಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16271,8 +15187,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಔರಾದ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1086"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16286,8 +15201,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾದಾಮಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1087"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16301,8 +15215,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗಲಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1088"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16316,8 +15229,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಗೇಪಲ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1089"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16331,8 +15243,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಲಹೊಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1090"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16346,8 +15257,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೈಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1091"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16361,8 +15271,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್",
-    "cellRef": "A1092"
+    "NameKN": "ಸತೀಶ್ ಕುಮಾರ್ ಎನ್"
   },
   {
     "Department": "stamps_sro",
@@ -16376,8 +15285,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ",
-    "cellRef": "A1093"
+    "NameKN": "ಶಂಕರ ಮೂರ್ತಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16391,8 +15299,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1094"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16406,8 +15313,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1095"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16421,8 +15327,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಾವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1096"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16436,8 +15341,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಗಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1097"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16451,8 +15355,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1098"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16466,8 +15369,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಂಟವಾಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1099"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16481,8 +15383,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವಕಲ್ಯಾಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1100"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16496,8 +15397,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಬಾಗೇವಾಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1101"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16511,8 +15411,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎ. ರಾಘವೇಂದ್ರ",
-    "cellRef": "A1102"
+    "NameKN": "ಎ. ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "stamps_sro",
@@ -16526,8 +15425,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಗೂರ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್. ಕಟ್ಟಿಮನಿ",
-    "cellRef": "A1103"
+    "NameKN": "ಸಂತೋಷ್ ಕುಮಾರ್ ಆರ್. ಕಟ್ಟಿಮನಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16541,8 +15439,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳಗಾವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1104"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16556,8 +15453,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಳ್ಳಾರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1105"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16571,8 +15467,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1106"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16586,8 +15481,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಳ್ತಂಗಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1107"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16601,8 +15495,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೇಲೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1108"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16616,8 +15509,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೆಟ್ಟದಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1109"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16631,8 +15523,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭದ್ರಾವತಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1110"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16646,8 +15537,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಾಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1111"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16661,8 +15551,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಭಟ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1112"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16676,8 +15565,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೀದರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1113"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16691,8 +15579,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿದರಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್",
-    "cellRef": "A1114"
+    "NameKN": "ಲಲಿತಾ ಅಮೃತೇಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -16706,8 +15593,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಜಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1115"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16721,8 +15607,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಿಳಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1116"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16736,8 +15621,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಸನ್ನ ಜಿ",
-    "cellRef": "A1117"
+    "NameKN": "ಪ್ರಸನ್ನ ಜಿ"
   },
   {
     "Department": "stamps_sro",
@@ -16751,8 +15635,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ರಹ್ಮಾವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1118"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16766,8 +15649,7 @@
     "Unnamed: 3": "",
     "AreaKN": "BTM ಲೇಔಟ್",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಾವ್ಯ ಕೆ. ಕೋರ",
-    "cellRef": "A1119"
+    "NameKN": "ಕಾವ್ಯ ಕೆ. ಕೋರ"
   },
   {
     "Department": "stamps_sro",
@@ -16781,8 +15663,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಡಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1120"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16796,8 +15677,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ.ವಿ. ರವಿಕುಮಾರ್",
-    "cellRef": "A1121"
+    "NameKN": "ಕೆ.ವಿ. ರವಿಕುಮಾರ್"
   },
   {
     "Department": "stamps_sro",
@@ -16811,8 +15691,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಳ್ಳಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1122"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16826,8 +15705,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1123"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16841,8 +15719,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಉಮಾದೇವಿ ಎ.ಎಸ್",
-    "cellRef": "A1124"
+    "NameKN": "ಉಮಾದೇವಿ ಎ.ಎಸ್"
   },
   {
     "Department": "stamps_sro",
@@ -16856,8 +15733,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1125"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16871,8 +15747,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನಪಟ್ಟಣ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1126"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -16886,8 +15761,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚನ್ನರಾಯಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1127"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16901,8 +15775,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1128"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -16916,8 +15789,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಮಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1129"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16931,8 +15803,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1130"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16946,8 +15817,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕೋಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1131"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16961,8 +15831,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂಚೋಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1132"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16976,8 +15845,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಂತಾಮಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1133"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -16991,8 +15859,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ರದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1134"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17006,8 +15873,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿತ್ತಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1135"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17021,8 +15887,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾಸನಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ",
-    "cellRef": "A1136"
+    "NameKN": "ಶೇಕ್ ಗುಲಾಮ್ ರಹಮಾನಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17036,8 +15901,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದಾವಣಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1137"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17051,8 +15915,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1138"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17066,8 +15929,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್",
-    "cellRef": "A1139"
+    "NameKN": "ರವೀಂದ್ರಗೌಡ ಕೆ.ಆರ್"
   },
   {
     "Department": "stamps_sro",
@@ -17081,8 +15943,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಧಾರವಾಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1140"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17096,8 +15957,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೊಡ್ಡಬಳ್ಳಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸತೀಶ್ ಎಚ್.ಎಸ್",
-    "cellRef": "A1141"
+    "NameKN": "ಸತೀಶ್ ಎಚ್.ಎಸ್"
   },
   {
     "Department": "stamps_sro",
@@ -17111,8 +15971,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗದಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1142"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17126,8 +15985,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಜೇಂದ್ರಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1143"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17141,8 +15999,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಾಂಧಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ",
-    "cellRef": "A1144"
+    "NameKN": "ಶಶಿಕಲಾ ಎಚ್.ಪಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17156,8 +16013,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ಕೆ. ಶಾಂತಮೂರ್ತಿ",
-    "cellRef": "A1145"
+    "NameKN": "ಎಂ.ಕೆ. ಶಾಂತಮೂರ್ತಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17171,8 +16027,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗಂಗಾವತಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1146"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17186,8 +16041,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೌರಿಬಿದನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1147"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17201,8 +16055,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗೋಕಾಕ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1148"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17216,8 +16069,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಬ್ಬಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1149"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17231,8 +16083,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಡಿಬಂಡೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1150"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17246,8 +16097,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಲ್ಬರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1151"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17261,8 +16111,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಳೇದಗುಡ್ಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1152"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17276,8 +16125,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಗುಂಡ್ಲುಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1153"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17291,8 +16139,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಗರಿಬೊಮ್ಮನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1154"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17306,8 +16153,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಳಿಯಾಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1155"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17321,8 +16167,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್",
-    "cellRef": "A1156"
+    "NameKN": "ಪ್ರಭಾವತಿ ಆರ್"
   },
   {
     "Department": "stamps_sro",
@@ -17336,8 +16181,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾನಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1157"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17351,8 +16195,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1158"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17366,8 +16209,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಪನಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1159"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17381,8 +16223,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹರಿಹರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1160"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17396,8 +16237,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾಸನ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1161"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17411,8 +16251,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಾವೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1162"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17426,8 +16265,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚೈತ್ರಾ ಬಿ.ಎ",
-    "cellRef": "A1163"
+    "NameKN": "ಚೈತ್ರಾ ಬಿ.ಎ"
   },
   {
     "Department": "stamps_sro",
@@ -17441,8 +16279,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಗ್ಗಡದೇವನ ಕೋಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1164"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17456,8 +16293,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಸರಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್",
-    "cellRef": "A1165"
+    "NameKN": "ಮಂಜುನಾಥ್ ಎನ್"
   },
   {
     "Department": "stamps_sro",
@@ -17471,8 +16307,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರೇಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1166"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17486,8 +16321,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಿರಿಯೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1167"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17501,8 +16335,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳಲ್ಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1168"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17516,8 +16349,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಳೆನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1169"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17531,8 +16363,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1170"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17546,8 +16377,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊನ್ನಾವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1171"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17561,8 +16391,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1172"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17576,8 +16405,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಕೋಟೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿ. ಗೀತಾ",
-    "cellRef": "A1173"
+    "NameKN": "ವಿ. ಗೀತಾ"
   },
   {
     "Department": "stamps_sro",
@@ -17591,8 +16419,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1174"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17606,8 +16433,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೊಸಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1175"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17621,8 +16447,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ ಉತ್ತರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1176"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17636,8 +16461,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಬ್ಬಳ್ಳಿ (ದಕ್ಷಿಣ)",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1177"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17651,8 +16475,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಕ್ಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1178"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17666,8 +16489,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಲಿಯೂರುದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1179"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17681,8 +16503,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಮ್ನಾಬಾದ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1180"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17696,8 +16517,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುನಗುಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1181"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17711,8 +16531,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1182"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17726,8 +16545,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹುಣಸೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1183"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17741,8 +16559,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೂವಿನ ಹಡಗಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1184"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17756,8 +16573,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಳಕಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1185"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17771,8 +16587,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1186"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17786,8 +16601,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಇಂದಿರಾನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸಿ.ಜೆ. ಪ್ರಭಾಕರ್",
-    "cellRef": "A1187"
+    "NameKN": "ಸಿ.ಜೆ. ಪ್ರಭಾಕರ್"
   },
   {
     "Department": "stamps_sro",
@@ -17801,8 +16615,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಗಳೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1188"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17816,8 +16629,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಸ್. ಎಸ್. ಸ್ವರ್ಣಲತಾ",
-    "cellRef": "A1189"
+    "NameKN": "ಎಸ್. ಎಸ್. ಸ್ವರ್ಣಲತಾ"
   },
   {
     "Department": "stamps_sro",
@@ -17831,8 +16643,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಮಖಂಡಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1190"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17846,8 +16657,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಬಿ. ಗುರು ರಾಘವೇಂದ್ರ",
-    "cellRef": "A1191"
+    "NameKN": "ಬಿ. ಗುರು ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "stamps_sro",
@@ -17861,8 +16671,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೇವರ್ಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1192"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17876,8 +16685,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಿಗಣಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಜಲಿ ಸಿ",
-    "cellRef": "A1193"
+    "NameKN": "ಅಂಜಲಿ ಸಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17891,8 +16699,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೆಪಿ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕೆ. ಆರ್. ದೇವರಾಜು",
-    "cellRef": "A1194"
+    "NameKN": "ಕೆ. ಆರ್. ದೇವರಾಜು"
   },
   {
     "Department": "stamps_sro",
@@ -17906,8 +16713,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ ಆರ್ ನಾಗರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1195"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17921,8 +16727,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್.ಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1196"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17936,8 +16741,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಚರಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ",
-    "cellRef": "A1197"
+    "NameKN": "ಶ್ರೀನಿವಾಸ ವಿ"
   },
   {
     "Department": "stamps_sro",
@@ -17951,8 +16755,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಡೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1198"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17966,8 +16769,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಲಘಟಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1199"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17981,8 +16783,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಂಪ್ಲಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1200"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -17996,8 +16797,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕನಕಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1201"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18011,8 +16811,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರಟಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1202"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18026,8 +16825,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರ್ಕಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1203"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18041,8 +16839,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾರವಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1204"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18056,8 +16853,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವೈ.ಎಚ್. ವೆಂಕಟೇಶ್",
-    "cellRef": "A1205"
+    "NameKN": "ವೈ.ಎಚ್. ವೆಂಕಟೇಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -18071,8 +16867,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆರೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1206"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18086,8 +16881,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಖಾನಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1207"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18101,8 +16895,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಿತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1208"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18116,8 +16909,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೋಲಾರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1209"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18131,8 +16923,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಳ್ಳೇಗಾಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1210"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18146,8 +16937,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1211"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18161,8 +16951,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊಪ್ಪಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1212"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18176,8 +16965,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೊರಟಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1213"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18191,8 +16979,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೃಷ್ಣರಾಜಪುರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಆರ್. ರಾಮಪ್ರಸಾದ್",
-    "cellRef": "A1214"
+    "NameKN": "ಆರ್. ರಾಮಪ್ರಸಾದ್"
   },
   {
     "Department": "stamps_sro",
@@ -18206,8 +16993,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುದೇರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1215"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18221,8 +17007,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೂಡ್ಲಿಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1216"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18236,8 +17021,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಟಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1217"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18251,8 +17035,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಗೋಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1218"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18266,8 +17049,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಂದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1219"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18281,8 +17063,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಣಿಗಲ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1220"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18296,8 +17077,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುರುಗೋಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1221"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18311,8 +17091,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಷ್ಟಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1222"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18326,8 +17105,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್",
-    "cellRef": "A1223"
+    "NameKN": "ಕಮಲಾ ಟಿ.ಆರ್"
   },
   {
     "Department": "stamps_sro",
@@ -18341,8 +17119,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಗ್ಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1224"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18356,8 +17133,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಕ್ಷ್ಮೇಶ್ವರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1225"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18371,8 +17147,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಲಿಂಗಶುಗರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1226"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18386,8 +17161,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾದನಾಯಕನಹಳ್ಳಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ.ವಿ. ಸತೀಶ್",
-    "cellRef": "A1227"
+    "NameKN": "ಎಂ.ವಿ. ಸತೀಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -18401,8 +17175,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮದ್ದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1228"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18416,8 +17189,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಧುಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1229"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18431,8 +17203,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿಕೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1230"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18446,8 +17217,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1231"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18461,8 +17231,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಹದೇವಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಮ್ಯಾ ಎನ್",
-    "cellRef": "A1232"
+    "NameKN": "ರಮ್ಯಾ ಎನ್"
   },
   {
     "Department": "stamps_sro",
@@ -18476,8 +17245,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಳವಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1233"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18491,8 +17259,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ವಿಕ್ರಮ್ ಕೆ. ಮಗರ್",
-    "cellRef": "A1234"
+    "NameKN": "ವಿಕ್ರಮ್ ಕೆ. ಮಗರ್"
   },
   {
     "Department": "stamps_sro",
@@ -18506,8 +17273,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಲೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1235"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -18521,8 +17287,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಡ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1236"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18536,8 +17301,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ನಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1237"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18551,8 +17315,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಂಗಳೂರು ತಾಲೂಕು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1238"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18566,8 +17329,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾನ್ವಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1239"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18581,8 +17343,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಿರ್ಲೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1240"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18596,8 +17357,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೊಳಕಾಲ್ಮೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1241"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18611,8 +17371,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಬಿದ್ರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1242"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18626,8 +17385,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುದ್ದೇಬಿಹಾಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1243"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18641,8 +17399,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಧೋಳ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1244"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18656,8 +17413,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೂಡಿಗೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1245"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18671,8 +17427,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಳಬಾಗಲು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1246"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18686,8 +17441,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಲ್ಕಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1247"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18701,8 +17455,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡಗೋಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1248"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18716,8 +17469,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುಂಡರಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1249"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18731,8 +17483,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮುರಗೋಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1250"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18746,8 +17497,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪೂರ್ವ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1251"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18761,8 +17511,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ದಕ್ಷಿಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1252"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18776,8 +17525,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು ಪಶ್ಚಿಮ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1253"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18791,8 +17539,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮೈಸೂರು (ಉತ್ತರ)",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1254"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18806,8 +17553,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗಮಂಗಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1255"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18821,8 +17567,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಾಗರಭಾವಿ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಚಂಪಾ ಎಲ್",
-    "cellRef": "A1256"
+    "NameKN": "ಚಂಪಾ ಎಲ್"
   },
   {
     "Department": "stamps_sro",
@@ -18836,8 +17581,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಂಜನಗೂಡು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1257"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18851,8 +17595,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಗುಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1258"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18866,8 +17609,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನರಸಿಂಹರಾಜಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1259"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18881,8 +17623,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನವಲಗುಂದ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1260"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18896,8 +17637,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನೆಲಮಂಗಲ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆ.ಪಿ",
-    "cellRef": "A1261"
+    "NameKN": "ಅಂಬಿಕಾ ಪಟೇಲ್ ಜೆ.ಪಿ"
   },
   {
     "Department": "stamps_sro",
@@ -18911,8 +17651,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನಿಪ್ಪಾಣಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1262"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18926,8 +17665,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ನುಗ್ಗೇಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1263"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18941,8 +17679,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾಂಡವಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1264"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18956,8 +17693,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಾವಗಡ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1265"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -18971,8 +17707,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಕರಿಬಸವ ಗೌಡ",
-    "cellRef": "A1266"
+    "NameKN": "ಕರಿಬಸವ ಗೌಡ"
   },
   {
     "Department": "stamps_sro",
@@ -18986,8 +17721,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪಿರಿಯಾಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1267"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19001,8 +17735,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೊನ್ನಂಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1268"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19016,8 +17749,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುತ್ತೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1269"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19031,8 +17763,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಬಾಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1270"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19046,8 +17777,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಯಚೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1271"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19061,8 +17791,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ.",
-    "cellRef": "A1272"
+    "NameKN": "ಮೋಹನ್ ಕುಮಾರ್ ಜಿ."
   },
   {
     "Department": "stamps_sro",
@@ -19076,8 +17805,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1273"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -19091,8 +17819,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಮದುರ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1274"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19106,8 +17833,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಣಿಬೆನ್ನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1275"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19121,8 +17847,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರೋಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1276"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19136,8 +17861,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್ ಆರ್ ನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಂ. ಗಿರೀಶ್",
-    "cellRef": "A1277"
+    "NameKN": "ಎಂ. ಗಿರೀಶ್"
   },
   {
     "Department": "stamps_sro",
@@ -19151,8 +17875,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಲಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1278"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19166,8 +17889,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಾಗರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1279"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19181,8 +17903,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಕಲೇಶಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1280"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19196,8 +17917,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಂಡೂರ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1281"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19211,8 +17931,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸರ್ಜಾಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ",
-    "cellRef": "A1282"
+    "NameKN": "ಶಿವಕುಮಾರ್ ಡಿ"
   },
   {
     "Department": "stamps_sro",
@@ -19226,8 +17945,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸವಣೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1283"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19241,8 +17959,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೇಡಮ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1284"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19256,8 +17973,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಹಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1285"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19271,8 +17987,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಂಕರನಾರಾಯಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1286"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19286,8 +18001,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಾಂತಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ರಾಘವೇಂದ್ರ",
-    "cellRef": "A1287"
+    "NameKN": "ರಾಘವೇಂದ್ರ"
   },
   {
     "Department": "stamps_sro",
@@ -19301,8 +18015,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಡ್ಲಘಟ್ಟ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1288"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -19316,8 +18029,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಗ್ಗೋನ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1289"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19331,8 +18043,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿಕಾರಿಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1290"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19346,8 +18057,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಮೊಗ್ಗ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1291"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19361,8 +18071,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಗುಪ್ಪಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1292"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19376,8 +18085,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿರಹಟ್ಟಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1293"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19391,8 +18099,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಅನಿತಾ ಜಿ. ಬಡಿಗೇರ್",
-    "cellRef": "A1294"
+    "NameKN": "ಅನಿತಾ ಜಿ. ಬಡಿಗೇರ್"
   },
   {
     "Department": "stamps_sro",
@@ -19406,8 +18113,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೋರಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1295"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19421,8 +18127,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶೃಂಗೇರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1296"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19436,8 +18141,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿದ್ದಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1297"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19451,8 +18155,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂದಗಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1298"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19466,8 +18169,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಂಧನೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1299"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19481,8 +18183,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1300"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19496,8 +18197,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿರ್ಸಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1301"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19511,8 +18211,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೋಮವಾರಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1302"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19526,8 +18225,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೊರಬ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1303"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19541,8 +18239,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸೌದತ್ತಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1304"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19556,8 +18253,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀನಿವಾಸಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1305"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19571,8 +18267,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಾಮಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಎಚ್. ಎಸ್. ಅರವಿಂದ್",
-    "cellRef": "A1306"
+    "NameKN": "ಎಚ್. ಎಸ್. ಅರವಿಂದ್"
   },
   {
     "Department": "stamps_sro",
@@ -19586,8 +18281,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶ್ರೀರಂಗಪಟ್ಟಣ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1307"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19601,8 +18295,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸುಳ್ಯ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1308"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19616,8 +18309,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿ.ನರಸೀಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1309"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19631,8 +18323,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತರೀಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1310"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19646,8 +18337,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಾವರೆಕೆರೆ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್",
-    "cellRef": "A1311"
+    "NameKN": "ಸರೋಜಾ ವೈ.ಹೆಚ್"
   },
   {
     "Department": "stamps_sro",
@@ -19661,8 +18351,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೇರಾಡಲ್\\r\\n",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1312"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19676,8 +18365,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತೀರ್ಥಹಳ್ಳಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1313"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19691,8 +18379,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತಿಪಟೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1314"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19706,8 +18393,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುಮಕೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "-",
-    "cellRef": "A1315"
+    "NameKN": "-"
   },
   {
     "Department": "stamps_sro",
@@ -19721,8 +18407,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ತುರುವೇಕೆರೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1316"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19736,8 +18421,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಡುಪಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1317"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19751,8 +18435,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವರ್ತೂರು",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ",
-    "cellRef": "A1318"
+    "NameKN": "ಪ್ರವೀಣ್ ಕುಮಾರ್ ಗೋಗಿ"
   },
   {
     "Department": "stamps_sro",
@@ -19766,8 +18449,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೀರಾಜಪೇಟೆ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1319"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19781,8 +18463,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಪ್ರಮೀಳಾ ಜಿ.ಜೆ",
-    "cellRef": "A1320"
+    "NameKN": "ಪ್ರಮೀಳಾ ಜಿ.ಜೆ"
   },
   {
     "Department": "stamps_sro",
@@ -19796,8 +18477,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಟ್ಲ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1321"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19811,8 +18491,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಾದಗಿರಿ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1322"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19826,8 +18505,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್",
-    "cellRef": "A1323"
+    "NameKN": "ನಜೀರ್ ಅಹಮ್ಮದ್ ನದಾಫ್"
   },
   {
     "Department": "stamps_sro",
@@ -19841,8 +18519,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಳಂದೂರು",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1324"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19856,8 +18533,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯೆಲ್ಬುರ್ಗಾ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1325"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19871,8 +18547,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲ್ಲಾಪುರ",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1326"
+    "NameKN": ""
   },
   {
     "Department": "stamps_sro",
@@ -19886,8 +18561,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವತಪುರ",
     "DesignationKN": "ಸಬ್ ರಿಜಿಸ್ಟ್ರಾರ್",
-    "NameKN": "ಸುರೇಶ್ ಜಿ",
-    "cellRef": "A1327"
+    "NameKN": "ಸುರೇಶ್ ಜಿ"
   },
   {
     "Department": "police_traffic",
@@ -19901,8 +18575,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆಡುಗೋಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1328"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19916,8 +18589,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಅಶೋಕ್ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1329"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19931,8 +18603,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬನಶಂಕರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1330"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19946,8 +18617,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಾಣಸವಾಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1331"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19961,8 +18631,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬಸವನಗುಡಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1332"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19976,8 +18645,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಬ್ಯಾಟರಾಯನಪುರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1333"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -19991,8 +18659,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಾಮರಾಜಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1334"
+    "NameKN": ""
   },
   {
     "Department": "police_traffic",
@@ -20006,8 +18673,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಬಾಣಾವರ ಪಿ.ಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1335"
+    "NameKN": ""
   },
   {
     "Department": "police_traffic",
@@ -20021,8 +18687,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಚಿಕ್ಕಜಾಲ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1336"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20036,8 +18701,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸಿಟಿ ಮಾರ್ಕೆಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1337"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20051,8 +18715,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಬ್ಬನ್ ಪಾರ್ಕ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1338"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20066,8 +18729,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ದೇವನಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1339"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20081,8 +18743,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಲೆಕ್ಟ್ರಾನಿಕ್ ಸಿಟಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1340"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20096,8 +18757,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎ.ಎಲ್. ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1341"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20111,8 +18771,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಎಚ್.ಎಸ್.ಆರ್.ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1342"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20126,8 +18785,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರು ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1343"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20141,8 +18799,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹಲಸೂರುಗೇಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1344"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20156,8 +18813,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಬ್ಬಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1345"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20171,8 +18827,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೆಣ್ಣೂರು ಪಿಎಸ್",
     "DesignationKN": "",
-    "NameKN": "",
-    "cellRef": "A1346"
+    "NameKN": ""
   },
   {
     "Department": "police_traffic",
@@ -20186,8 +18841,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಹೈ ಗ್ರೌಂಡ್ಸ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1347"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20201,8 +18855,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಾಲಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1348"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20216,8 +18869,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1349"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20231,8 +18883,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಜೀವನ್ ಭೀಮನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1350"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20246,8 +18897,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆ.ಆರ್. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1351"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20261,8 +18911,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಡುಗೊಂಡನ ಹಳ್ಳಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1352"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20276,8 +18925,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕಾಮಾಕ್ಷಿಪಾಳ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1353"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20291,8 +18939,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕೆಂಗೇರಿ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1354"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20306,8 +18953,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಕುಮಾರಸ್ವಾಮಿ ಲೇಔಟ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1355"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20321,8 +18967,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಡಿವಾಳ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1356"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20336,8 +18981,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಾಗಡಿ ರಸ್ತೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1357"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20351,8 +18995,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಮಲ್ಲೇಶ್ವರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1358"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20366,8 +19009,7 @@
     "Unnamed: 3": "",
     "AreaKN": "MICO ಲೇಔಟ್ ಬೆಂಗಳೂರು PS",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1359"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20381,8 +19023,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪೀಣ್ಯ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1360"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20396,8 +19037,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಪುಲಕೇಶಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1361"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20411,8 +19051,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಆರ್.ಟಿ. ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1362"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20426,8 +19065,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ರಾಜಾಜಿ ನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1363"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20441,8 +19079,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಸದಾಶಿವನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1364"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20456,8 +19093,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಶಿವಾಜಿನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1365"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20471,8 +19107,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಉಪ್ಪಾರಪೇಟೆ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1366"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20486,8 +19121,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿ.ವಿ. ಪುರಂ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1367"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20501,8 +19135,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಜಯನಗರ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1368"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20516,8 +19149,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವೈಟ್‌ಫೀಲ್ಡ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1369"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20531,8 +19163,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ವಿಲ್ಸನ್‌ಗಾರ್ಡನ್ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1370"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20546,8 +19177,7 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಲಹಂಕ ಪಿಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1371"
+    "NameKN": "-"
   },
   {
     "Department": "police_traffic",
@@ -20561,7 +19191,6 @@
     "Unnamed: 3": "",
     "AreaKN": "ಯಶವಂತಪುರ ಪಿ.ಎಸ್",
     "DesignationKN": "ಪೊಲೀಸ್ ಇನ್ಸ್‌ಪೆಕ್ಟರ್ ಸಂಚಾರ",
-    "NameKN": "-",
-    "cellRef": "A1372"
+    "NameKN": "-"
   }
 ]


### PR DESCRIPTION
Optimizes https://github.com/Vonter/blr-city-officials/pull/59 for the implementation of https://github.com/Vonter/blr-city-officials/issues/55

As the location of elements in the `officials.json` directly correspond to their location in the Google Sheet, the `cellRef` can be directly calculated on the fly without needing to store it in the `officials.json`. Doing this reduces the uncompressed size of `officials.json` by 30KB.