### PR TITLE
Configure MapLibre control locations based on screen size

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -61,10 +61,28 @@
 </main>
 
 <style>
-  /* On mobile, hide the attribution */
+  /* Hide the controls based on screen size */
   @media (max-width: 768px) {
-    :global(.maplibregl-ctrl.maplibregl-ctrl-attrib) {
+    :global(.maplibregl-ctrl-bottom-right) {
       display: none;
     }
+  }
+  @media (max-width: 768px) {
+    :global(.maplibregl-ctrl-bottom-left) {
+      display: none;
+    }
+  }
+  @media (min-width: 768px) {
+    :global(.maplibregl-ctrl-top-right) {
+      display: none;
+    }
+  }
+  @media (min-width: 768px) {
+    :global(.maplibregl-ctrl-top-left) {
+      display: none;
+    }
+  }
+  :global(.maplibregl-ctrl-fullscreen .maplibregl-ctrl-icon) {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9IiM0YjU1NjMiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1heGltaXplLTIiPjxwb2x5bGluZSBwb2ludHM9IjE1IDMgMjEgMyAyMSA5Ii8+PHBvbHlsaW5lIHBvaW50cz0iOSAyMSAzIDIxIDMgMTUiLz48bGluZSB4MT0iMjEiIHgyPSIxNCIgeTE9IjMiIHkyPSIxMCIvPjxsaW5lIHgxPSIzIiB4Mj0iMTAiIHkxPSIyMSIgeTI9IjE0Ii8+PC9zdmc+') !important;
   }
 </style>

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -44,6 +44,15 @@
       ...defaultZoom
     });
 
+    // Add attribution control on top right for mobile
+    const attributionControl = new maplibregl.AttributionControl();
+    map.addControl(attributionControl, 'top-right');
+
+    // Add full screen control on top left for mobile, bottom left for desktop
+    const fullscreenControl = new maplibregl.FullscreenControl();
+    map.addControl(fullscreenControl, 'top-left');
+    map.addControl(fullscreenControl, 'bottom-left');
+
     // Override default browser zoom hotkeys
     window.addEventListener(
       'keydown',


### PR DESCRIPTION
- Add attribution control:
	- Bottom-right on desktop
	- Top-right on mobile
- Add fullscreen control (with custom SVG icon from [Lucide icons](https://lucide.dev/icons/)):
	- Bottom-left on desktop
	- Top-left on mobile